### PR TITLE
docs: use consistent docker image tag

### DIFF
--- a/config/crd/bases/apps.emqx.io_emqxbrokers.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxbrokers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxbrokers.apps.emqx.io
 spec:
   group: apps.emqx.io

--- a/config/crd/bases/apps.emqx.io_emqxenterprises.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxenterprises.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxenterprises.apps.emqx.io
 spec:
   group: apps.emqx.io

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxes.apps.emqx.io
 spec:
   group: apps.emqx.io

--- a/config/crd/bases/apps.emqx.io_emqxplugins.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxplugins.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxplugins.apps.emqx.io
 spec:
   group: apps.emqx.io

--- a/config/crd/bases/apps.emqx.io_rebalances.yaml
+++ b/config/crd/bases/apps.emqx.io_rebalances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: rebalances.apps.emqx.io
 spec:
   group: apps.emqx.io

--- a/config/samples/emqx/v2alpha1/emqx-slim.yaml
+++ b/config/samples/emqx/v2alpha1/emqx-slim.yaml
@@ -3,4 +3,4 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx:5
+  image: emqx/emqx:latest

--- a/config/samples/emqx/v2beta1/emqx-slim.yaml
+++ b/config/samples/emqx/v2beta1/emqx-slim.yaml
@@ -3,4 +3,4 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx:5
+  image: emqx/emqx:latest

--- a/controllers/apps/v2beta1/add_emqx_core_test.go
+++ b/controllers/apps/v2beta1/add_emqx_core_test.go
@@ -24,7 +24,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 			},
 		},
 		Spec: appsv2beta1.EMQXSpec{
-			Image:         "emqx/emqx:5.1",
+			Image:         "emqx/emqx:latest",
 			ClusterDomain: "cluster.local",
 		},
 	}

--- a/controllers/apps/v2beta1/add_emqx_repl_test.go
+++ b/controllers/apps/v2beta1/add_emqx_repl_test.go
@@ -23,7 +23,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 			},
 		},
 		Spec: appsv2beta1.EMQXSpec{
-			Image:         "emqx/emqx:5.1",
+			Image:         "emqx/emqx:latest",
 			ClusterDomain: "cluster.local",
 		},
 	}

--- a/deploy/charts/emqx-operator/templates/crd.emqxbrokers.apps.emqx.io.yaml
+++ b/deploy/charts/emqx-operator/templates/crd.emqxbrokers.apps.emqx.io.yaml
@@ -5,7 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxbrokers.apps.emqx.io
 spec:
   conversion:

--- a/deploy/charts/emqx-operator/templates/crd.emqxenterprises.apps.emqx.io.yaml
+++ b/deploy/charts/emqx-operator/templates/crd.emqxenterprises.apps.emqx.io.yaml
@@ -6,7 +6,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxenterprises.apps.emqx.io
 spec:
   conversion:

--- a/deploy/charts/emqx-operator/templates/crd.emqxes.apps.emqx.io.yaml
+++ b/deploy/charts/emqx-operator/templates/crd.emqxes.apps.emqx.io.yaml
@@ -6,7 +6,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxes.apps.emqx.io
 spec:
   conversion:

--- a/deploy/charts/emqx-operator/templates/crd.emqxplugins.apps.emqx.io.yaml
+++ b/deploy/charts/emqx-operator/templates/crd.emqxplugins.apps.emqx.io.yaml
@@ -6,7 +6,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: emqxplugins.apps.emqx.io
 spec:
   conversion:

--- a/deploy/charts/emqx-operator/templates/crd.rebalances.apps.emqx.io.yaml
+++ b/deploy/charts/emqx-operator/templates/crd.rebalances.apps.emqx.io.yaml
@@ -6,7 +6,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "emqx-operator.fullname" . }}-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: rebalances.apps.emqx.io
 spec:
   conversion:

