### PR TITLE
Add extra selectors to the Services

### DIFF
--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/emqx-operator/templates/controller-manager-metrics-service.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-metrics-service.yaml
@@ -13,3 +13,4 @@ spec:
     targetPort: metrics
   selector:
     control-plane: controller-manager
+    {{- include "emqx-operator.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/emqx-operator/templates/controller-manager-webhook-service.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-webhook-service.yaml
@@ -10,3 +10,4 @@ spec:
     targetPort: 9443
   selector:
     control-plane: controller-manager
+    {{- include "emqx-operator.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
We need to add extra labels to the Service selector to point explicitly to the correct pod in the namespace. It is pretty useful when you have much other stuff to be in the same namespace to avoid conflicts.