### PR TITLE
refactor: Refactor EMQX controller reconciliation and cleanup.

### DIFF
--- a/controllers/apps/v2alpha1/add_bootstrap_resource.go
+++ b/controllers/apps/v2alpha1/add_bootstrap_resource.go
@@ -21,7 +21,7 @@ type addBootstrap struct {
 	*EMQXReconciler
 }
 
-func (a *addBootstrap) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
+func (a *addBootstrap) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, _ *portForwardAPI) subResult {
 	for _, resource := range []client.Object{
 		generateNodeCookieSecret(instance),
 		generateBootstrapUserSecret(instance),

--- a/controllers/apps/v2alpha1/add_emqx_core.go
+++ b/controllers/apps/v2alpha1/add_emqx_core.go
@@ -17,7 +17,7 @@ type addCore struct {
 	*EMQXReconciler
 }
 
-func (a *addCore) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
+func (a *addCore) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, _ *portForwardAPI) subResult {
 	sts := generateStatefulSet(instance)
 	if err := a.CreateOrUpdateList(instance, a.Scheme, []client.Object{sts}); err != nil {
 		return subResult{err: emperror.Wrap(err, "failed to create or update statefulSet")}

--- a/controllers/apps/v2alpha1/add_emqx_repl.go
+++ b/controllers/apps/v2alpha1/add_emqx_repl.go
@@ -21,9 +21,9 @@ type addRepl struct {
 	*EMQXReconciler
 }
 
-func (a *addRepl) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
+func (a *addRepl) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, _ *portForwardAPI) subResult {
 	if !instance.Status.IsRunning() && !instance.Status.IsCoreNodesReady() {
-		return subResult{result: ctrl.Result{RequeueAfter: time.Second}}
+		return subResult{}
 	}
 
 	deploy := a.getNewDeployment(ctx, instance)

--- a/controllers/apps/v2alpha1/add_listener.go
+++ b/controllers/apps/v2alpha1/add_listener.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	emperror "emperror.dev/errors"
 	appsv2alpha1 "github.com/emqx/emqx-operator/apis/apps/v2alpha1"
@@ -17,7 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,7 +25,10 @@ type addListener struct {
 
 func (a *addListener) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
 	if !instance.Status.IsRunning() && !instance.Status.IsCoreNodesReady() {
-		return subResult{result: ctrl.Result{RequeueAfter: time.Second}}
+		return subResult{}
+	}
+	if p == nil {
+		return subResult{}
 	}
 
 	resources := []client.Object{}

--- a/controllers/apps/v2alpha1/add_svc.go
+++ b/controllers/apps/v2alpha1/add_svc.go
@@ -15,7 +15,7 @@ type addSvc struct {
 	*EMQXReconciler
 }
 
-func (a *addSvc) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
+func (a *addSvc) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, _ *portForwardAPI) subResult {
 	if err := a.CreateOrUpdateList(instance, a.Scheme, []client.Object{
 		generateHeadlessService(instance),
 		generateDashboardService(instance),

--- a/controllers/apps/v2alpha1/emqx_controller.go
+++ b/controllers/apps/v2alpha1/emqx_controller.go
@@ -228,8 +228,5 @@ func (r *EMQXReconciler) getBootstrapUser(ctx context.Context, instance *appsv2a
 }
 
 func (p *portForwardAPI) requestAPI(method, path string, body []byte) (resp *http.Response, respBody []byte, err error) {
-	if p.Options == nil {
-		return nil, nil, emperror.Errorf("failed to %s %s, portForward is not ready", method, path)
-	}
 	return p.Options.RequestAPI(p.Username, p.Password, method, path, body)
 }

--- a/controllers/apps/v2alpha1/status_machine.go
+++ b/controllers/apps/v2alpha1/status_machine.go
@@ -81,7 +81,7 @@ func (s *emqxStatusMachine) setCurrentStatus(emqx *appsv2alpha1.EMQX) {
 	}
 }
 
-func (s *emqxStatusMachine) CheckNodeCount(emqxNodes []appsv2alpha1.EMQXNode) {
+func (s *emqxStatusMachine) UpdateNodeCount(emqxNodes []appsv2alpha1.EMQXNode) {
 	s.emqx.Status.CoreNodeReplicas = *s.emqx.Spec.CoreTemplate.Spec.Replicas
 	s.emqx.Status.ReplicantNodeReplicas = *s.emqx.Spec.ReplicantTemplate.Spec.Replicas
 

--- a/controllers/apps/v2alpha1/status_machine_test.go
+++ b/controllers/apps/v2alpha1/status_machine_test.go
@@ -51,7 +51,7 @@ func TestCheckNodeCount(t *testing.T) {
 		}
 
 		emqxStatusMachine := newEMQXStatusMachine(emqx)
-		emqxStatusMachine.CheckNodeCount(emqxNodes)
+		emqxStatusMachine.UpdateNodeCount(emqxNodes)
 		assert.Equal(t, emqxStatusMachine.GetEMQX().Status.CoreNodeReplicas, int32(1))
 		assert.Equal(t, emqxStatusMachine.GetEMQX().Status.CoreNodeReadyReplicas, int32(1))
 		assert.Equal(t, emqxStatusMachine.GetEMQX().Status.ReplicantNodeReplicas, int32(1))

--- a/controllers/apps/v2alpha1/update_emqx_status.go
+++ b/controllers/apps/v2alpha1/update_emqx_status.go
@@ -19,28 +19,20 @@ type updateStatus struct {
 
 func (u *updateStatus) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
 	var err error
-	instance, err = u.updateStatus(ctx, instance, p)
-	if err != nil {
-		return subResult{err: emperror.Wrap(err, "failed to update status")}
-	}
-	if err := u.Client.Status().Update(ctx, instance); err != nil {
-		return subResult{err: emperror.Wrap(err, "failed to update status")}
-	}
-	return subResult{}
-}
-
-func (u *updateStatus) updateStatus(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) (*appsv2alpha1.EMQX, error) {
 	var emqxNodes []appsv2alpha1.EMQXNode
 	var existedSts *appsv1.StatefulSet = &appsv1.StatefulSet{}
 	var existedDeploy *appsv1.Deployment = &appsv1.Deployment{}
-	var err error
 
-	err = u.Client.Get(ctx, types.NamespacedName{Name: instance.Spec.CoreTemplate.Name, Namespace: instance.Namespace}, existedSts)
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return instance, nil
+	if p != nil && p.Options != nil {
+		if emqxNodes, err = getNodeStatuesByAPI(p); err != nil {
+			u.EventRecorder.Event(instance, corev1.EventTypeWarning, "FailedToGetNodeStatuses", err.Error())
 		}
-		return nil, emperror.Wrap(err, "failed to get existed statefulSet")
+	}
+
+	if err = u.Client.Get(ctx, types.NamespacedName{Name: instance.Spec.CoreTemplate.Name, Namespace: instance.Namespace}, existedSts); err != nil {
+		if !k8sErrors.IsNotFound(err) {
+			return subResult{err: emperror.Wrap(err, "failed to get existed statefulSet")}
+		}
 	}
 
 	dList := getDeploymentList(ctx, u.Client,
@@ -51,15 +43,15 @@ func (u *updateStatus) updateStatus(ctx context.Context, instance *appsv2alpha1.
 		existedDeploy = dList[len(dList)-1]
 	}
 
-	emqxNodes, err = getNodeStatuesByAPI(p)
-	if err != nil {
-		u.EventRecorder.Event(instance, corev1.EventTypeWarning, "FailedToGetNodeStatuses", err.Error())
-	}
-
 	emqxStatusMachine := newEMQXStatusMachine(instance)
-	emqxStatusMachine.CheckNodeCount(emqxNodes)
+	emqxStatusMachine.UpdateNodeCount(emqxNodes)
 	emqxStatusMachine.NextStatus(existedSts, existedDeploy)
-	return emqxStatusMachine.GetEMQX(), nil
+	emqxStatusMachine.GetEMQX()
+
+	if err := u.Client.Status().Update(ctx, instance); err != nil {
+		return subResult{err: emperror.Wrap(err, "failed to update status")}
+	}
+	return subResult{}
 }
 
 func getNodeStatuesByAPI(p *portForwardAPI) ([]appsv2alpha1.EMQXNode, error) {

--- a/controllers/apps/v2alpha1/update_pod_conditions.go
+++ b/controllers/apps/v2alpha1/update_pod_conditions.go
@@ -16,7 +16,7 @@ type updatePodConditions struct {
 	*EMQXReconciler
 }
 
-func (u *updatePodConditions) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, p *portForwardAPI) subResult {
+func (u *updatePodConditions) reconcile(ctx context.Context, instance *appsv2alpha1.EMQX, _ *portForwardAPI) subResult {
 	pods := &corev1.PodList{}
 	_ = u.Client.List(ctx, pods,
 		client.InNamespace(instance.Namespace),


### PR DESCRIPTION
- Rename `CheckNodeCount` to `UpdateNodeCount` to better represent its functionality.
- Remove unused parameters and imports in various files.
- Refactor code to avoid unnecessary API calls and improve error handling.
- Update `UpdateStatus()` and `NextStatus()` methods for improved functionality.
- Clean up code formatting and remove commented out code.