--- a/docs/en_US/deployment/on-aws-eks.md
+++ b/docs/en_US/deployment/on-aws-eks.md
@@ -79,8 +79,8 @@ The following is the relevant configuration of EMQX custom resources. You can se
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   18m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   18m
   ```
 
 + Obtain Dashboard External IP of EMQX cluster and access EMQX console

--- a/docs/en_US/deployment/on-azure-aks.md
+++ b/docs/en_US/deployment/on-azure-aks.md
@@ -28,7 +28,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx:5.1"
+  image: "emqx/emqx:latest"
   coreTemplate:
     spec:
       volumeClaimTemplates:
@@ -53,8 +53,8 @@ Wait for the EMQX cluster to be ready. You can check the status of the EMQX clus
 
 ```shell
 $ kubectl get emqx
-NAME   IMAGE      STATUS    AGE
-emqx   emqx:5.1   Running   118s
+NAME   IMAGE              STATUS    AGE
+emqx   emqx/emqx:latest   Running   118s
 ```
 
 Get the External IP of the EMQX cluster and access the EMQX console.

--- a/docs/en_US/deployment/on-gcp-gke.md
+++ b/docs/en_US/deployment/on-gcp-gke.md
@@ -39,7 +39,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx:5.1"
+  image: "emqx/emqx:latest"
   coreTemplate:
     spec:
       volumeClaimTemplates:
@@ -64,8 +64,8 @@ Wait for the EMQX cluster to be ready. You can check the status of the EMQX clus
 
 ```shell
 $ kubectl get emqx
-NAME   IMAGE      STATUS    AGE
-emqx   emqx:5.1   Running   118s
+NAME   IMAGE              STATUS    AGE
+emqx   emqx/emqx:latest   Running   118s
 ```
 
 Get the External IP of the EMQX cluster and access the EMQX console.

--- a/docs/en_US/getting-started/getting-started.md
+++ b/docs/en_US/getting-started/getting-started.md
@@ -74,7 +74,7 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
    metadata:
       name: emqx-ee
    spec:
-      image: emqx/emqx-enterprise:5.6
+      image: emqx/emqx-enterprise:5.8
    ```
 
    For more details about the EMQX CRD, please check the [reference document](../reference/v2beta1-reference.md).
@@ -85,7 +85,7 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
    $ kubectl get emqx
 
    NAME      IMAGE                        STATUS    AGE
-   emqx-ee   emqx/emqx-enterprise:5.1.0   Running   2m55s
+   emqx-ee   emqx/emqx-enterprise:5.8.6   Running   2m55s
    ```
 
    Make sure the `STATUS` is `Running`, it maybe takes some time to wait for the EMQX cluster to be ready.
@@ -101,7 +101,7 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
    metadata:
       name: emqx
    spec:
-      image: emqx:5
+      image: emqx/emqx:latest
    ```
 
    For more details about the EMQX CRD, please check the [reference document](../reference/v2beta1-reference.md).
@@ -111,8 +111,8 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
    ```bash
    $ kubectl get emqx
 
-   NAME   IMAGE      STATUS    AGE
-   emqx   emqx:5.1   Running   2m55s
+   NAME   IMAGE              STATUS    AGE
+   emqx   emqx/emqx:latest   Running   2m55s
    ```
 
    Make sure the `STATUS` is `Running`, it maybe takes some time to wait for the EMQX cluster to be ready.

--- a/docs/en_US/tasks/configure-emqx-blueGreenUpdate.md
+++ b/docs/en_US/tasks/configure-emqx-blueGreenUpdate.md
@@ -113,7 +113,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx:5
+  image: emqx/emqx:latest
   updateStrategy:
     evacuationStrategy:
       connEvictRate: 1000

--- a/docs/en_US/tasks/configure-emqx-config.md
+++ b/docs/en_US/tasks/configure-emqx-config.md
@@ -18,7 +18,7 @@ The main configuration file of EMQX is `/etc/emqx.conf`. Starting from version 5
    metadata:
       name: emqx
    spec:
