### PR TITLE
update docs

### DIFF
--- a/docs/directory.json
+++ b/docs/directory.json
@@ -77,6 +77,10 @@
         {
           "title": "Cluster Load Rebalancing (EMQX Enterprise)",
           "path": "tasks/configure-emqx-rebalance"
+        },
+        {
+          "title": "Deploy EMQX Cluster in k8s with restricted access",
+          "path": "tasks/configure-emqx-restricted-k8s"
         }
       ]
     },
@@ -193,6 +197,10 @@
         {
           "title": "集群负载重平衡（EMQX 企业版）",
           "path": "tasks/configure-emqx-rebalance"
+        },
+        {
+          "title": "在受限制的 k8s 环境中部署 EMQX 集群",
+          "path": "tasks/configure-emqx-restricted-k8s"
         }
       ]
     },

--- a/docs/en_US/deployment/on-aws-eks.md
+++ b/docs/en_US/deployment/on-aws-eks.md
@@ -12,6 +12,8 @@ Before you begin, you must have the following:
 
 - Deploy an AWS Load Balancer Controller on a cluster, for details, please refer to: [Create a Network Load Balancer](https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html)
 
+- Install the Amazon EBS CSI driver on the cluster, for details, please refer to: [Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)
+
 - Install EMQX Operator: For details, please refer to: [Install EMQX Operator](../getting-started/getting-started.md)
 
 ## Quickly Deploy An EMQX Cluster
@@ -24,20 +26,26 @@ The following is the relevant configuration of EMQX custom resources. You can se
 + Save the following content as a YAML file and deploy it via the `kubectl apply` command
 
   ```yaml
+  # Configure EBS StorageClass with WaitForFirstConsumer binding mode
+  # This ensures volumes are created in the same AZ as the pods that will use them
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: ebs-sc
+  provisioner: ebs.csi.aws.com
+  volumeBindingMode: WaitForFirstConsumer
+  ---
   apiVersion: apps.emqx.io/v2beta1
   kind: EMQX
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx-enterprise:5
     coreTemplate:
       spec:
         ## EMQX custom resources do not support updating this field at runtime
         volumeClaimTemplates:
-          ## More content: https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
-          ## Please manage the Amazon EBS CSI driver as an Amazon EKS add-on.
-          ## For more documentation please refer to: https://docs.aws.amazon.com/zh_cn/eks/latest/userguide/managing-ebs-csi.html
-          storageClassName: gp2
+          storageClassName: ebs-sc
           resources:
             requests:
               storage: 10Gi
@@ -48,9 +56,8 @@ The following is the relevant configuration of EMQX custom resources. You can se
         ## More content: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/
         annotations:
           ## Specifies whether the NLB is Internet-facing or internal. If not specified, defaults to internal.
+          service.beta.kubernetes.io/aws-load-balancer-type: external
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-          ## Specify the availability zone to which the NLB will route traffic. Specify at least one subnet, either subnetID or subnetName (subnet name label) can be used.
-          service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-xxx1,subnet-xxx2
       spec:
         type: LoadBalancer
         ## More content: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/nlb/
@@ -60,9 +67,8 @@ The following is the relevant configuration of EMQX custom resources. You can se
         ## More content: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/
         annotations:
           ## Specifies whether the NLB is Internet-facing or internal. If not specified, defaults to internal.
+          service.beta.kubernetes.io/aws-load-balancer-type: external
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-          ## Specify the availability zone to which the NLB will route traffic. Specify at least one subnet, either subnetID or subnetName (subnet name label) can be used.
-          service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-xxx1,subnet-xxx2
       spec:
         type: LoadBalancer
         ## More content: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/nlb/
@@ -95,6 +101,15 @@ The following is the relevant configuration of EMQX custom resources. You can se
 + Save the following content as a YAML file and deploy it via the `kubectl apply` command
 
   ```yaml
+  # Configure EBS StorageClass with WaitForFirstConsumer binding mode
+  # This ensures volumes are created in the same AZ as the pods that will use them
+  apiVersion: storage.k8s.io/v1
+  kind: StorageClass
+  metadata:
+    name: ebs-sc
+  provisioner: ebs.csi.aws.com
+  volumeBindingMode: WaitForFirstConsumer
+  ---
   apiVersion: apps.emqx.io/v1beta4
   kind: EmqxEnterprise
   metadata:
@@ -105,10 +120,7 @@ The following is the relevant configuration of EMQX custom resources. You can se
       metadata:
         name: emqx-ee
       spec:
