### PR TITLE
fix: Indent ENABLE_WEBHOOKS env variable under container

### DIFF
--- a/deploy/charts/emqx-operator/templates/controller-manager.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager.yaml
@@ -27,9 +27,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      env:
-      - name: ENABLE_WEBHOOKS
-        value: {{ .Values.webhook.enabled | quote }}
       containers:
       - args:
         - --leader-elect
@@ -56,8 +53,10 @@ spec:
           name: webhook-server
           protocol: TCP
         {{- end }}
-        {{- if .Values.singleNamespace }}
         env:
+        - name: ENABLE_WEBHOOKS
+          value: {{ .Values.webhook.enabled | quote }}
+        {{- if .Values.singleNamespace }}
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Refined environment variable configuration for the EMQX operator controller manager.
	- Added conditional `WATCH_NAMESPACE` environment variable support.
	- Reorganized environment variable placement for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->