### PR TITLE
docs: use emqx/emqx-enterprise:5.10.0 consistently in examples

### DIFF
--- a/docs/en_US/deployment/on-aws-eks.md
+++ b/docs/en_US/deployment/on-aws-eks.md
@@ -40,7 +40,12 @@ The following is the relevant configuration of EMQX custom resources. You can se
   metadata:
     name: emqx
   spec:
-    image: emqx/emqx-enterprise:5
+    image: emqx/emqx-enterprise:5.10
+    config:
+      data: |
+        license {
+          key = "..."
+        }
     coreTemplate:
       spec:
         ## EMQX custom resources do not support updating this field at runtime
@@ -79,8 +84,8 @@ The following is the relevant configuration of EMQX custom resources. You can se
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE              STATUS    AGE
-  emqx   emqx/emqx:latest   Running   18m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   18m
   ```
 
 + Obtain Dashboard External IP of EMQX cluster and access EMQX console

--- a/docs/en_US/deployment/on-azure-aks.md
+++ b/docs/en_US/deployment/on-azure-aks.md
@@ -28,7 +28,12 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx/emqx:latest"
+  image: "emqx/emqx-enterprise:5.10"
+  config:
+    data: |
+      license {
+        key = "..."
+      }
   coreTemplate:
     spec:
       volumeClaimTemplates:
@@ -53,8 +58,8 @@ Wait for the EMQX cluster to be ready. You can check the status of the EMQX clus
 
 ```shell
 $ kubectl get emqx
-NAME   IMAGE              STATUS    AGE
-emqx   emqx/emqx:latest   Running   118s
+NAME   IMAGE                         STATUS    AGE
+emqx   emqx/emqx-enterprise:5.10.0   Running   118s
 ```
 
 Get the External IP of the EMQX cluster and access the EMQX console.

--- a/docs/en_US/deployment/on-gcp-gke.md
+++ b/docs/en_US/deployment/on-gcp-gke.md
@@ -39,7 +39,12 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: "emqx/emqx:latest"
+  image: "emqx/emqx-enterprise:5.10"
+  config:
+    data: |
+      license {
+        key = "..."
+      }
   coreTemplate:
     spec:
       volumeClaimTemplates:
@@ -64,8 +69,8 @@ Wait for the EMQX cluster to be ready. You can check the status of the EMQX clus
 
 ```shell
 $ kubectl get emqx
-NAME   IMAGE              STATUS    AGE
-emqx   emqx/emqx:latest   Running   118s
+NAME   IMAGE                         STATUS    AGE
+emqx   emqx/emqx-enteprirse:5.10.0   Running   118s
 ```
 
 Get the External IP of the EMQX cluster and access the EMQX console.

--- a/docs/en_US/getting-started/getting-started.md
+++ b/docs/en_US/getting-started/getting-started.md
@@ -74,7 +74,12 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
    metadata:
       name: emqx-ee
    spec:
-      image: emqx/emqx-enterprise:5.8
+     image: emqx/emqx-enterprise:5.10
+     config:
+       data: |
+         license {
+           key = "..."
+         }
    ```
 
    For more details about the EMQX CRD, please check the [reference document](../reference/v2beta1-reference.md).
@@ -85,7 +90,7 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
    $ kubectl get emqx
 
    NAME      IMAGE                        STATUS    AGE
