### PR TITLE
fix: fix nil point error

### DIFF
--- a/controllers/apps/v2beta1/update_emqx_status.go
+++ b/controllers/apps/v2beta1/update_emqx_status.go
@@ -34,8 +34,8 @@ func (u *updateStatus) reconcile(ctx context.Context, logger logr.Logger, instan
 	}
 
 	updateSts, currentSts, oldStsList := getStateFulSetList(ctx, u.Client, instance)
-	if updateSts != nil && updateSts.UID != currentSts.UID {
-		if currentSts.Status.Replicas == 0 {
+	if updateSts != nil {
+		if currentSts == nil || (updateSts.UID != currentSts.UID && currentSts.Status.Replicas == 0) {
 			var i int
 			for i = 0; i < len(oldStsList); i++ {
 				if oldStsList[i].Status.Replicas > 0 {
@@ -55,8 +55,8 @@ func (u *updateStatus) reconcile(ctx context.Context, logger logr.Logger, instan
 	}
 
 	updateRs, currentRs, oldRsList := getReplicaSetList(ctx, u.Client, instance)
-	if updateRs != nil && updateRs.UID != currentRs.UID {
-		if currentRs.Status.Replicas == 0 {
+	if updateRs != nil {
+		if currentRs == nil || (updateRs.UID != currentRs.UID && currentRs.Status.Replicas == 0) {
 			var i int
 			for i = 0; i < len(oldRsList); i++ {
 				if oldRsList[i].Status.Replicas > 0 {


### PR DESCRIPTION
When the EMQX resource is in `coreNodesProgressing/replicantNodesProgressing` state, if the user manually deletes `currentSts/currentRs`, it will cause a nil point error.