### PR TITLE
ci: when create release, do not use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -10,12 +10,6 @@ on:
       tag:
         required: true
         type: string
-  workflow_run:
-    ##  Release by github-actions will not trigger "release" event, so need this
-    workflows:
-      - "Release emqx operator"
-    types:
-      - completed
   release:
     types:
       - published

--- a/.github/workflows/push-helm.yaml
+++ b/.github/workflows/push-helm.yaml
@@ -1,0 +1,36 @@
+name: Push Helm Chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+  release:
+    types:
+      - published
+
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get tag
+      id: get_tag
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          tag="${{ inputs.tag }}"
+        fi
+        if [ "${{ github.event_name }}" = "release" ]; then
+          tag="${{ github.event.release.tag_name }}"
+        fi
+        echo "tag=$tag" >> GITHUB_OUTPUT
+    - name: Update helm repo
+      uses: emqx/push-helm-action@v1.1
+      with:
+        charts_dir: "${{ github.workspace }}/deploy/charts/emqx-operator"
+        version: ${{ steps.get_tag.outputs.tag }}
+        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws_region: "us-west-2"
+        aws_bucket_name: "repos-emqx-io"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
     - uses: actions/checkout@v3
     - name: Check helm
       run: |
-        version=$(egrep "^version" deploy/charts/emqx-operator/Chart.yaml | sed -r 's|^version:[[:space:]]([0-9]+.[0-9]+.[0-9]+)$|\1|g')
+        version=$(grep -E "^version" deploy/charts/emqx-operator/Chart.yaml | grep -oE "[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9])?")
         if [ "$version" != "${GITHUB_REF##*/}" ]; then
           echo "Need update version for Chart.yaml"
           exit 1
         fi
-        appVersion=$(egrep "^appVersion" deploy/charts/emqx-operator/Chart.yaml | sed -r 's|^appVersion:[[:space:]]([0-9]+.[0-9]+.[0-9]+)$|\1|g')
+        appVersion=$(grep -E "^appVersion" deploy/charts/emqx-operator/Chart.yaml | grep -oE "[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9])?")
         if [ "$appVersion" != "${GITHUB_REF##*/}" ]; then
           echo "Need update appVersion for Chart.yaml"
           exit 1
@@ -64,16 +64,13 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       with:
         prerelease: ${{ steps.prerelease.outputs.prerelease }}
-        token: ${{ github.token }}
+        ## When you use the repository's GITHUB_TOKEN to perform tasks,
+        ## events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch,
+        ## will not create a new workflow run.
+        ## This prevents you from accidentally creating recursive workflow runs.
+        ## More info: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+        # token: ${{ github.token }}
+        token: ${{ secret.CI_GIT_TOKEN }}
         name: EMQX Operator ${{ github.ref_name }} Released
         body_path: RELEASE.md
         generate_release_notes: true
-    - name: Update helm repo
-      uses: emqx/push-helm-action@v1
-      with:
-        charts_dir: "${{ github.workspace }}/deploy/charts/emqx-operator"
-        version: ${{ github.ref_name }}
-        aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws_region: "us-west-2"
-        aws_bucket_name: "repos-emqx-io"


### PR DESCRIPTION
And change regex for helm version check, support pre-release version