### PR TITLE
fix: change scale down strategy when blue green update

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release Note 🍻
 
-EMQX Operator 2.2.28 has been released.
+EMQX Operator 2.2.29-beta.1 has been released.
 
 ## Supported version
 + apps.emqx.io/v2beta1
@@ -13,13 +13,9 @@ EMQX Operator 2.2.28 has been released.
   + EMQX at 4.4.14 and later
   + EMQX Enterprise at 4.4.14 and later
 
-## Fixes 🛠
+## Fix 🐞
 
-+ Fix the Helm template formatting issue, thanks to [Rouke Broersma](https://github.com/rouke-broersma) for their contribution in [PR#1102](https://github.com/emqx/emqx-operator/pull/1102)
-
-## Enhancements 🚀
-
-+ Better documents
++ Fix the issue that the replicas of the statefulSet is not current when the `emqx` CR is updated
 
 ## How to install/upgrade EMQX Operator 💡
 
@@ -31,7 +27,7 @@ helm repo update
 helm upgrade --install emqx-operator emqx/emqx-operator \
   --namespace emqx-operator-system \
   --create-namespace \
-  --version 2.2.28
+  --version 2.2.29-beta.1
 kubectl wait --for=condition=Ready pods -l "control-plane=controller-manager" -n emqx-operator-system
 ```
 

--- a/controllers/apps/v2beta1/sync_pods.go
+++ b/controllers/apps/v2beta1/sync_pods.go
@@ -76,7 +76,8 @@ func (s *syncPods) reconcile(ctx context.Context, logger logr.Logger, instance *
 				}
 			}
 			if _, ok := pod.Annotations["controller.kubernetes.io/pod-deletion-cost"]; ok {
-				currentRs.Spec.Replicas = ptr.To(int32(instance.Status.ReplicantNodesStatus.CurrentReplicas - 1))
+				// https://github.com/emqx/emqx-operator/issues/1105
+				currentRs.Spec.Replicas = ptr.To(int32(*currentRs.Spec.Replicas - 1))
 				if err := s.Client.Update(ctx, currentRs); err != nil {
 					return subResult{err: emperror.Wrap(err, "failed to scale down old replicaSet")}
 				}
@@ -92,7 +93,8 @@ func (s *syncPods) reconcile(ctx context.Context, logger logr.Logger, instance *
 			return subResult{err: emperror.Wrap(err, "failed to check if sts can be scale down")}
 		}
 		if canBeScaledDown {
-			currentSts.Spec.Replicas = ptr.To(int32(instance.Status.CoreNodesStatus.CurrentReplicas - 1))
+			// https://github.com/emqx/emqx-operator/issues/1105
+			currentSts.Spec.Replicas = ptr.To(int32(*currentSts.Spec.Replicas - 1))
 			if err := s.Client.Update(ctx, currentSts); err != nil {
 				return subResult{err: emperror.Wrap(err, "failed to scale down old statefulSet")}
 			}

--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.28
+version: 2.2.29-beta.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.2.28
+appVersion: 2.2.29-beta.1
 
 sources:
   - https://github.com/emqx/emqx-operator/tree/main/deploy/charts/emqx-operator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the operator and Helm chart to version 2.2.29-beta.1.
  - Expanded supported API versions to improve compatibility with EMQX and EMQX Enterprise.
  - Updated installation instructions to reflect the new release.

- **Bug Fixes**
  - Resolved an issue where replica scaling during updates did not reflect the current count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->