-      image: emqx:5
+      image: emqx/emqx:latest
       imagePullPolicy: IfNotPresent
       config:
          data: |
@@ -40,8 +40,8 @@ The main configuration file of EMQX is `/etc/emqx.conf`. Starting from version 5
 
    ```bash
    $ kubectl get emqx emqx
-   NAME   IMAGE      STATUS    AGE
-   emqx   emqx:5.1   Running   10m
+   NAME   IMAGE              STATUS    AGE
+   emqx   emqx/emqx:latest   Running   10m
    ```
 
 + Obtain the Dashboard External IP of EMQX cluster and access EMQX console

--- a/docs/en_US/tasks/configure-emqx-core-replicant.md
+++ b/docs/en_US/tasks/configure-emqx-core-replicant.md
@@ -33,7 +33,7 @@ There must be at least one Core node in the EMQX cluster. For the purpose of hig
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         replicas: 2
@@ -59,8 +59,8 @@ There must be at least one Core node in the EMQX cluster. For the purpose of hig
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + Obtain the Dashboard External IP of EMQX cluster and access EMQX console

--- a/docs/en_US/tasks/configure-emqx-log-level.md
+++ b/docs/en_US/tasks/configure-emqx-log-level.md
@@ -41,8 +41,8 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + EMQX Operator will create two EMQX Service resources, one is emqx-dashboard and the other is emqx-listeners, corresponding to EMQX console and EMQX listening port respectively.

--- a/docs/en_US/tasks/configure-emqx-persistence.md
+++ b/docs/en_US/tasks/configure-emqx-persistence.md
@@ -24,7 +24,7 @@ When the user configures the `.spec.coreTemplate.spec.volumeClaimTemplates` fiel
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         volumeClaimTemplates:
@@ -49,8 +49,8 @@ When the user configures the `.spec.coreTemplate.spec.volumeClaimTemplates` fiel
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + Obtain the Dashboard External IP of the EMQX cluster and access the EMQX console

--- a/docs/en_US/tasks/configure-emqx-prometheus.md
+++ b/docs/en_US/tasks/configure-emqx-prometheus.md
@@ -23,7 +23,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx:5
+  image: emqx/emqx:latest
 ```
 
 Save the above content as `emqx.yaml` and execute the following command to deploy the EMQX cluster:
@@ -39,8 +39,8 @@ Check the status of the EMQX cluster and make sure that `STATUS` is `Running`, w
 ```bash
 $ kubectl get emqx emqx
 
-NAME   IMAGE      STATUS    AGE
-emqx   emqx:5.1   Running   10m
+NAME   IMAGE              STATUS    AGE
+emqx   emqx/emqx:latest   Running   10m
 ```
 
 :::

--- a/docs/en_US/tasks/configure-emqx-service.md
+++ b/docs/en_US/tasks/configure-emqx-service.md
@@ -21,7 +21,7 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     listenersServiceTemplate:
       spec:
         type: LoadBalancer
@@ -38,8 +38,8 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 + Obtain the Dashboard External IP of the EMQX cluster and access the EMQX console
 

--- a/docs/en_US/tasks/configure-emqx-tls.md
+++ b/docs/en_US/tasks/configure-emqx-tls.md
@@ -52,7 +52,7 @@ There are many types of Volumes. For the description of Volumes, please refer to
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     config:
       data: |
         listeners.ssl.default {
@@ -102,8 +102,8 @@ There are many types of Volumes. For the description of Volumes, please refer to
   ```bash
   $ kubectl get emqx
 
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + Obtain the External IP of EMQX cluster and access EMQX console

--- a/docs/zh_CN/deployment/on-alibaba-cloud.md
+++ b/docs/zh_CN/deployment/on-alibaba-cloud.md
@@ -30,7 +30,7 @@ EMQX Operator 支持在阿里云容器服务 Kubernetes 版部署 EMQX。阿里�
   metadata:
     name: emqx
   spec:
