### PR TITLE
chore: format annotations for statefulSet

### DIFF
--- a/apis/apps/v1beta3/servicetemplate.go
+++ b/apis/apps/v1beta3/servicetemplate.go
@@ -28,6 +28,9 @@ func (s *ServiceTemplate) Default(emqx Emqx) {
 		s.ObjectMeta.Annotations = map[string]string{}
 	}
 	for key, value := range emqx.GetAnnotations() {
+		if key == "kubectl.kubernetes.io/last-applied-configuration" {
+			continue
+		}
 		if _, ok := s.ObjectMeta.Annotations[key]; !ok {
 			s.ObjectMeta.Annotations[key] = value
 		}

--- a/controllers/apps/v1beta3/emqx_handler_test.go
+++ b/controllers/apps/v1beta3/emqx_handler_test.go
@@ -149,7 +149,8 @@ func TestGenerateStatefulSetDef(t *testing.T) {
 						"apps.emqx.io/instance":   "emqx",
 					},
 					Annotations: map[string]string{
-						"foo": "bar",
+						"foo":                            "bar",
+						"apps.emqx.io/manage-containers": "emqx,reloader,extra",
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -860,6 +861,11 @@ func TestGenerateAcl(t *testing.T) {
 	expectSts := &appsv1.StatefulSet{
 		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"ACL/Base64EncodeConfig": "e2FsbG93LCBhbGx9CntkZW55LCBhbGx9Cg==",
+					},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -969,6 +975,11 @@ func TestGenerateLoadedModules(t *testing.T) {
 	expectSts := &appsv1.StatefulSet{
 		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"LoadedModules/Base64EncodeConfig": "e2VtcXhfbW9kdWxlLCB0cnVlfS4K",
+					},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{

--- a/e2e/v1beta3/e2e_test.go
+++ b/e2e/v1beta3/e2e_test.go
@@ -106,8 +106,8 @@ var _ = Describe("Check EMQX Custom Resource", func() {
 			check_emqx_status(enterprise)
 
 			By("should check StatefulSet annotations")
-			check_sts_annotations(broker)
-			check_sts_annotations(enterprise)
+			check_pod_annotations(broker)
+			check_pod_annotations(enterprise)
 
 			By("should create EMQX Plugins")
 			check_plugin(broker, pluginList)
@@ -245,28 +245,28 @@ func check_emqx_status(emqx appsv1beta3.Emqx) {
 	Expect(emqx.GetStatus().EmqxNodes).Should(HaveLen(3))
 }
 
-func check_sts_annotations(emqx appsv1beta3.Emqx) {
+func check_pod_annotations(emqx appsv1beta3.Emqx) {
 	sts := &appsv1.StatefulSet{}
 	Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(emqx), sts)).Should(Succeed())
-	Expect(sts.Annotations).Should(HaveKey(handler.ManageContainersAnnotation))
+	Expect(sts.Spec.Template.Annotations).Should(HaveKey(handler.ManageContainersAnnotation))
 	if len(emqx.GetACL()) != 0 {
-		Expect(sts.Annotations).Should(HaveKey("ACL/Base64EncodeConfig"))
+		Expect(sts.Spec.Template.Annotations).Should(HaveKey("ACL/Base64EncodeConfig"))
 	} else {
-		Expect(sts.Annotations).ShouldNot(HaveKey("ACL/Base64EncodeConfig"))
+		Expect(sts.Spec.Template.Annotations).ShouldNot(HaveKey("ACL/Base64EncodeConfig"))
 	}
 
 	switch instance := emqx.(type) {
 	case *appsv1beta3.EmqxBroker:
 		if len(instance.GetModules()) != 0 {
-			Expect(sts.Annotations).Should(HaveKey("LoadedModules/Base64EncodeConfig"))
+			Expect(sts.Spec.Template.Annotations).Should(HaveKey("LoadedModules/Base64EncodeConfig"))
 		} else {
-			Expect(sts.Annotations).ShouldNot(HaveKey("LoadedModules/Base64EncodeConfig"))
+			Expect(sts.Spec.Template.Annotations).ShouldNot(HaveKey("LoadedModules/Base64EncodeConfig"))
 		}
 	case *appsv1beta3.EmqxEnterprise:
 		if len(instance.GetModules()) != 0 {
-			Expect(sts.Annotations).Should(HaveKey("LoadedModules/Base64EncodeConfig"))
+			Expect(sts.Spec.Template.Annotations).Should(HaveKey("LoadedModules/Base64EncodeConfig"))
 		} else {
-			Expect(sts.Annotations).ShouldNot(HaveKey("LoadedModules/Base64EncodeConfig"))
+			Expect(sts.Spec.Template.Annotations).ShouldNot(HaveKey("LoadedModules/Base64EncodeConfig"))
 		}
 	}
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -115,7 +115,6 @@ func (handler *Handler) CreateOrUpdate(obj client.Object, postFun func(client.Ob
 	opts := []patch.CalculateOption{}
 	switch resource := obj.(type) {
 	case *appsv1.StatefulSet:
-		_ = client.NewDryRunClient(handler.Client).Update(context.TODO(), obj)
 		opts = append(
 			opts,
 			patch.IgnoreStatusFields(),
@@ -196,7 +195,7 @@ func IgnoreOtherContainers() patch.CalculateOption {
 func selectManagerContainer(obj []byte) ([]byte, error) {
 	sts := &appsv1.StatefulSet{}
 	_ = json.Unmarshal(obj, sts)
-	containerNames := sts.Annotations[ManageContainersAnnotation]
+	containerNames := sts.Spec.Template.Annotations[ManageContainersAnnotation]
 	containers := []corev1.Container{}
 	for _, container := range sts.Spec.Template.Spec.Containers {
 		if strings.Contains(containerNames, container.Name) {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -31,13 +31,13 @@ func TestIgnoreOtherContainer(t *testing.T) {
 	selectEmqxContainer := handler.IgnoreOtherContainers()
 
 	currentObject := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				handler.ManageContainersAnnotation: "emqx,reloader",
-			},
-		},
 		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						handler.ManageContainersAnnotation: "emqx,reloader",
+					},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -54,13 +54,13 @@ func TestIgnoreOtherContainer(t *testing.T) {
 	current, _ := json.ConfigCompatibleWithStandardLibrary.Marshal(currentObject)
 
 	modifiedObject := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{
-				handler.ManageContainersAnnotation: "emqx,reloader",
-			},
-		},
 		Spec: appsv1.StatefulSetSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						handler.ManageContainersAnnotation: "emqx,reloader",
+					},
+				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
move some annotations from metadata to spec.template.metadata, beacuse
statefulset's metadata can not update.

fix some error for compatible with 1.2.2