### PR TITLE
chore: delete preStop command

### DIFF
--- a/controllers/apps/emqx_handler.go
+++ b/controllers/apps/emqx_handler.go
@@ -197,17 +197,6 @@ func generateStatefulSetDef(instance appsv1beta3.Emqx) *appsv1.StatefulSet {
 							ReadinessProbe:  instance.GetReadinessProbe(),
 							LivenessProbe:   instance.GetLivenessProbe(),
 							StartupProbe:    instance.GetStartupProbe(),
-							Lifecycle: &corev1.Lifecycle{
-								PreStop: &corev1.LifecycleHandler{
-									Exec: &corev1.ExecAction{
-										Command: []string{
-											"/opt/emqx/bin/emqx_ctl",
-											"cluster",
-											"leave",
-										},
-									},
-								},
-							},
 						},
 					},
 				},

--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
There is a risk that preStop will fail. When persistence is enabled, preStop failure can lead to inconsistent emqx cluster data