-    image: "emqx:5.1"
+    image: "emqx/emqx:latest"
     coreTemplate:
       spec:
         ## EMQX 自定义资源不支持在运行时更新这个字段
@@ -66,8 +66,8 @@ EMQX Operator 支持在阿里云容器服务 Kubernetes 版部署 EMQX。阿里�
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   2m55s
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   2m55s
   ```
 
 + 获取 EMQX 集群 Dashboard External IP, 访问 EMQX 控制台
@@ -212,7 +212,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx:5.1"
+  image: "emqx/emqx:latest"
   coreTemplate:
     spec:
       ## EMQX 自定义资源不支持在运行时更新这个字段

--- a/docs/zh_CN/deployment/on-aws-eks.md
+++ b/docs/zh_CN/deployment/on-aws-eks.md
@@ -29,7 +29,7 @@ EMQX Operator 支持在 Amazon 容器服务 EKS（Elastic Kubernetes Service）�
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         ## 若开启了持久化，您需要配置 podSecurityContext，
@@ -82,8 +82,8 @@ EMQX Operator 支持在 Amazon 容器服务 EKS（Elastic Kubernetes Service）�
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   18m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   18m
   ```
 
 + 获取 EMQX 集群的 Dashboard External IP, 访问 EMQX 控制台

--- a/docs/zh_CN/deployment/on-azure-aks.md
+++ b/docs/zh_CN/deployment/on-azure-aks.md
@@ -28,7 +28,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx:5.1"
+  image: "emqx/emqx:latest"
   coreTemplate:
     spec:
       volumeClaimTemplates:
@@ -53,8 +53,8 @@ spec:
 
 ```shell
 $ kubectl get emqx
-NAME   IMAGE      STATUS    AGE
-emqx   emqx:5.1   Running   118s
+NAME   IMAGE              STATUS    AGE
+emqx   emqx/emqx:latest   Running   118s
 ```
 
 获取 EMQX 集群的外部 IP，并访问 EMQX 控制台。

--- a/docs/zh_CN/deployment/on-gcp-gke.md
+++ b/docs/zh_CN/deployment/on-gcp-gke.md
@@ -37,7 +37,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx:5.1"
+  image: "emqx/emqx:latest"
   coreTemplate:
     spec:
       volumeClaimTemplates:
@@ -62,8 +62,8 @@ spec:
 
 ```shell
 $ kubectl get emqx
-NAME   IMAGE      STATUS    AGE
-emqx   emqx:5.1   Running   118s
+NAME   IMAGE              STATUS    AGE
+emqx   emqx/emqx:latest   Running   118s
 ```
 
 获取 EMQX 集群的外部 IP 地址，并访问 EMQX 控制台。

--- a/docs/zh_CN/deployment/on-huawei-cloud.md
+++ b/docs/zh_CN/deployment/on-huawei-cloud.md
@@ -40,7 +40,7 @@ EMQX Operator 支持在华为云容器引擎（Cloud Container Engine，简称 C
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         ## EMQX 自定义资源不支持在运行时更新这个字段
@@ -86,8 +86,8 @@ EMQX Operator 支持在华为云容器引擎（Cloud Container Engine，简称 C
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   2m55s
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   2m55s
   ```
 
 + 获取 EMQX 集群的 External IP，访问 EMQX 控制台

--- a/docs/zh_CN/deployment/on-tencent-cloud.md
+++ b/docs/zh_CN/deployment/on-tencent-cloud.md
@@ -30,7 +30,7 @@ EMQX Operator 支持在腾讯云容器服务（Tencent Kubernetes Engine，TKE�
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         ## EMQX 自定义资源不支持在运行时更新这个字段
@@ -63,8 +63,8 @@ EMQX Operator 支持在腾讯云容器服务（Tencent Kubernetes Engine，TKE�
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   2m55s
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   2m55s
   ```
 
 + 获取 EMQX 集群的 External IP，访问 EMQX 控制台

