### PR TITLE
Helm Chart:  Remove wrong image pull usage in SA

### DIFF
--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -10,10 +10,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- with .Values.imagePullSecrets }}
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 {{ if .Values.singleNamespace }}


### PR DESCRIPTION
The Kubernetes service account resource does not support an image pull secret config 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the deployment configuration by removing the option for specifying container image pull credentials. This change streamlines the setup without affecting user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->