### PR TITLE
chore: add PublishNotReadyAddresses for headless service

### DIFF
--- a/controllers/apps/v1beta3/emqx_handler.go
+++ b/controllers/apps/v1beta3/emqx_handler.go
@@ -577,8 +577,9 @@ func generateSvc(instance appsv1beta3.Emqx) (headlessSvc, svc *corev1.Service) {
 			Namespace: instance.GetNamespace(),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector:  instance.GetLabels(),
-			ClusterIP: corev1.ClusterIPNone,
+			Selector:                 instance.GetLabels(),
+			ClusterIP:                corev1.ClusterIPNone,
+			PublishNotReadyAddresses: true,
 		},
 	}
 

--- a/controllers/apps/v1beta3/emqx_handler_test.go
+++ b/controllers/apps/v1beta3/emqx_handler_test.go
@@ -792,7 +792,8 @@ func TestGenerateSvc(t *testing.T) {
 				"apps.emqx.io/instance":   "emqx",
 				"apps.emqx.io/managed-by": "emqx-operator",
 			},
-			ClusterIP: corev1.ClusterIPNone,
+			ClusterIP:                corev1.ClusterIPNone,
+			PublishNotReadyAddresses: true,
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "http-management-8081",


### PR DESCRIPTION
This fixes the issue of emqx clusters not being able to be deployed twice