--- a/docs/zh_CN/getting-started/getting-started.md
+++ b/docs/zh_CN/getting-started/getting-started.md
@@ -71,7 +71,7 @@
    metadata:
       name: emqx-ee
    spec:
-      image: emqx/emqx-enterprise:5.6
+      image: emqx/emqx-enterprise:5.8
    ```
 
    并使用 `kubectl apply` 命令来部署 EMQX。
@@ -88,7 +88,7 @@
    $ kubectl get emqx
 
    NAME      IMAGE                        STATUS    AGE
-   emqx-ee   emqx/emqx-enterprise:5.1.0   Running   2m55s
+   emqx-ee   emqx/emqx-enterprise:5.8.6   Running   2m55s
    ```
 :::
 
@@ -102,7 +102,7 @@
    metadata:
       name: emqx
    spec:
-      image: emqx:5
+      image: emqx/emqx:latest
    ```
 
    并使用 `kubectl apply` 命令来部署 EMQX。
@@ -118,8 +118,8 @@
    ```bash
    $ kubectl get emqx
 
-   NAME   IMAGE      STATUS    AGE
-   emqx   emqx:5.1   Running   2m55s
+   NAME   IMAGE              STATUS    AGE
+   emqx   emqx/emqx:latest   Running   2m55s
    ```
 :::
 

--- a/docs/zh_CN/tasks/configure-emqx-blueGreenUpdate.md
+++ b/docs/zh_CN/tasks/configure-emqx-blueGreenUpdate.md
@@ -108,7 +108,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx:5
+  image: emqx/emqx:latest
   updateStrategy:
     evacuationStrategy:
       connEvictRate: 1000

--- a/docs/zh_CN/tasks/configure-emqx-config.md
+++ b/docs/zh_CN/tasks/configure-emqx-config.md
@@ -22,7 +22,7 @@ EMQX 主配置文件为 `etc/emqx.conf`，从 5.0 版本开始，EMQX 采用 [HO
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     config:
       data: |
         listeners.tcp.test {
@@ -43,8 +43,8 @@ EMQX 主配置文件为 `etc/emqx.conf`，从 5.0 版本开始，EMQX 采用 [HO
 
   ```
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   2m55s
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   2m55s
   ```
 
 + 获取 EMQX 集群的 Dashboard External IP，访问 EMQX 控制台

--- a/docs/zh_CN/tasks/configure-emqx-core-replicant.md
+++ b/docs/zh_CN/tasks/configure-emqx-core-replicant.md
@@ -33,7 +33,7 @@ EMQX 集群中至少要有一个 Core 节点，出于高可用的目的，EMQX O
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         replicas: 2
@@ -59,8 +59,8 @@ EMQX 集群中至少要有一个 Core 节点，出于高可用的目的，EMQX O
 
   ```
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   2m55s
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   2m55s
   ```
 
 + 获取 EMQX 集群的 Dashboard External IP，访问 EMQX 控制台

--- a/docs/zh_CN/tasks/configure-emqx-log-level.md
+++ b/docs/zh_CN/tasks/configure-emqx-log-level.md
@@ -41,8 +41,8 @@
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + 获取 EMQX 集群的 Dashboard External IP，访问 EMQX 控制台

--- a/docs/zh_CN/tasks/configure-emqx-persistence.md
+++ b/docs/zh_CN/tasks/configure-emqx-persistence.md
@@ -24,7 +24,7 @@
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     coreTemplate:
       spec:
         volumeClaimTemplates:
@@ -49,8 +49,8 @@
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + 获取 EMQX 集群的 Dashboard External IP，访问 EMQX 控制台

--- a/docs/zh_CN/tasks/configure-emqx-prometheus.md
+++ b/docs/zh_CN/tasks/configure-emqx-prometheus.md
@@ -23,7 +23,7 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx:5
+  image: emqx/emqx:latest
   coreTemplate:
     spec:
       ports:
@@ -50,8 +50,8 @@ emqx.apps.emqx.io/emqx created
 ```bash
 $ kubectl get emqx emqx
 
