### PR TITLE
make webhook into namespace scope when singleNamespace=true

### DIFF
--- a/deploy/charts/emqx-operator/templates/webhook-mutating-configuration.yaml
+++ b/deploy/charts/emqx-operator/templates/webhook-mutating-configuration.yaml
@@ -5,7 +5,11 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert
+  {{- if .Values.singleNamespace }}
+  name: {{ .Release.Namespace }}-{{ include "emqx-operator.fullname" . }}-mutating-webhook-configuration
+  {{- else }}
   name: {{ include "emqx-operator.fullname" . }}-mutating-webhook-configuration
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -27,6 +31,11 @@ webhooks:
     - UPDATE
     resources:
     - emqxbrokers
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 - admissionReviewVersions:
   - v1
@@ -48,6 +57,11 @@ webhooks:
     - UPDATE
     resources:
     - emqxenterprises
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 - admissionReviewVersions:
   - v1
@@ -69,5 +83,10 @@ webhooks:
     - UPDATE
     resources:
     - emqxplugins
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 {{- end -}}

--- a/deploy/charts/emqx-operator/templates/webhook-validating-configuration.yaml
+++ b/deploy/charts/emqx-operator/templates/webhook-validating-configuration.yaml
@@ -5,7 +5,11 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert
+  {{- if .Values.singleNamespace }}
+  name: {{ .Release.Namespace }}-{{ include "emqx-operator.fullname" . }}-validating-webhook-configuration
+  {{- else }}
   name: {{ include "emqx-operator.fullname" . }}-validating-webhook-configuration
+  {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -27,6 +31,11 @@ webhooks:
     - UPDATE
     resources:
     - rebalances
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 - admissionReviewVersions:
   - v1
@@ -48,6 +57,11 @@ webhooks:
     - UPDATE
     resources:
     - emqxbrokers
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 - admissionReviewVersions:
   - v1
@@ -69,6 +83,11 @@ webhooks:
     - UPDATE
     resources:
     - emqxenterprises
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 - admissionReviewVersions:
   - v1
@@ -90,5 +109,10 @@ webhooks:
     - UPDATE
     resources:
     - emqxplugins
+  {{- if .Values.singleNamespace }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   sideEffects: None
 {{- end -}}


### PR DESCRIPTION
currently when we try to install multi emqx-operators in one K8s cluster

 `helm install --set singleNamespace=true  --set singleNamespace=true --set skipCRDs=true`

it will crash on webhook, this pull request solves this problem.

when we watch only one namespace, just install webhooks at the namespace scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced webhook configurations that automatically adapt to a single namespace mode. The system now adjusts webhook names and applies scope restrictions based on the selected namespace, ensuring operations remain confined to the intended environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->