### PR TITLE
feat(deploy): support single namespace

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,6 +32,12 @@ jobs:
 
           - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-slim.yaml"]
           - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-full.yaml"]
+        single_namespace:
+          - false
+          - true
+        exclude:
+          - install: static
+            single_namespace: true
 
     steps:
       - run: minikube start
@@ -63,11 +69,15 @@ jobs:
           helm install emqx-operator deploy/charts/emqx-operator \
             --set image.tag=${{ github.sha }} \
             --set development=true \
-            --namespace emqx-operator-system \
+            --set singleNamespace=${{ matrix.single_namespace }} \
+            --namespace ${{ matrix.single_namespace && 'default' || 'emqx-operator-system' }} \
             --create-namespace
       - name: Check operator
         timeout-minutes: 5
-        run: kubectl wait --for=condition=Ready pods -l "control-plane=controller-manager" -n emqx-operator-system
+        run: |
+          kubectl wait --for=condition=Ready pods \
+            -l "control-plane=controller-manager" \
+            -n ${{ matrix.single_namespace && 'default' || 'emqx-operator-system' }}
       - name: Deployment emqx
         timeout-minutes: 5
         uses: ./.github/actions/deploy-emqx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Note 🍻
 
-EMQX Operator 2.2.25 has been released.
+EMQX Operator 2.2.26-rc.1 has been released.
 
 ## Supported version
 + apps.emqx.io/v2beta1
@@ -15,9 +15,7 @@ EMQX Operator 2.2.25 has been released.
 
 ## Enhancements 🚀
 
-+ `apps.emqx.io/v2beta1 EMQX`.
-
-  + Fix sometimes got `EOF` error when request EMQX API
++ EMQX operator can now be deployed in a single namespace scope, where it will only manage resources within that namespace. Just set `singleNamespace: true` in the `values.yaml` file of Helm chart, and then the operator will only manage resources in the namespace where it is deployed.
 
 ## How to install/upgrade EMQX Operator 💡
 
@@ -29,7 +27,7 @@ helm repo update
 helm upgrade --install emqx-operator emqx/emqx-operator \
   --namespace emqx-operator-system \
   --create-namespace \
-  --version 2.2.25
+  --version 2.2.26-rc.1
 kubectl wait --for=condition=Ready pods -l "control-plane=controller-manager" -n emqx-operator-system
 ```
 

--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.26
+version: 2.2.26-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.2.26
+appVersion: 2.2.26-rc.1
 
 sources:
   - https://github.com/emqx/emqx-operator/tree/main/deploy/charts/emqx-operator

--- a/deploy/charts/emqx-operator/README.md
+++ b/deploy/charts/emqx-operator/README.md
@@ -34,6 +34,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `skipCRDs` | If `true`, skips installing CRDs | `false` |
+| `singleNamespace` | If true, the operator will watch only the namespace where it is deployed. If false, the operator will watch all namespaces. | `false` |
 | `development` | Development configures the logger to use a Zap development config  (stacktraces on warnings, no sampling), otherwise a Zap production config will be used (stacktraces on errors, sampling). | `false` |
 | `image.repository` | Image repository | `emqx/emqx-operator-controller` |
 | `image.tag` | Image tag | `{{RELEASE_VERSION}}` |

--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -16,12 +16,23 @@ imagePullSecrets:
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{ if .Values.singleNamespace }}
+kind: RoleBinding
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-manager-rolebinding
+  namespace: {{ .Release.Namespace }}
+{{- else }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "emqx-operator.fullname" . }}-manager-rolebinding
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.singleNamespace }}
+  kind: Role
+  {{- else }}
   kind: ClusterRole
+  {{- end }}
   name: {{ include "emqx-operator.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
@@ -29,10 +40,16 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{ if .Values.singleNamespace }}
+kind: Role
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-manager-role
+  namespace: {{ .Release.Namespace }}
+{{- else }}
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: {{ include "emqx-operator.fullname" . }}-manager-role
+{{- end }}
 rules:
 - apiGroups:
   - ""

--- a/deploy/charts/emqx-operator/templates/controller-manager.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager.yaml
@@ -51,6 +51,13 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        {{- if .Values.singleNamespace }}
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /readyz

--- a/deploy/charts/emqx-operator/values.yaml
+++ b/deploy/charts/emqx-operator/values.yaml
@@ -4,6 +4,9 @@
 
 skipCRDs: false
 
+## If true, the operator will watch only the namespace where it is deployed. If false, the operator will watch all namespaces.
+singleNamespace: false
+
 # Development configures the logger to use a Zap development config
 # (stacktraces on warnings, no sampling), otherwise a Zap production
 # config will be used (stacktraces on errors, sampling).

--- a/sidecar/reloader/Dockerfile
+++ b/sidecar/reloader/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18.3 as builder
+FROM golang:1.18.3 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configurable parameter `singleNamespace` for the EMQX operator, allowing deployment in a single namespace.
	- Added an environment variable `WATCH_NAMESPACE` to the controller manager for dynamic namespace awareness.
	- Updated release notes to reflect new supported API versions.

- **Bug Fixes**
	- Enhanced role and binding creation logic based on the `singleNamespace` setting.

- **Documentation**
	- Updated README to include the new `singleNamespace` parameter in the configuration table.
	- Revised release notes to clarify compatibility with new EMQX versions.

- **Chores**
	- Improved deployment workflow configuration for better flexibility in namespace management.
	- Updated Dockerfiles for stylistic consistency.
	- Changed versioning in the Chart.yaml to reflect a release candidate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->