-   emqx-ee   emqx/emqx-enterprise:5.8.6   Running   2m55s
+   emqx-ee   emqx/emqx-enterprise:5.10.0   Running   2m55s
    ```
 
    Make sure the `STATUS` is `Running`, it maybe takes some time to wait for the EMQX cluster to be ready.
@@ -132,7 +137,7 @@ Alternatively, if you are interested in learning how to upgrade or uninstall EMQ
            emqxContainer:
              image:
                repository: emqx/emqx-ee
-               version: 4.4.17
+               version: 4.4.30
     ```
 
     For more details please check the [reference document](https://github.com/emqx/emqx-operator/blob/main/docs/en_US/reference/v1beta4-reference.md).

--- a/docs/en_US/getting-started/hello-emqx-operator.md
+++ b/docs/en_US/getting-started/hello-emqx-operator.md
@@ -92,10 +92,12 @@ kind: EMQX
 metadata:
   name: emqx-ee
 spec:
-  image: emqx/emqx-enterprise:5.8
+  image: emqx/emqx-enterprise:5.10
   config:
-    data:
-      log.console.level = debug
+    data: |
+      license {
+        key = "..."
+      }
   coreTemplate:
     spec:
       replicas: 2
@@ -104,7 +106,7 @@ spec:
       replicas: 3
 ```
 
-In the `emqx.yaml` file, you define the `image` field to specify the EMQX image to use. And also define the `config` field to specify the EMQX configuration, in this example, set the `log.console.level` to `debug`. You also define the `coreTemplate` and `replicantTemplate` to specify the number of replicas for the core and replicant nodes.
+In the `emqx.yaml` file, you define the `image` field to specify the EMQX image to use. And also define the `config` field to specify the EMQX configuration, in this example, set the `license.key` to license content. You also define the `coreTemplate` and `replicantTemplate` to specify the number of replicas for the core and replicant nodes.
 
 EMQX custom resource definition (CRD) also provides `dashboardServiceTemplate` and `listenersServiceTemplate` to configure the EMQX dashboard and listeners service. For
 more configuration options, you can refer to the [EMQX Operator documentation](https://docs.emqx.com/en/emqx-operator/latest/reference/v2beta1-reference.html).
@@ -180,7 +182,7 @@ You can check the EMQX cluster status by running the following command:
 
 ```bash
 $ pod_name=$(kubectl get pods -l apps.emqx.io/db-role=core,apps.emqx.io/instance=emqx-ee -o jsonpath='{.items[0].metadata.name}')
-$ kubectl exec -it $pod_name -- emqx_ctl cluster status
+$ kubectl exec -it $pod_name -- emqx ctl cluster status
 Cluster status: #{running_nodes =>
                       ['emqx@10.244.0.12','emqx@10.244.0.13',
                        'emqx@10.244.0.14',
@@ -221,7 +223,7 @@ $ kubectl port-forward svc/emqx-ee-listeners 1883:1883
 
 Now you can access the EMQX listeners by visiting `tcp://localhost:1883` in your MQTT client.
 
-For example, you can use the MQTT X CLI to connect to the EMQX cluster, you can refer to the [MQTT X CLI documentation](https://mqttx.app/cli) for more information.
+For example, you can use the MQTT X CLI to connect to the EMQX cluster, you can refer to the [MQTTX CLI documentation](https://mqttx.app/cli) for more information.
 
 ```bash
 $ mqttx conn -h localhost -p 1883

--- a/docs/en_US/index.md
+++ b/docs/en_US/index.md
@@ -35,7 +35,7 @@ The EMQX Operator includes, but is not limited to, the following features:
 | 5.0.6 (included) ～ 5.0.8 | 2.0.0, 2.0.1, 2.0.3                                |  [apps.emqx.io/v2alpha1](./reference/v2alpha1-reference.md)         |  EMQX     |
 | 5.0.8 (included) ～  5.0.14 | 2.0.2                                            |  [apps.emqx.io/v2alpha1](./reference/v2alpha1-reference.md)         |  EMQX     |
 | 5.0.14 (included)  ~ 5.0.23 | 2.1.0, 2.1.1                                                | [apps.emqx.io/v2alpha1](./reference/v2alpha1-reference.md)         | EMQX     |
-|      5.1.1 or higher       |    2.2.0                                        | [apps.emqx.io/v2beta1](./reference/v2beta1-reference.md) |      EMQX      |
+|      5.1.1 ~ 5.8.7       |    2.2.0                                        | [apps.emqx.io/v2beta1](./reference/v2beta1-reference.md) |      EMQX      |
 
 
 ## How to selector Kubernetes version

--- a/docs/en_US/tasks/configure-emqx-blueGreenUpdate.md
+++ b/docs/en_US/tasks/configure-emqx-blueGreenUpdate.md
@@ -111,9 +111,14 @@ Create `apps.emqx.io/v2beta1` EMQX and configure update strategy.
 apiVersion: apps.emqx.io/v2beta1
 kind: EMQX
 metadata:
-  name: emqx
+  name: emqx-ee
 spec:
-  image: emqx/emqx:latest
+  image: emqx/emqx-enterprise:5.10
+  config:
+    data: |
+      license {
+        key = "..."
+      }
   updateStrategy:
     evacuationStrategy:
       connEvictRate: 1000
@@ -170,7 +175,7 @@ spec:
       emqxContainer:
         image:
           repository: emqx/emqx-ee
-          version: 4.4.14
+          version: 4.4.30
 ```
 
 `initialDelaySeconds`: The waiting time before the start node is evacuated after all nodes are ready (unit: second).
@@ -201,7 +206,7 @@ emqx-ee   Running  8m33s
 :::
 ::::
 
-### Connect to EMQX cluster using MQTT X CLI.
+### Connect to EMQX cluster using MQTTX CLI.
 
 MQTT X CLI is an open-source MQTT 5.0 CLI Client that supports automatic reconnection. It is also a pure command-line mode MQTT X. It aims to help develop and debug MQTT services and applications faster without using a graphical interface. For documentation about MQTT X CLI, please refer to: [MQTTX CLI](https://mqttx.app/cli).
 

--- a/docs/en_US/tasks/configure-emqx-config.md
+++ b/docs/en_US/tasks/configure-emqx-config.md
@@ -18,13 +18,16 @@ The main configuration file of EMQX is `/etc/emqx.conf`. Starting from version 5
    metadata:
       name: emqx
    spec:
-      image: emqx/emqx:latest
+      image: emqx/emqx-enterprise:5.10
       imagePullPolicy: IfNotPresent
       config:
          data: |
             listeners.tcp.test {
                bind = "0.0.0.0:1884"
                max_connections = 1024000
+            }
+            license {
+              key = "..."
             }
       listenersServiceTemplate:
          spec:
@@ -40,8 +43,8 @@ The main configuration file of EMQX is `/etc/emqx.conf`. Starting from version 5
 
    ```bash
    $ kubectl get emqx emqx
-   NAME   IMAGE              STATUS    AGE
-   emqx   emqx/emqx:latest   Running   10m
+   NAME   IMAGE                         STATUS    AGE
+   emqx   emqx/emqx-enterprise:5.10.0   Running   10m
    ```
 
 + Obtain the Dashboard External IP of EMQX cluster and access EMQX console
@@ -61,7 +64,7 @@ The main configuration file of EMQX is `/etc/emqx.conf`. Starting from version 5
 + View EMQX cluster listener information
 
    ```bash
-   $ kubectl exec -it emqx-core-0 -c emqx -- emqx_ctl listeners
+   $ kubectl exec -it emqx-core-0 -c emqx -- emqx ctl listeners
    ```
 
    You can get a print similar to the following, which means that the listener named `test` configured by us has taken effect.

--- a/docs/en_US/tasks/configure-emqx-core-replicant.md
+++ b/docs/en_US/tasks/configure-emqx-core-replicant.md
@@ -33,7 +33,12 @@ There must be at least one Core node in the EMQX cluster. For the purpose of hig
   metadata:
     name: emqx
   spec:
-    image: emqx/emqx:latest
+    image: emqx/emqx-enterprise:5.10
+    config:
+      data: |
+        license {
+          key = "..."
+        }
     coreTemplate:
       spec:
         replicas: 2
@@ -59,8 +64,8 @@ There must be at least one Core node in the EMQX cluster. For the purpose of hig
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE              STATUS    AGE
-  emqx   emqx/emqx:latest   Running   10m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   10m
   ```
 
 + Obtain the Dashboard External IP of EMQX cluster and access EMQX console
@@ -85,23 +90,23 @@ There must be at least one Core node in the EMQX cluster. For the purpose of hig
     {
       "node": "emqx@emqx-core-0.emqx-headless.default.svc.cluster.local",
       "node_status": "running",
-      "otp_release": "24.3.4.2-2/12.3.2.2",
+      "otp_release": "27.2-3/15.2",
       "role": "core",
-      "version": "5.0.20"
+      "version": "5.10.0"
     },
     {
       "node": "emqx@emqx-core-1.emqx-headless.default.svc.cluster.local",
       "node_status": "running",
-      "otp_release": "24.3.4.2-2/12.3.2.2",
+      "otp_release": "27.2-3/15.2",
       "role": "core",
-      "version": "5.0.20"
+      "version": "5.10.0"
     },
      {
       "node": "emqx@emqx-core-2.emqx-headless.default.svc.cluster.local",
       "node_status": "running",
-      "otp_release": "24.3.4.2-2/12.3.2.2",
+      "otp_release": "27.2-3/15.2",
       "role": "core",
-      "version": "5.0.20"
+      "version": "5.10.0"
     }
   ]
   ```
@@ -113,23 +118,23 @@ There must be at least one Core node in the EMQX cluster. For the purpose of hig
     {
       "node": "emqx@10.244.4.56",
       "node_status": "running",
-      "otp_release": "24.3.4.2-2/12.3.2.2",
+      "otp_release": "27.2-3/15.2",
       "role": "replicant",
-      "version": "5.0.20"
+      "version": "5.10.0"
     },
     {
       "node": "emqx@10.244.4.57",
       "node_status": "running",
-      "otp_release": "24.3.4.2-2/12.3.2.2",
+      "otp_release": "27.2-3/15.2",
       "role": "replicant",
-      "version": "5.0.20"
+      "version": "5.10.0"
     },
     {
       "node": "emqx@10.244.4.58",
       "node_status": "running",
-      "otp_release": "24.3.4.2-2/12.3.2.2",
+      "otp_release": "27.2-3/15.2",
       "role": "replicant",
-      "version": "5.0.20"
+      "version": "5.10.0"
     }
   ]
   ```

--- a/docs/en_US/tasks/configure-emqx-license.md
+++ b/docs/en_US/tasks/configure-emqx-license.md
@@ -33,7 +33,7 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
         license {
           key = "..."
         }
-    image: emqx/emqx-enterprise:5.6
+    image: emqx/emqx-enterprise:5.10
     dashboardServiceTemplate:
       spec:
         type: LoadBalancer
@@ -45,8 +45,8 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
 
   ```bash
   $ kubectl get emqx emqx-ee
-  NAME   IMAGE                        STATUS    AGE
-  emqx   emqx/emqx-enterprise:5.1.0   Running   10m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   10m
   ```
 
 + Obtain the Dashboard External IP of EMQX cluster and access EMQX console
@@ -93,7 +93,7 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
         emqxContainer:
           image:
             repository: emqx/emqx-ee
-            version: 4.4.14
+            version: 4.4.30
     serviceTemplate:
       spec:
         type: LoadBalancer

--- a/docs/en_US/tasks/configure-emqx-log-level.md
+++ b/docs/en_US/tasks/configure-emqx-log-level.md
@@ -23,10 +23,13 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
   metadata:
     name: emqx
   spec:
-    image: emqx5.0
+    image: emqx/emqx-enterprise:5.10
     config:
       data: |
         log.console.level = debug
+        license {
+          key = "..."
+        }
     dashboardServiceTemplate:
       spec:
         type: LoadBalancer
@@ -41,8 +44,8 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
 
   ```bash
   $ kubectl get emqx
-  NAME   IMAGE              STATUS    AGE
-  emqx   emqx/emqx:latest   Running   10m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   10m
   ```
 
 + EMQX Operator will create two EMQX Service resources, one is emqx-dashboard and the other is emqx-listeners, corresponding to EMQX console and EMQX listening port respectively.
@@ -73,7 +76,7 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
         emqxContainer:
           image:
             repository: emqx/emqx-ee
-            version: 4.4.14
+            version: 4.4.30
           emqxConfig:
             log.level: debug
     serviceTemplate:

--- a/docs/en_US/tasks/configure-emqx-persistence.md
+++ b/docs/en_US/tasks/configure-emqx-persistence.md
@@ -24,7 +24,12 @@ When the user configures the `.spec.coreTemplate.spec.volumeClaimTemplates` fiel
   metadata:
     name: emqx
   spec:
-    image: emqx/emqx:latest
+    image: emqx/emqx-enterprise:5.10
+    config:
+      data: |
+        license {
+          key = "..."
+        }
     coreTemplate:
       spec:
         volumeClaimTemplates:
@@ -49,8 +54,8 @@ When the user configures the `.spec.coreTemplate.spec.volumeClaimTemplates` fiel
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE              STATUS    AGE
-  emqx   emqx/emqx:latest   Running   10m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   10m
   ```
 
 + Obtain the Dashboard External IP of the EMQX cluster and access the EMQX console
@@ -95,7 +100,7 @@ When the user configures the `.spec.persistent` field, EMQX Operator will mount 
         emqxContainer:
           image:
             repository: emqx/emqx-ee
-            version: 4.4.14
+            version: 4.4.30
     serviceTemplate:
       spec:
         type: LoadBalancer

--- a/docs/en_US/tasks/configure-emqx-prometheus.md
+++ b/docs/en_US/tasks/configure-emqx-prometheus.md
@@ -23,7 +23,12 @@ kind: EMQX
 metadata:
   name: emqx
 spec:
-  image: emqx/emqx:latest
+  image: emqx/emqx-enterprise:5.10
+  config:
+    data: |
+      license {
+        key = "..."
+      }
 ```
 
 Save the above content as `emqx.yaml` and execute the following command to deploy the EMQX cluster:
@@ -39,8 +44,8 @@ Check the status of the EMQX cluster and make sure that `STATUS` is `Running`, w
 ```bash
 $ kubectl get emqx emqx
 
-NAME   IMAGE              STATUS    AGE
-emqx   emqx/emqx:latest   Running   10m
+NAME   IMAGE                         STATUS    AGE
+emqx   emqx/emqx-enterprise:5.10.0   Running   10m
 ```
 
 :::
@@ -59,7 +64,7 @@ spec:
       emqxContainer:
         image:
           repository: emqx/emqx-ee
-          version: 4.4.16
+          version: 4.4.30
         ports:
           # prometheus monitor requires the pod must name the target port
           - name: dashboard

--- a/docs/en_US/tasks/configure-emqx-restricted-k8s.md
+++ b/docs/en_US/tasks/configure-emqx-restricted-k8s.md
@@ -19,7 +19,7 @@ Here we are assuming k8s cluster does not have access to the internet, and the u
 ```bash
 export CERT_MANAGER_VERSION='v1.16.2'
 export EMQX_OPERATOR_VERSION='2.2.26'
-export EMQX_VERSION='5.8.4'
+export EMQX_VERSION='5.10.0'
 export REGISTRY='my.private.registry'
 
 CERT_MANAGER_IMAGES=(
@@ -118,12 +118,17 @@ kubectl -n emqx wait --for=condition=Ready pods -l "control-plane=controller-man
     namespace: emqx
   spec:
     image: ${REGISTRY}/emqx/emqx-enterprise:${EMQX_VERSION}
+    config:
+      data: |
+        license {
+          key = "..."
+        }
   ```
 
 + Wait for the EMQX cluster to be ready, you can check the status of EMQX cluster through `kubectl get` command, please make sure `STATUS` is `Running`, this may take some time
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE                                            STATUS    AGE
-  emqx   my.private.registry/emqx/emqx-enterprise:5.8.4   Running   10m
+  NAME   IMAGE                                             STATUS    AGE
+  emqx   my.private.registry/emqx/emqx-enterprise:5.10.0   Running   10m
   ```

--- a/docs/en_US/tasks/configure-emqx-service.md
+++ b/docs/en_US/tasks/configure-emqx-service.md
@@ -21,7 +21,12 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
   metadata:
     name: emqx
   spec:
-    image: emqx/emqx:latest
+    image: emqx/emqx-enterprise:5.10
+    config:
+      data: |
+        license {
+          key = "..."
+        }
     listenersServiceTemplate:
       spec:
         type: LoadBalancer
@@ -38,8 +43,8 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
 
   ```bash
   $ kubectl get emqx emqx
-  NAME   IMAGE              STATUS    AGE
-  emqx   emqx/emqx:latest   Running   10m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   10m
   ```
 + Obtain the Dashboard External IP of the EMQX cluster and access the EMQX console
 
@@ -71,7 +76,7 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
         emqxContainer:
           image:
             repository: emqx/emqx-ee
-            version: 4.4.14
+            version: 4.4.30
     serviceTemplate:
       spec:
         type: LoadBalancer
@@ -99,7 +104,7 @@ The following is the relevant configuration of EMQX Custom Resource. You can cho
 :::
 ::::
 
-## Connect To EMQX Cluster By MQTT X CLI
+## Connect To EMQX Cluster By MQTTX CLI
 
 + Obtain the External IP of the EMQX cluster
 

--- a/docs/en_US/tasks/configure-emqx-tls.md
+++ b/docs/en_US/tasks/configure-emqx-tls.md
@@ -52,7 +52,7 @@ There are many types of Volumes. For the description of Volumes, please refer to
   metadata:
     name: emqx
   spec:
-    image: emqx/emqx:latest
+    image: emqx/emqx-enterprise:5.10
     config:
       data: |
         listeners.ssl.default {
@@ -64,6 +64,9 @@ There are many types of Volumes. For the description of Volumes, please refer to
             gc_after_handshake = true
             handshake_timeout = 5s
           }
+        }
+        license {
+          key = "..."
         }
     coreTemplate:
       spec:
@@ -102,8 +105,8 @@ There are many types of Volumes. For the description of Volumes, please refer to
   ```bash
   $ kubectl get emqx
 
-  NAME   IMAGE              STATUS    AGE
-  emqx   emqx/emqx:latest   Running   10m
+  NAME   IMAGE                         STATUS    AGE
+  emqx   emqx/emqx-enterprise:5.10.0   Running   10m
   ```
 
 + Obtain the External IP of EMQX cluster and access EMQX console
@@ -138,7 +141,7 @@ There are many types of Volumes. For the description of Volumes, please refer to
         emqxContainer:
           image:
             repository: emqx/emqx-ee
-            version: 4.4.14
+            version: 4.4.30
           emqxConfig:
             listener.ssl.external.cacertfile: /mounted/cert/ca.crt
             listener.ssl.external.certfile: /mounted/cert/tls.crt
@@ -187,9 +190,9 @@ There are many types of Volumes. For the description of Volumes, please refer to
 :::
 ::::
 
-## Verify TLS Connection Using MQTT X CLI
+## Verify TLS Connection Using MQTTX CLI
 
-[MQTT X CLI](https://mqttx.app/cli) is an open source MQTT 5.0 command line client tool, designed to help developers to more Quickly develop and debug MQTT services and applications.
+[MQTTX CLI](https://mqttx.app/cli) is an open source MQTT 5.0 command line client tool, designed to help developers to more Quickly develop and debug MQTT services and applications.
 
 + Obtain the External IP of EMQX cluster
 


### PR DESCRIPTION
- ensure license key is set in examples for emqx/emqx-enterprise:5.10
- use emqx/emqx-ee:4.4.30 consistently in examples for v4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and configuration examples to use EMQX Enterprise version 5.10 and corresponding image tags.
  * Added license key configuration blocks to relevant YAML examples.
  * Updated example command outputs to reflect new image versions and names.
  * Corrected references to MQTTX CLI and updated related links.
  * Made minor textual and formatting improvements across multiple documentation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->