### PR TITLE
refactor: Update Kubernetes lease settings and enable zap developer m…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run ./main.go --zap-devel=true
 
 docker-build: test ## Build docker image with the manager.
 	docker build --no-cache -t ${IMG} .

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/utils/pointer"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -82,17 +83,12 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
-		Development: true,
-		Level:       zapcore.InfoLevel,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	leaseDuration := time.Second * 30
-	renewDeadline := time.Second * 20
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -101,8 +97,8 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "19fd6fcc.emqx.io",
-		LeaseDuration:          &leaseDuration,
-		RenewDeadline:          &renewDeadline,
+		LeaseDuration:          pointer.Duration(time.Second * 30),
+		RenewDeadline:          pointer.Duration(time.Second * 20),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
…ode in Makefile

- Update lease duration and renew deadline using Kubernetes library pointer functions in main.go
- Add --zap-devel flag to the run target in Makefile
- Improvements to logging and error handling throughout the codebase.