### PR TITLE
fix: correct TopologySpreadConstraints reference in generateReplicaSet

### DIFF
--- a/controllers/apps/v2beta1/add_emqx_repl.go
+++ b/controllers/apps/v2beta1/add_emqx_repl.go
@@ -191,7 +191,7 @@ func generateReplicaSet(instance *appsv2beta1.EMQX) *appsv1.ReplicaSet {
 						// TODO: just for compatible with old version, will remove in future
 						instance.Spec.ReplicantTemplate.Spec.ToleRations...,
 					),
-					TopologySpreadConstraints: instance.Spec.CoreTemplate.Spec.TopologySpreadConstraints,
+					TopologySpreadConstraints: instance.Spec.ReplicantTemplate.Spec.TopologySpreadConstraints,
 					NodeName:                  instance.Spec.ReplicantTemplate.Spec.NodeName,
 					NodeSelector:              instance.Spec.ReplicantTemplate.Spec.NodeSelector,
 					InitContainers:            instance.Spec.ReplicantTemplate.Spec.InitContainers,


### PR DESCRIPTION
Updated the TopologySpreadConstraints to use the correct path from the ReplicantTemplate instead of the CoreTemplate in the generateReplicaSet function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted replica set configuration so that topology spread settings now follow the intended template. This update ensures that replica deployments consistently adhere to the expected distribution policies across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->