### PR TITLE
Image version needs to be a string

### DIFF
--- a/docs/en_US/getting-started/getting-started.md
+++ b/docs/en_US/getting-started/getting-started.md
@@ -104,7 +104,7 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
           emqxContainer:
             image:
               repository: emqx
-              version: 4.4
+              version: "4.4.18"
    ```
 
    For more details please check the [reference document](https://github.com/emqx/emqx-operator/blob/main/docs/en_US/reference/v1beta4-reference.md).


### PR DESCRIPTION
Image version needs to be a string or else admission webhook errors. `4.4` is too old as well.

The current version of manifest fails to deploy, e.g.
```bash
Error from server: error when creating "emqx.yaml": admission webhook "mutating.broker.emqx.io" denied the request: json: cannot unmarshal number into Go struct field EmqxImage.spec.template.spec.emqxContainer.image.version of type string

Error from server (image version 4.4 is too old, please upgrade to 4.4.14 or later): error when creating "emqx.yaml": admission webhook "validator.broker.emqx.io" denied the request: image version 4.4 is too old, please upgrade to 4.4.14 or later
```