### PR TITLE
chore: set default replicas to 1

### DIFF
--- a/.github/workflows/cts.yaml
+++ b/.github/workflows/cts.yaml
@@ -109,13 +109,14 @@ jobs:
           - "v1.30.0"
           - "v1.31.0"
           - "v1.32.0"
+          - "v1.33.0"
         emqx:
           # - [EmqxBroker, emqx, "config/samples/emqx/v1beta4/emqxbroker-slim.yaml"]
           # - [EmqxBroker, emqx, "config/samples/emqx/v1beta4/emqxbroker-full.yaml"]
           - [EmqxEnterprise, emqx-ee, "config/samples/emqx/v1beta4/emqxenterprise-slim.yaml"]
           - [EmqxEnterprise, emqx-ee, "config/samples/emqx/v1beta4/emqxenterprise-full.yaml"]
           - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-slim.yaml"]
-          - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-full.yaml"]
+          # - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-full.yaml"]
 
     steps:
       - if: matrix.kubernetes-env == 'k3s'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,28 +27,20 @@ jobs:
           - [EmqxEnterprise, emqx-ee, "config/samples/emqx/v1beta4/emqxenterprise-slim.yaml"]
           - [EmqxEnterprise, emqx-ee, "config/samples/emqx/v1beta4/emqxenterprise-full.yaml"]
 
-          - [EMQX, emqx, "config/samples/emqx/v2alpha1/emqx-slim.yaml"]
-          - [EMQX, emqx, "config/samples/emqx/v2alpha1/emqx-full.yaml"]
+          # - [EMQX, emqx, "config/samples/emqx/v2alpha1/emqx-slim.yaml"]
+          # - [EMQX, emqx, "config/samples/emqx/v2alpha1/emqx-full.yaml"]
 
           - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-slim.yaml"]
-          - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-full.yaml"]
+          # - [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-full.yaml"]
         single_namespace:
           - false
-          - true
         enable_webhook:
           - true
