### PR TITLE
feat: add imagepullsecret to service account.

### DIFF
--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.1.0
+appVersion: 2.1.1

--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -10,6 +10,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The imagePullSecrets are not applied to the main emqx/emqx-operator-controller image. This PR includes the change to add the imagePullSecrets to the service account to be able to pull images from private registries.