-NAME   IMAGE      STATUS    AGE
-emqx   emqx:5.1   Running   10m
+NAME   IMAGE              STATUS    AGE
+emqx   emqx/emqx:latest   Running   10m
 ```
 
 :::

--- a/docs/zh_CN/tasks/configure-emqx-service.md
+++ b/docs/zh_CN/tasks/configure-emqx-service.md
@@ -21,7 +21,7 @@
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     listenersServiceTemplate:
       spec:
         type: LoadBalancer
@@ -38,8 +38,8 @@
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 + 获取 EMQX 集群的 Dashboard External IP，访问 EMQX 控制台
 

--- a/docs/zh_CN/tasks/configure-emqx-tls.md
+++ b/docs/zh_CN/tasks/configure-emqx-tls.md
@@ -52,7 +52,7 @@ Volumes 的类型有很多种，关于 Volumes 描述可以参考文档：[Volum
   metadata:
     name: emqx
   spec:
-    image: emqx:5
+    image: emqx/emqx:latest
     config:
       data: |
         listeners.ssl.default {
@@ -101,8 +101,8 @@ Volumes 的类型有很多种，关于 Volumes 描述可以参考文档：[Volum
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE      STATUS    AGE
-  emqx   emqx:5.1   Running   10m
+  NAME   IMAGE              STATUS    AGE
+  emqx   emqx/emqx:latest   Running   10m
   ```
 
 + 获取 EMQX 集群的 Dashboard External IP，访问 EMQX 控制台

--- a/e2e/v2beta1/e2e_rebalance_test.go
+++ b/e2e/v2beta1/e2e_rebalance_test.go
@@ -108,7 +108,7 @@ var _ = Describe("EMQX 5 Rebalance Test", Label("rebalance"), func() {
 
 	Context("EMQX is not enterprise", func() {
 		BeforeEach(func() {
-			instance.Spec.Image = "emqx/emqx:5.1"
+			instance.Spec.Image = "emqx/emqx:latest"
 			r = rebalance.DeepCopy()
 			r.Namespace = instance.GetNamespace()
 			r.Spec.InstanceKind = instance.GroupVersionKind().Kind

--- a/e2e/v2beta1/e2e_test.go
+++ b/e2e/v2beta1/e2e_test.go
@@ -226,7 +226,7 @@ var _ = Describe("E2E Test", Label("base"), Ordered, func() {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 					return err
 				}
-				instance.Spec.Image = "emqx:5"
+				instance.Spec.Image = "emqx/emqx:latest"
 				return k8sClient.Update(ctx, instance)
 			})).Should(Succeed())
 
@@ -565,7 +565,7 @@ var _ = Describe("E2E Test", Label("base"), Ordered, func() {
 				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance); err != nil {
 					return err
 				}
-				instance.Spec.Image = "emqx:5"
+				instance.Spec.Image = "emqx/emqx:latest"
 				instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
 				return k8sClient.Update(ctx, instance)
 			})).Should(Succeed())


### PR DESCRIPTION
`emqx:emqx/latest` for CE and `emqx:emqx-enterprise/5.8` for EE
fixes emqx/emqx#14978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated deployment configurations to pull the latest EMQX container images, ensuring that users benefit from current updates and improvements.

- **Documentation**
  - Enhanced cloud deployment guides with updated command outputs and clearer instructions for accessing the EMQX console, now including steps to retrieve the Dashboard External IP.
  - Updated getting started guides to reflect the latest EMQX image versions and provide improved clarity on deployment processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->