-        exclude:
-          - install: static
-            single_namespace: true
         include:
           - enable_webhook: false
             install: helm
             single_namespace: true
             emqx: [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-slim.yaml"]
-          - enable_webhook: false
-            install: helm
-            single_namespace: true
-            emqx: [EMQX, emqx, "config/samples/emqx/v2beta1/emqx-full.yaml"]
 
     steps:
       - run: minikube start

--- a/apis/apps/v2beta1/emqx_types.go
+++ b/apis/apps/v2beta1/emqx_types.go
@@ -84,7 +84,7 @@ type EMQXSpec struct {
 	UpdateStrategy UpdateStrategy `json:"updateStrategy,omitempty"`
 
 	// CoreTemplate is the object that describes the EMQX core node that will be created
-	//+kubebuilder:default={spec:{replicas:2}}
+	//+kubebuilder:default={spec:{replicas:1}}
 	CoreTemplate EMQXCoreTemplate `json:"coreTemplate,omitempty"`
 
 	// ReplicantTemplate is the object that describes the EMQX replicant node that will be created

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -6951,7 +6951,7 @@ spec:
               coreTemplate:
                 default:
                   spec:
-                    replicas: 2
+                    replicas: 1
                 properties:
                   metadata:
                     properties:

--- a/config/samples/emqx/v2beta1/emqx-full.yaml
+++ b/config/samples/emqx/v2beta1/emqx-full.yaml
@@ -21,7 +21,7 @@ spec:
         apps.emqx.io/managed-by: emqx-operator
         apps.emqx.io/db-role: core
     spec:
-      replicas: 2
+      replicas: 1
       volumeClaimTemplates:
         resources:
           requests:

--- a/deploy/charts/emqx-operator/Chart.yaml
+++ b/deploy/charts/emqx-operator/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.29
+version: 2.2.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.2.29
+appVersion: 2.2.30
 
 sources:
   - https://github.com/emqx/emqx-operator/tree/main/deploy/charts/emqx-operator

--- a/deploy/charts/emqx-operator/templates/crd.emqxes.apps.emqx.io.yaml
+++ b/deploy/charts/emqx-operator/templates/crd.emqxes.apps.emqx.io.yaml
@@ -6964,7 +6964,7 @@ spec:
                 coreTemplate:
                   default:
                     spec:
-                      replicas: 2
+                      replicas: 1
                   properties:
                     metadata:
                       properties:

--- a/docs/en_US/reference/v2beta1-reference.md
+++ b/docs/en_US/reference/v2beta1-reference.md
@@ -274,7 +274,7 @@ _Appears in:_
 | `clusterDomain` _string_ |  | cluster.local |  |
 | `revisionHistoryLimit` _integer_ | The number of old ReplicaSets, old StatefulSet and old PersistentVolumeClaim to retain to allow rollback.<br />This is a pointer to distinguish between explicit zero and not specified.<br />Defaults to 3. | 3 |  |
 | `updateStrategy` _[UpdateStrategy](#updatestrategy)_ | UpdateStrategy is the object that describes the EMQX blue-green update strategy | \{ evacuationStrategy:map[connEvictRate:1000 sessEvictRate:1000 waitTakeover:10] initialDelaySeconds:10 type:Recreate \} |  |
-| `coreTemplate` _[EMQXCoreTemplate](#emqxcoretemplate)_ | CoreTemplate is the object that describes the EMQX core node that will be created | \{ spec:map[replicas:2] \} |  |
+| `coreTemplate` _[EMQXCoreTemplate](#emqxcoretemplate)_ | CoreTemplate is the object that describes the EMQX core node that will be created | \{ spec:map[replicas:1] \} |  |
 | `replicantTemplate` _[EMQXReplicantTemplate](#emqxreplicanttemplate)_ | ReplicantTemplate is the object that describes the EMQX replicant node that will be created |  |  |
 | `dashboardServiceTemplate` _[ServiceTemplate](#servicetemplate)_ | DashboardServiceTemplate is the object that describes the EMQX dashboard service that will be created<br />This service always selector the EMQX core node |  |  |
 | `listenersServiceTemplate` _[ServiceTemplate](#servicetemplate)_ | ListenersServiceTemplate is the object that describes the EMQX listener service that will be created<br />If the EMQX replicant node exist, this service will selector the EMQX replicant node<br />Else this service will selector EMQX core node |  |  |

--- a/docs/zh_CN/reference/v2beta1-reference.md
+++ b/docs/zh_CN/reference/v2beta1-reference.md
@@ -274,7 +274,7 @@ _Appears in:_
 | `clusterDomain` _string_ |  | cluster.local |  |
 | `revisionHistoryLimit` _integer_ | The number of old ReplicaSets, old StatefulSet and old PersistentVolumeClaim to retain to allow rollback.<br />This is a pointer to distinguish between explicit zero and not specified.<br />Defaults to 3. | 3 |  |
 | `updateStrategy` _[UpdateStrategy](#updatestrategy)_ | UpdateStrategy is the object that describes the EMQX blue-green update strategy | \{ evacuationStrategy:map[connEvictRate:1000 sessEvictRate:1000 waitTakeover:10] initialDelaySeconds:10 type:Recreate \} |  |
-| `coreTemplate` _[EMQXCoreTemplate](#emqxcoretemplate)_ | CoreTemplate is the object that describes the EMQX core node that will be created | \{ spec:map[replicas:2] \} |  |
+| `coreTemplate` _[EMQXCoreTemplate](#emqxcoretemplate)_ | CoreTemplate is the object that describes the EMQX core node that will be created | \{ spec:map[replicas:1] \} |  |
 | `replicantTemplate` _[EMQXReplicantTemplate](#emqxreplicanttemplate)_ | ReplicantTemplate is the object that describes the EMQX replicant node that will be created |  |  |
 | `dashboardServiceTemplate` _[ServiceTemplate](#servicetemplate)_ | DashboardServiceTemplate is the object that describes the EMQX dashboard service that will be created<br />This service always selector the EMQX core node |  |  |
 | `listenersServiceTemplate` _[ServiceTemplate](#servicetemplate)_ | ListenersServiceTemplate is the object that describes the EMQX listener service that will be created<br />If the EMQX replicant node exist, this service will selector the EMQX replicant node<br />Else this service will selector EMQX core node |  |  |

--- a/e2e/v2beta1/e2e_rebalance_test.go
+++ b/e2e/v2beta1/e2e_rebalance_test.go
@@ -132,7 +132,7 @@ var _ = Describe("EMQX 5 Rebalance Test", Label("rebalance"), func() {
 			By("Creating EMQX CR", func() {
 				// create EMQX CR
 				instance.Spec.ReplicantTemplate = nil
-				instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(2))
+				instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(1))
 				Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 				// check EMQX CR if created successfully
@@ -176,7 +176,7 @@ var _ = Describe("EMQX 5 Rebalance Test", Label("rebalance"), func() {
 					HaveField("Status", corev1.ConditionTrue),
 				)),
 				HaveField("Conditions", ContainElements(
-					HaveField("Message", ContainSubstring("Only enterprise edition can be rebalanced"))),
+					HaveField("Message", ContainSubstring("Failed to start rebalance"))),
 				),
 			))
 		})
@@ -204,7 +204,7 @@ var _ = Describe("EMQX 5 Rebalance Test", Label("rebalance"), func() {
 			By("Creating EMQX CR", func() {
 				// create EMQX CR
 				instance.Spec.ReplicantTemplate = nil
-				instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(2))
+				instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(1))
 				Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
 				// check EMQX CR if created successfully

--- a/e2e/v2beta1/e2e_test.go
+++ b/e2e/v2beta1/e2e_test.go
@@ -41,6 +41,12 @@ var _ = Describe("E2E Test", Label("base"), Ordered, func() {
 		JustBeforeEach(func() {
 			instance.Spec.ReplicantTemplate = nil
 			instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(2))
+			instance.Spec.CoreTemplate.Spec.EMQXReplicantTemplateSpec.Env = []corev1.EnvVar{
+				{
+					Name:  "EMQX_LICENSE__KEY",
+					Value: "evaluation",
+				},
+			}
 		})
 
 		It("should create namespace and EMQX CR", func() {
@@ -339,9 +345,22 @@ var _ = Describe("E2E Test", Label("base"), Ordered, func() {
 					return err
 				}
 				instance.Spec = *emqx.Spec.DeepCopy()
+				instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(2))
+				instance.Spec.CoreTemplate.Spec.EMQXReplicantTemplateSpec.Env = []corev1.EnvVar{
+					{
+						Name:  "EMQX_LICENSE__KEY",
+						Value: "evaluation",
+					},
+				}
 				instance.Spec.ReplicantTemplate = &appsv2beta1.EMQXReplicantTemplate{
 					Spec: appsv2beta1.EMQXReplicantTemplateSpec{
 						Replicas: ptr.To(int32(2)),
+					},
+				}
+				instance.Spec.ReplicantTemplate.Spec.Env = []corev1.EnvVar{
+					{
+						Name:  "EMQX_LICENSE__KEY",
+						Value: "evaluation",
 					},
 				}
 				return k8sClient.Update(ctx, instance)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default number of EMQX core node replicas from 2 to 1 in configuration, documentation, and deployment templates.

- **Documentation**
  - Revised English and Chinese reference documents to reflect the new default replica count.

- **Chores**
  - Incremented Helm chart version.
  - Updated sample configuration and test workflows to align with the new default.
  - Adjusted end-to-end tests to set license key environment variables and explicitly specify replica counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->