### PR TITLE
chore(rbac): add patch permission for event

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       tags: ${{ steps.tags.outputs.tags}}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
 
     steps:
@@ -52,7 +52,7 @@ jobs:
       matrix:
         tags: ${{ fromJSON(needs.prepare.outputs.tags) }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'emqx'
     steps:
     - name: clone docs

--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   gitlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.24 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   resources:
   - configmaps
   - endpoints
-  - events
   - persistentvolumes
   - secrets
   - services
@@ -17,6 +16,17 @@ rules:
   - create
   - get
   - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.29-beta.1
+version: 2.2.29-beta.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.2.29-beta.1
+appVersion: 2.2.29-beta.2
 
 sources:
   - https://github.com/emqx/emqx-operator/tree/main/deploy/charts/emqx-operator

--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -51,16 +51,10 @@ rules:
   - ""
   resources:
   - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - endpoints
+  - persistentvolumes
+  - secrets
+  - services
   verbs:
   - create
   - get
@@ -75,6 +69,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
@@ -84,16 +79,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - create
   - get
   - list
   - update
@@ -114,51 +99,10 @@ rules:
   verbs:
   - patch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - replicasets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
   - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
   verbs:
   - create
   - delete
@@ -170,109 +114,9 @@ rules:
   - apps.emqx.io
   resources:
   - emqxbrokers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxbrokers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxbrokers/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
   - emqxenterprises
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxenterprises/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxenterprises/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
   - emqxes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxes/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxes/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
   - emqxplugins
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxplugins/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxplugins/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - apps.emqx.io
-  resources:
   - rebalances
   verbs:
   - create
@@ -285,12 +129,20 @@ rules:
 - apiGroups:
   - apps.emqx.io
   resources:
+  - emqxbrokers/finalizers
+  - emqxenterprises/finalizers
+  - emqxes/finalizers
+  - emqxplugins/finalizers
   - rebalances/finalizers
   verbs:
   - update
 - apiGroups:
   - apps.emqx.io
   resources:
+  - emqxbrokers/status
+  - emqxenterprises/status
+  - emqxes/status
+  - emqxplugins/status
   - rebalances/status
   verbs:
   - get
@@ -302,6 +154,17 @@ rules:
   - leases
   verbs:
   - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
   - get
   - list
   - update

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emqx/emqx-operator
 
-go 1.22
+go 1.24
 
 require (
 	emperror.dev/errors v0.8.1

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
-//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update
+//+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update


### PR DESCRIPTION
Fix https://github.com/emqx/emqx-operator/issues/1130
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated permissions for Kubernetes "events" resources to allow patch operations in addition to existing actions.
  - Simplified and consolidated RBAC role rules for better permission management.
  - Added support for new resource types in RBAC permissions, including rebalances and their subresources.
  - Updated Go module and Docker base image to version 1.24.
  - Incremented Helm chart and application version to 2.2.29-beta.2.
  - Updated CI workflows to use the latest Ubuntu runner environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->