-        ## More content: https://docs.aws.amazon.com/eks/latest/userguide/storage-classes.html
-        ## Please manage the Amazon EBS CSI driver as an Amazon EKS add-on.
-        ## For more documentation please refer to: https://docs.aws.amazon.com/zh_cn/eks/latest/userguide/managing-ebs-csi.html
-        storageClassName: gp2
+        storageClassName: ebs-sc
         resources:
           requests:
             storage: 10Gi
@@ -134,9 +146,8 @@ The following is the relevant configuration of EMQX custom resources. You can se
         ## More content: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/
         annotations:
           ## Specifies whether the NLB is Internet-facing or internal. If not specified, defaults to internal.
+          service.beta.kubernetes.io/aws-load-balancer-type: external
           service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
-          ## Specify the availability zone to which the NLB will route traffic. Specify at least one subnet, either subnetID or subnetName (subnet name label) can be used.
-          service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-xxx1,subnet-xxx2
       spec:
         type: LoadBalancer
         ## More content: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/nlb/
@@ -164,9 +175,9 @@ The following is the relevant configuration of EMQX custom resources. You can se
 :::
 ::::
 
-## Use MQTT X CLI To Publish/Subscribe Messages
+## Use MQTTX application To Publish/Subscribe Messages
 
-[MQTT X CLI](https://mqttx.app/cli) is an open source MQTT 5.0 command line client tool, designed to help developers to more Quickly develop and debug MQTT services and applications.
+[MQTTX CLI](https://mqttx.app/cli) is an open source MQTT 5.0 command line client tool, designed to help developers to more Quickly develop and debug MQTT services and applications.
 
 + Obtain External IP of EMQX cluster
 

--- a/docs/en_US/tasks/configure-emqx-restricted-k8s.md
+++ b/docs/en_US/tasks/configure-emqx-restricted-k8s.md
@@ -1,0 +1,129 @@
+# Deploy EMQX Cluster in k8s with restricted access
+
+Here we are assuming k8s cluster does not have access to the internet, and the user does not have permissions to create and/or use `ClusterRole`.
+
++ Both `emqx-operator` and `emqx` are installed in the same namespace
++ Cert manager may be available cluster-wide or in the same namespace as `emqx-operator`
++ The `emqx-operator` is configured to use a private docker registry, and the `emqx` is configured to use a custom `securityContext`
+
+## Task Target
+
+- Push necessary images to a private docker registry
+- Override default parameters of `cert-manager` to use private registry
+- Manually install EMQX Operator CRDs
+- Override default parameters of `emqx-operator` to use private registry, single namespace, custom `securityContext`, and disabled webhook
+- Use custom `securityContext` for EMQX
+
+## Push necessary docker images to a private docker registry
+
+```bash
+export CERT_MANAGER_VERSION='v1.16.2'
+export EMQX_OPERATOR_VERSION='2.2.26'
+export EMQX_VERSION='5.8.4'
+export REGISTRY='my.private.registry'
+
+CERT_MANAGER_IMAGES=(
+    "cert-manager-controller"
+    "cert-manager-cainjector"
+    "cert-manager-webhook"
+    "cert-manager-acmesolver"
+    "cert-manager-startupapicheck"
+)
+
+pull_retag_push() {
+    local source=$1
+    local target=$2
+    docker pull "$source"
+    docker tag "$source" "$target"
+    docker push "$target"
+}
+
+for img in "${CERT_MANAGER_IMAGES[@]}"; do
+    pull_retag_push "quay.io/jetstack/$img:$CERT_MANAGER_VERSION" "$REGISTRY/jetstack/$img:$CERT_MANAGER_VERSION"
+done
+
+pull_retag_push "emqx/emqx-enterprise:$EMQX_VERSION" "$REGISTRY/emqx/emqx-enterprise:$EMQX_VERSION"
+pull_retag_push "emqx/emqx-operator-controller:$EMQX_OPERATOR_VERSION" "$REGISTRY/emqx/emqx-operator-controller:$EMQX_OPERATOR_VERSION"
+```
+
+## Deploy cert-manager
+
+Skip this step if cert-manager is installed in the cluster.
+
+Update namespace name if required.
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm upgrade --install cert-manager jetstack/cert-manager \
+   --namespace emqx \
+   --create-namespace \
+   --set crds.enabled=true \
+   --set image.repository=$REGISTRY/jetstack/cert-manager-controller \
+   --set image.tag=$CERT_MANAGER_VERSION \
+   --set webhook.image.repository=$REGISTRY/jetstack/cert-manager-webhook \
+   --set webhook.image.tag=$CERT_MANAGER_VERSION \
+   --set cainjector.image.repository=$REGISTRY/jetstack/cert-manager-cainjector \
+   --set cainjector.image.tag=$CERT_MANAGER_VERSION \
+   --set acmesolver.image.repository=$REGISTRY/jetstack/cert-manager-acmesolver \
+   --set acmesolver.image.tag=$CERT_MANAGER_VERSION \
+   --set startupapicheck.image.repository=$REGISTRY/jetstack/cert-manager-startupapicheck \
+   --set startupapicheck.image.tag=$CERT_MANAGER_VERSION
+```
+
+## Deploy EMQX Operator
+
+### Deploy CRDs manually from release assets
+
+```bash
+kubectl -n emqx apply -f https://github.com/emqx/emqx-operator/releases/download/$EMQX_OPERATOR_VERSION/crds.yaml
+```
+
+### Deploy emqx-operator
+
+If cert-manager is installed cluster-wide already, add `--set cert-manager.enable=false`.
+
+In this example `podSecurityContext` and `containerSecurityContext` contain default values, override as necessary.
+
+```bash
+helm repo add emqx https://repos.emqx.io/charts
+helm repo update
+helm upgrade --install emqx-operator emqx/emqx-operator \
+  --namespace emqx \
+  --create-namespace \
+  --set singleNamespace=true \
+  --set webhook.enabled=false \
+  --set crds.enabled=false \
+  --set-json='podSecurityContext={"runAsNonRoot":true}' \
+  --set-json='containerSecurityContext={"allowPrivilegeEscalation":false}' \
+  --set image.repository=$REGISTRY/emqx/emqx-operator-controller \
+  --set image.tag=$EMQX_OPERATOR_VERSION
+```
+
+### Ensure emqx-operator is up and running
+
+```bash
+kubectl -n emqx wait --for=condition=Ready pods -l "control-plane=controller-manager"
+```
+
+## Configure EMQX Cluster
+
++ Save the following content as a YAML file and deploy it with the `kubectl apply` command
+
+  ```yaml
+  apiVersion: apps.emqx.io/v2beta1
+  kind: EMQX
+  metadata:
+    name: emqx
+    namespace: emqx
+  spec:
+    image: ${REGISTRY}/emqx/emqx-enterprise:${EMQX_VERSION}
+  ```
+
++ Wait for the EMQX cluster to be ready, you can check the status of EMQX cluster through `kubectl get` command, please make sure `STATUS` is `Running`, this may take some time
+
+  ```bash
+  $ kubectl get emqx emqx
+  NAME   IMAGE                                            STATUS    AGE
+  emqx   my.private.registry/emqx/emqx-enterprise:5.8.4   Running   10m
+  ```

--- a/docs/zh_CN/tasks/configure-emqx-restricted-k8s.md
+++ b/docs/zh_CN/tasks/configure-emqx-restricted-k8s.md
@@ -1,0 +1,127 @@
+# Deploy EMQX Cluster in k8s with restricted access
+
+Here we are assuming k8s cluster does not have access to the internet, and the user does not have permissions to create and/or use `ClusterRole`. Both `emqx-operator` and `emqx` are installed in the same namespace. Cert manager may be available cluster-wide or in the same namespace as `emqx-operator`. The `emqx-operator` is configured to use a private docker registry, and the `emqx` is configured to use a custom `securityContext`.
+
+## Task Target
+
+- Push necessary images to a private docker registry
+- Override default parameters of `cert-manager` to use private registry
+- Manually install EMQX Operator CRDs
+- Override default parameters of `emqx-operator` to use private registry, single namespace, custom `securityContext`, and disabled webhook
+- Use custom `securityContext` for EMQX
+
+## Push cert-manager, emqx-operator and emqx-enterprise images to a private docker registry
+
+```bash
+export CERT_MANAGER_VERSION='v1.16.2'
+export EMQX_OPERATOR_VERSION='2.2.26'
+export EMQX_VERSION='5.8.4'
+export REGISTRY='my.private.registry'
+
+CERT_MANAGER_IMAGES=(
+    "cert-manager-controller"
+    "cert-manager-cainjector"
+    "cert-manager-webhook"
+    "cert-manager-acmesolver"
+    "cert-manager-startupapicheck"
+)
+
+pull_retag_push() {
+    local source=$1
+    local target=$2
+    docker pull "$source"
+    docker tag "$source" "$target"
+    docker push "$target"
+}
+
+for img in "${CERT_MANAGER_IMAGES[@]}"; do
+    pull_retag_push "quay.io/jetstack/$img:$CERT_MANAGER_VERSION" "$REGISTRY/jetstack/$img:$CERT_MANAGER_VERSION"
+done
+
+pull_retag_push "emqx/emqx-enterprise:$EMQX_VERSION" "$REGISTRY/emqx/emqx-enterprise:$EMQX_VERSION"
+pull_retag_push "emqx/emqx-operator-controller:$EMQX_OPERATOR_VERSION" "$REGISTRY/emqx/emqx-operator-controller:$EMQX_OPERATOR_VERSION"
+```
+
+## Deploy cert-manager
+
+Skip this step if cert-manager is installed in the cluster.
+
+Update namespace name if required.
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm upgrade --install cert-manager jetstack/cert-manager \
+   --namespace emqx \
+   --create-namespace \
+   --set crds.enabled=true \
+   --set image.repository=$REGISTRY/jetstack/cert-manager-controller \
+   --set image.tag=$CERT_MANAGER_VERSION \
+   --set webhook.image.repository=$REGISTRY/jetstack/cert-manager-webhook \
+   --set webhook.image.tag=$CERT_MANAGER_VERSION \
+   --set cainjector.image.repository=$REGISTRY/jetstack/cert-manager-cainjector \
+   --set cainjector.image.tag=$CERT_MANAGER_VERSION \
+   --set acmesolver.image.repository=$REGISTRY/jetstack/cert-manager-acmesolver \
+   --set acmesolver.image.tag=$CERT_MANAGER_VERSION \
+   --set startupapicheck.image.repository=$REGISTRY/jetstack/cert-manager-startupapicheck \
+   --set startupapicheck.image.tag=$CERT_MANAGER_VERSION
+```
+
+## Deploy EMQX Operator
+
+### Deploy CRDs manually from release assets
+
+```bash
+kubectl -n emqx apply -f https://github.com/emqx/emqx-operator/releases/download/$EMQX_OPERATOR_VERSION/crds.yaml
+```
+
+### Deploy emqx-operator
+
+If cert-manager is installed cluster-wide already, add `--set cert-manager.enable=false`.
+
+In this example `podSecurityContext` and `containerSecurityContext` contain default values, override as necessary.
+
+```bash
+helm repo add emqx https://repos.emqx.io/charts
+helm repo update
+helm upgrade --install emqx-operator emqx/emqx-operator \
+  --namespace emqx \
+  --create-namespace \
+  --set singleNamespace=true \
+  --set webhook.enabled=false \
+  --set crds.enabled=false \
+  --set-json='podSecurityContext={"runAsNonRoot":true}' \
+  --set-json='containerSecurityContext={"allowPrivilegeEscalation":false}' \
+  --set image.repository=$REGISTRY/emqx/emqx-operator-controller \
+  --set image.tag=$EMQX_OPERATOR_VERSION
+```
+
+### Ensure emqx-operator is up and running
+
+```bash
+kubectl -n emqx wait --for=condition=Ready pods -l "control-plane=controller-manager"
+```
+
+## Configure EMQX Cluster
+
+`apps.emqx.io/v2beta1 EMQX` supports configuring the Core node of the EMQX cluster through the `.spec.coreTemplate` field, and configuring the Replicant node of the EMQX cluster using the `.spec.replicantTemplate` field. For more information, please refer to: [API Reference](../reference/v2beta1-reference.md#emqxspec).
+
++ Save the following content as a YAML file and deploy it with the `kubectl apply` command
+
+  ```yaml
+  apiVersion: apps.emqx.io/v2beta1
+  kind: EMQX
+  metadata:
+    name: emqx
+    namespace: emqx
+  spec:
+    image: emqx/emqx-enterprise:5.8
+  ```
+
++ Wait for the EMQX cluster to be ready, you can check the status of EMQX cluster through `kubectl get` command, please make sure `STATUS` is `Running`, this may take some time
+
+  ```bash
+  $ kubectl get emqx emqx
+  NAME   IMAGE                      STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.8   Running   10m
+  ```


### PR DESCRIPTION
* add a documentation for deploying operator in restricted k8s environment
* update AWS EKS documentation according to the latest experience https://github.com/id/emqx-eks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added new documentation for deploying EMQX Cluster in Kubernetes with restricted access (available in English and Chinese)
	- Updated AWS EKS deployment guide with:
		- New prerequisite for Amazon EBS CSI driver
		- Updated storage class configuration
		- Updated EMQX enterprise image
		- Modified load balancer annotations
		- Revised section title for MQTT client usage
	- Enhanced clarity and specificity of deployment instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->