### PR TITLE
feat(config): map `.Spec.Config` into `base.hocon` config files

### DIFF
--- a/api/v2beta1/const.go
+++ b/api/v2beta1/const.go
@@ -22,8 +22,6 @@ const DefaultContainerName string = "emqx"
 
 const DefaultBootstrapAPIKey string = "emqx-operator-controller"
 
-const BaseConfigFile string = "base.hocon"
-
 const (
 	// labels
 	LabelsInstanceKey        string = "apps.emqx.io/instance"   // my-emqx

--- a/api/v2beta1/const.go
+++ b/api/v2beta1/const.go
@@ -22,6 +22,8 @@ const DefaultContainerName string = "emqx"
 
 const DefaultBootstrapAPIKey string = "emqx-operator-controller"
 
+const BaseConfigFile string = "base.hocon"
+
 const (
 	// labels
 	LabelsInstanceKey        string = "apps.emqx.io/instance"   // my-emqx

--- a/api/v2beta1/emqx_types_spec.go
+++ b/api/v2beta1/emqx_types_spec.go
@@ -313,3 +313,7 @@ type ServiceTemplate struct {
 	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	Spec corev1.ServiceSpec `json:"spec,omitempty"`
 }
+
+func (s *ServiceTemplate) IsEnabled() bool {
+	return s.Enabled != nil && *s.Enabled
+}

--- a/api/v2beta1/emqx_types_spec.go
+++ b/api/v2beta1/emqx_types_spec.go
@@ -101,7 +101,9 @@ type Config struct {
 	// +kubebuilder:validation:Enum=Merge;Replace
 	// +kubebuilder:default=Merge
 	Mode string `json:"mode,omitempty"`
-	// EMQX config, HOCON format, like etc/emqx.conf file
+	// Bootstrap EMQX config, in HOCON format.
+	// This configuration will be supplied as `base.hocon` to the container, see respective
+	// [documentation](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#base-configuration-file).
 	Data string `json:"data,omitempty"`
 }
 

--- a/api/v2beta1/names.go
+++ b/api/v2beta1/names.go
@@ -29,12 +29,20 @@ func (instance *EMQX) NamespacedName(name string) types.NamespacedName {
 	}
 }
 
+func (instance *EMQX) CoreName() string {
+	return fmt.Sprintf("%s-core", instance.Name)
+}
+
 func (instance *EMQX) CoreNamespacedName() types.NamespacedName {
-	return instance.NamespacedName(fmt.Sprintf("%s-core", instance.Name))
+	return instance.NamespacedName(instance.CoreName())
+}
+
+func (instance *EMQX) ReplicantName() string {
+	return fmt.Sprintf("%s-replicant", instance.Name)
 }
 
 func (instance *EMQX) ReplicantNamespacedName() types.NamespacedName {
-	return instance.NamespacedName(fmt.Sprintf("%s-replicant", instance.Name))
+	return instance.NamespacedName(instance.ReplicantName())
 }
 
 func (instance *EMQX) HeadlessServiceNamespacedName() types.NamespacedName {

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -98,7 +98,10 @@ spec:
                 description: EMQX config
                 properties:
                   data:
-                    description: EMQX config, HOCON format, like etc/emqx.conf file
+                    description: |-
+                      Bootstrap EMQX config, in HOCON format.
+                      This configuration will be supplied as `base.hocon` to the container, see respective
+                      [documentation](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#base-configuration-file).
                     type: string
                   mode:
                     default: Merge

--- a/internal/controller/add_bootstrap_resource.go
+++ b/internal/controller/add_bootstrap_resource.go
@@ -6,12 +6,12 @@ import (
 	emperror "emperror.dev/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
 	config "github.com/emqx/emqx-operator/internal/controller/config"
+	resources "github.com/emqx/emqx-operator/internal/controller/resources"
 	"github.com/sethvargo/go-password/password"
 )
 
@@ -82,20 +82,7 @@ func (a *addBootstrap) readSecret(ctx context.Context, instance *appsv2beta1.EMQ
 func generateBootstrapAPIKeySecret(instance *appsv2beta1.EMQX, bootstrapAPIKeys string) *corev1.Secret {
 	defPassword, _ := password.Generate(64, 10, 0, true, true)
 	bootstrapAPIKeys += appsv2beta1.DefaultBootstrapAPIKey + ":" + defPassword
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: instance.Namespace,
-			Name:      instance.BootstrapAPIKeyNamespacedName().Name,
-			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), instance.Labels),
-		},
-		StringData: map[string]string{
-			"bootstrap_api_key": bootstrapAPIKeys,
-		},
-	}
+	return resources.BootstrapAPIKey(instance).Secret(bootstrapAPIKeys)
 }
 
 func generateNodeCookieSecret(instance *appsv2beta1.EMQX, conf *config.EMQX) *corev1.Secret {
@@ -103,18 +90,5 @@ func generateNodeCookieSecret(instance *appsv2beta1.EMQX, conf *config.EMQX) *co
 	if cookie == "" {
 		cookie, _ = password.Generate(64, 10, 0, true, true)
 	}
-	return &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: instance.Namespace,
-			Name:      instance.NodeCookieNamespacedName().Name,
-			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), instance.Labels),
-		},
-		StringData: map[string]string{
-			"node_cookie": cookie,
-		},
-	}
+	return resources.Cookie(instance).Secret(cookie)
 }

--- a/internal/controller/add_bootstrap_resource.go
+++ b/internal/controller/add_bootstrap_resource.go
@@ -98,7 +98,7 @@ func generateBootstrapAPIKeySecret(instance *appsv2beta1.EMQX, bootstrapAPIKeys 
 	}
 }
 
-func generateNodeCookieSecret(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Secret {
+func generateNodeCookieSecret(instance *appsv2beta1.EMQX, conf *config.EMQX) *corev1.Secret {
 	cookie := conf.GetNodeCookie()
 	if cookie == "" {
 		cookie, _ = password.Generate(64, 10, 0, true, true)

--- a/internal/controller/add_bootstrap_resource_test.go
+++ b/internal/controller/add_bootstrap_resource_test.go
@@ -23,7 +23,7 @@ func TestGenerateNodeCookieSecret(t *testing.T) {
 	}
 
 	t.Run("generate node cookie secret", func(t *testing.T) {
-		conf, _ := config.EMQXConf(instance.Spec.Config.Data)
+		conf, _ := config.EMQXConfig(instance.Spec.Config.Data)
 		got := generateNodeCookieSecret(instance, conf)
 		assert.Equal(t, "emqx-node-cookie", got.Name)
 		_, ok := got.StringData["node_cookie"]
@@ -32,7 +32,7 @@ func TestGenerateNodeCookieSecret(t *testing.T) {
 
 	t.Run("generate node cookie when already set node cookie", func(t *testing.T) {
 		instance.Spec.Config.Data = "node.cookie = fake"
-		conf, _ := config.EMQXConf(instance.Spec.Config.Data)
+		conf, _ := config.EMQXConfig(instance.Spec.Config.Data)
 		got := generateNodeCookieSecret(instance, conf)
 		assert.Equal(t, "emqx-node-cookie", got.Name)
 		_, ok := got.StringData["node_cookie"]

--- a/internal/controller/add_core_set.go
+++ b/internal/controller/add_core_set.go
@@ -275,8 +275,8 @@ func generateStatefulSet(instance *appsv2beta1.EMQX) *appsv1.StatefulSet {
 								},
 								{
 									Name:      "bootstrap-config",
-									MountPath: "/opt/emqx/etc/emqx.conf",
-									SubPath:   "emqx.conf",
+									MountPath: "/opt/emqx/etc/" + appsv2beta1.BaseConfigFile,
+									SubPath:   appsv2beta1.BaseConfigFile,
 									ReadOnly:  true,
 								},
 								{

--- a/internal/controller/add_core_set.go
+++ b/internal/controller/add_core_set.go
@@ -3,12 +3,13 @@ package controller
 import (
 	"fmt"
 	"reflect"
-	"strconv"
+	"slices"
 
 	emperror "emperror.dev/errors"
 	"github.com/cisco-open/k8s-objectmatcher/patch"
 	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
 	config "github.com/emqx/emqx-operator/internal/controller/config"
+	resources "github.com/emqx/emqx-operator/internal/controller/resources"
 	util "github.com/emqx/emqx-operator/internal/controller/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,7 +27,7 @@ type addCoreSet struct {
 }
 
 func (a *addCoreSet) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) subResult {
-	sts := getNewStatefulSet(instance, r.conf)
+	sts := newStatefulSet(instance, r.conf)
 	stsHash := sts.Labels[appsv2beta1.LabelsPodTemplateHashKey]
 
 	needCreate := false
@@ -116,31 +117,18 @@ func (a *addCoreSet) updateEMQXStatus(r *reconcileRound, instance *appsv2beta1.E
 	return a.Client.Status().Update(r.ctx, instance)
 }
 
-func getNewStatefulSet(instance *appsv2beta1.EMQX, conf *config.Conf) *appsv1.StatefulSet {
-	svcPorts := conf.GetDashboardServicePort()
-	preSts := generateStatefulSet(instance)
-	podTemplateSpecHash := computeHash(preSts.Spec.Template.DeepCopy(), instance.Status.CoreNodesStatus.CollisionCount)
-	preSts.Name = preSts.Name + "-" + podTemplateSpecHash
-	preSts.Labels = appsv2beta1.CloneAndAddLabel(preSts.Labels, appsv2beta1.LabelsPodTemplateHashKey, podTemplateSpecHash)
-	preSts.Spec.Selector = appsv2beta1.CloneSelectorAndAddLabel(preSts.Spec.Selector, appsv2beta1.LabelsPodTemplateHashKey, podTemplateSpecHash)
-	preSts.Spec.Template.Labels = appsv2beta1.CloneAndAddLabel(preSts.Spec.Template.Labels, appsv2beta1.LabelsPodTemplateHashKey, podTemplateSpecHash)
-	preSts.Spec.Template.Spec.Containers[0].Ports = util.MergeContainerPorts(
-		preSts.Spec.Template.Spec.Containers[0].Ports,
-		util.MapServicePortsToContainerPorts(svcPorts),
+func newStatefulSet(instance *appsv2beta1.EMQX, conf *config.EMQX) *appsv1.StatefulSet {
+	sts := generateStatefulSet(instance)
+	podTemplateSpecHash := computeHash(sts.Spec.Template.DeepCopy(), instance.Status.CoreNodesStatus.CollisionCount)
+	sts.Name = sts.Name + "-" + podTemplateSpecHash
+	sts.Labels = appsv2beta1.CloneAndAddLabel(sts.Labels, appsv2beta1.LabelsPodTemplateHashKey, podTemplateSpecHash)
+	sts.Spec.Selector = appsv2beta1.CloneSelectorAndAddLabel(sts.Spec.Selector, appsv2beta1.LabelsPodTemplateHashKey, podTemplateSpecHash)
+	sts.Spec.Template.Labels = appsv2beta1.CloneAndAddLabel(sts.Spec.Template.Labels, appsv2beta1.LabelsPodTemplateHashKey, podTemplateSpecHash)
+	sts.Spec.Template.Spec.Containers[0].Ports = util.MergeContainerPorts(
+		sts.Spec.Template.Spec.Containers[0].Ports,
+		util.MapServicePortsToContainerPorts(conf.GetDashboardServicePorts()),
 	)
-	for _, p := range preSts.Spec.Template.Spec.Containers[0].Ports {
-		if p.Name == "dashboard" {
-			preSts.Spec.Template.Spec.Containers[0].Env = append([]corev1.EnvVar{
-				{Name: "EMQX_DASHBOARD__LISTENERS__HTTP__BIND", Value: strconv.Itoa(int(p.ContainerPort))},
-			}, preSts.Spec.Template.Spec.Containers[0].Env...)
-		}
-		if p.Name == "dashboard-https" {
-			preSts.Spec.Template.Spec.Containers[0].Env = append([]corev1.EnvVar{
-				{Name: "EMQX_DASHBOARD__LISTENERS__HTTPS__BIND", Value: strconv.Itoa(int(p.ContainerPort))},
-			}, preSts.Spec.Template.Spec.Containers[0].Env...)
-		}
-	}
-	return preSts
+	return sts
 }
 
 func generateStatefulSet(instance *appsv2beta1.EMQX) *appsv1.StatefulSet {
@@ -163,6 +151,10 @@ func generateStatefulSet(instance *appsv2beta1.EMQX) *appsv1.StatefulSet {
 			Command: []string{"/bin/sh", "-c", "emqx ctl cluster leave"},
 		},
 	}
+
+	cookie := resources.Cookie(instance)
+	bootstrapAPIKeys := resources.BootstrapAPIKey(instance)
+	config := resources.EMQXConfig(instance)
 
 	sts := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
@@ -243,21 +235,8 @@ func generateStatefulSet(instance *appsv2beta1.EMQX) *appsv1.StatefulSet {
 									Name:  "EMQX_NODE__ROLE",
 									Value: "core",
 								},
-								{
-									Name: "EMQX_NODE__COOKIE",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: instance.NodeCookieNamespacedName().Name,
-											},
-											Key: "node_cookie",
-										},
-									},
-								},
-								{
-									Name:  "EMQX_API_KEY__BOOTSTRAP_FILE",
-									Value: `"/opt/emqx/data/bootstrap_api_key"`,
-								},
+								cookie.EnvVar(),
+								bootstrapAPIKeys.EnvVar(),
 							}, instance.Spec.CoreTemplate.Spec.Env...),
 							EnvFrom:         instance.Spec.CoreTemplate.Spec.EnvFrom,
 							Resources:       instance.Spec.CoreTemplate.Spec.Resources,
@@ -266,51 +245,28 @@ func generateStatefulSet(instance *appsv2beta1.EMQX) *appsv1.StatefulSet {
 							ReadinessProbe:  instance.Spec.CoreTemplate.Spec.ReadinessProbe,
 							StartupProbe:    instance.Spec.CoreTemplate.Spec.StartupProbe,
 							Lifecycle:       lifecycle,
-							VolumeMounts: append([]corev1.VolumeMount{
-								{
-									Name:      "bootstrap-api-key",
-									MountPath: "/opt/emqx/data/bootstrap_api_key",
-									SubPath:   "bootstrap_api_key",
-									ReadOnly:  true,
+							VolumeMounts: slices.Concat(
+								[]corev1.VolumeMount{
+									{
+										Name:      instance.CoreName() + "-log",
+										MountPath: "/opt/emqx/log",
+									},
+									{
+										Name:      instance.CoreName() + "-data",
+										MountPath: "/opt/emqx/data",
+									},
+									bootstrapAPIKeys.VolumeMount(),
 								},
-								{
-									Name:      "bootstrap-config",
-									MountPath: "/opt/emqx/etc/" + appsv2beta1.BaseConfigFile,
-									SubPath:   appsv2beta1.BaseConfigFile,
-									ReadOnly:  true,
-								},
-								{
-									Name:      instance.CoreNamespacedName().Name + "-log",
-									MountPath: "/opt/emqx/log",
-								},
-								{
-									Name:      instance.CoreNamespacedName().Name + "-data",
-									MountPath: "/opt/emqx/data",
-								},
-							}, instance.Spec.CoreTemplate.Spec.ExtraVolumeMounts...),
+								config.VolumeMounts(),
+								instance.Spec.CoreTemplate.Spec.ExtraVolumeMounts,
+							),
 						},
 					}, instance.Spec.CoreTemplate.Spec.ExtraContainers...),
 					Volumes: append([]corev1.Volume{
+						config.Volume(),
+						bootstrapAPIKeys.Volume(),
 						{
-							Name: "bootstrap-api-key",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: instance.BootstrapAPIKeyNamespacedName().Name,
-								},
-							},
-						},
-						{
-							Name: "bootstrap-config",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: instance.ConfigsNamespacedName().Name,
-									},
-								},
-							},
-						},
-						{
-							Name: instance.CoreNamespacedName().Name + "-log",
+							Name: instance.CoreName() + "-log",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},

--- a/internal/controller/add_core_set_test.go
+++ b/internal/controller/add_core_set_test.go
@@ -44,7 +44,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 
 	t.Run("check metadata", func(t *testing.T) {
 		emqx := instance.DeepCopy()
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewStatefulSet(emqx, conf)
 
 		assert.Equal(t, emqx.Spec.CoreTemplate.Annotations, got.Annotations)
@@ -58,7 +58,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 
 	t.Run("check selector and pod metadata", func(t *testing.T) {
 		emqx := instance.DeepCopy()
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewStatefulSet(emqx, conf)
 		assert.Equal(t, emqx.Spec.CoreTemplate.ObjectMeta.Annotations, got.Spec.Template.Annotations)
 		assert.EqualValues(t, map[string]string{
@@ -81,7 +81,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 	t.Run("check http port", func(t *testing.T) {
 		emqx := instance.DeepCopy()
 		emqx.Spec.Config.Data = "dashboard.listeners.http.bind = 18083"
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewStatefulSet(emqx, conf)
 
 		assert.Contains(t, got.Spec.Template.Spec.Containers[0].Ports,
@@ -106,7 +106,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		dashboard.listeners.http.bind = 0
 		dashboard.listeners.https.bind = 18084
 		`
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewStatefulSet(emqx, conf)
 
 		assert.Contains(t, got.Spec.Template.Spec.Containers[0].Ports,
@@ -131,7 +131,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		dashboard.listeners.http.bind = 18083
 		dashboard.listeners.https.bind = 18084
 		`
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewStatefulSet(emqx, conf)
 
 		assert.Contains(t, got.Spec.Template.Spec.Containers[0].Ports,

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -191,7 +191,7 @@ func generateReplicaSet(instance *appsv2beta1.EMQX) *appsv1.ReplicaSet {
 					SecurityContext:           instance.Spec.ReplicantTemplate.Spec.PodSecurityContext,
 					Affinity:                  instance.Spec.ReplicantTemplate.Spec.Affinity,
 					Tolerations:               instance.Spec.ReplicantTemplate.Spec.Tolerations,
-					TopologySpreadConstraints: instance.Spec.CoreTemplate.Spec.TopologySpreadConstraints,
+					TopologySpreadConstraints: instance.Spec.ReplicantTemplate.Spec.TopologySpreadConstraints,
 					NodeName:                  instance.Spec.ReplicantTemplate.Spec.NodeName,
 					NodeSelector:              instance.Spec.ReplicantTemplate.Spec.NodeSelector,
 					InitContainers:            instance.Spec.ReplicantTemplate.Spec.InitContainers,

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -273,8 +273,8 @@ func generateReplicaSet(instance *appsv2beta1.EMQX) *appsv1.ReplicaSet {
 								},
 								{
 									Name:      "bootstrap-config",
-									MountPath: "/opt/emqx/etc/emqx.conf",
-									SubPath:   "emqx.conf",
+									MountPath: "/opt/emqx/etc/" + appsv2beta1.BaseConfigFile,
+									SubPath:   appsv2beta1.BaseConfigFile,
 									ReadOnly:  true,
 								},
 								{

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -82,8 +82,8 @@ func (a *addReplicantSet) reconcile(r *reconcileRound, instance *appsv2beta1.EMQ
 			}
 			return subResult{err: emperror.Wrap(err, "failed to create replicaSet")}
 		}
-		_ = a.updateEMQXStatus(r, instance, "CreateReplicaSet", rsHash)
-		return subResult{}
+		updateResult := a.updateEMQXStatus(r, instance, "CreateReplicaSet", rsHash)
+		return subResult{err: updateResult}
 	}
 
 	rs.ObjectMeta = updateReplicantSet.ObjectMeta
@@ -109,7 +109,8 @@ func (a *addReplicantSet) reconcile(r *reconcileRound, instance *appsv2beta1.EMQ
 		}); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update replicaSet")}
 		}
-		_ = a.updateEMQXStatus(r, instance, "UpdateReplicaSet", rsHash)
+		updateResult := a.updateEMQXStatus(r, instance, "UpdateReplicaSet", rsHash)
+		return subResult{err: updateResult}
 	}
 	return subResult{}
 }

--- a/internal/controller/add_replicant_set_test.go
+++ b/internal/controller/add_replicant_set_test.go
@@ -47,7 +47,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 
 	t.Run("check metadata", func(t *testing.T) {
 		emqx := instance.DeepCopy()
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewReplicaSet(emqx, conf)
 
 		assert.Equal(t, emqx.Spec.ReplicantTemplate.Annotations, got.Annotations)
@@ -61,7 +61,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 
 	t.Run("check selector and pod metadata", func(t *testing.T) {
 		emqx := instance.DeepCopy()
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewReplicaSet(emqx, conf)
 
 		assert.Equal(t, emqx.Spec.ReplicantTemplate.ObjectMeta.Annotations, got.Spec.Template.Annotations)
@@ -85,7 +85,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 	t.Run("check http port", func(t *testing.T) {
 		emqx := instance.DeepCopy()
 		emqx.Spec.Config.Data = "dashboard.listeners.http.bind = 18083"
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewReplicaSet(emqx, conf)
 
 		assert.Contains(t, got.Spec.Template.Spec.Containers[0].Ports,
@@ -110,7 +110,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		dashboard.listeners.http.bind = 0
 		dashboard.listeners.https.bind = 18084
 		`
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewReplicaSet(emqx, conf)
 
 		assert.Contains(t, got.Spec.Template.Spec.Containers[0].Ports,
@@ -135,7 +135,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		dashboard.listeners.http.bind = 18083
 		dashboard.listeners.https.bind = 18084
 		`
-		conf, _ := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+		conf, _ := config.EMQXConf(emqx.Spec.Config.Data)
 		got := getNewReplicaSet(emqx, conf)
 
 		assert.Contains(t, got.Spec.Template.Spec.Containers[0].Ports,

--- a/internal/controller/add_service.go
+++ b/internal/controller/add_service.go
@@ -51,13 +51,14 @@ func (a *addService) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 }
 
 func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Service {
-	svc := &corev1.Service{}
+	meta := &metav1.ObjectMeta{}
+	spec := &corev1.ServiceSpec{}
 	if instance.Spec.DashboardServiceTemplate != nil {
 		if !instance.Spec.DashboardServiceTemplate.IsEnabled() {
 			return nil
 		}
-		svc.ObjectMeta = *instance.Spec.DashboardServiceTemplate.ObjectMeta.DeepCopy()
-		svc.Spec = *instance.Spec.DashboardServiceTemplate.Spec.DeepCopy()
+		meta = instance.Spec.DashboardServiceTemplate.ObjectMeta.DeepCopy()
+		spec = instance.Spec.DashboardServiceTemplate.Spec.DeepCopy()
 	}
 
 	ports := conf.GetDashboardServicePort()
@@ -65,8 +66,8 @@ func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *co
 		return nil
 	}
 
-	svc.Spec.Ports = util.MergeServicePorts(svc.Spec.Ports, ports)
-	svc.Spec.Selector = appsv2beta1.DefaultCoreLabels(instance)
+	spec.Ports = util.MergeServicePorts(spec.Ports, ports)
+	spec.Selector = appsv2beta1.DefaultCoreLabels(instance)
 
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -76,21 +77,22 @@ func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *co
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   instance.Namespace,
 			Name:        instance.DashboardServiceNamespacedName().Name,
-			Labels:      appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), svc.ObjectMeta.Labels),
-			Annotations: svc.ObjectMeta.Annotations,
+			Labels:      appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), meta.Labels),
+			Annotations: meta.Annotations,
 		},
-		Spec: svc.Spec,
+		Spec: *spec,
 	}
 }
 
 func generateListenerService(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Service {
-	svc := &corev1.Service{}
+	meta := &metav1.ObjectMeta{}
+	spec := &corev1.ServiceSpec{}
 	if instance.Spec.ListenersServiceTemplate != nil {
 		if !instance.Spec.ListenersServiceTemplate.IsEnabled() {
 			return nil
 		}
-		svc.ObjectMeta = *instance.Spec.ListenersServiceTemplate.ObjectMeta.DeepCopy()
-		svc.Spec = *instance.Spec.ListenersServiceTemplate.Spec.DeepCopy()
+		meta = instance.Spec.ListenersServiceTemplate.ObjectMeta.DeepCopy()
+		spec = instance.Spec.ListenersServiceTemplate.Spec.DeepCopy()
 	}
 
 	ports := conf.GetListenersServicePorts()
@@ -123,10 +125,10 @@ func generateListenerService(instance *appsv2beta1.EMQX, conf *config.Conf) *cor
 		}...)
 	}
 
-	svc.Spec.Ports = util.MergeServicePorts(svc.Spec.Ports, ports)
-	svc.Spec.Selector = appsv2beta1.DefaultCoreLabels(instance)
+	spec.Ports = util.MergeServicePorts(spec.Ports, ports)
+	spec.Selector = appsv2beta1.DefaultCoreLabels(instance)
 	if appsv2beta1.IsExistReplicant(instance) && instance.Status.ReplicantNodesStatus.ReadyReplicas > 0 {
-		svc.Spec.Selector = appsv2beta1.DefaultReplicantLabels(instance)
+		spec.Selector = appsv2beta1.DefaultReplicantLabels(instance)
 	}
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -136,9 +138,9 @@ func generateListenerService(instance *appsv2beta1.EMQX, conf *config.Conf) *cor
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   instance.Namespace,
 			Name:        instance.ListenersServiceNamespacedName().Name,
-			Labels:      appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), svc.ObjectMeta.Labels),
-			Annotations: svc.ObjectMeta.Annotations,
+			Labels:      appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), meta.Labels),
+			Annotations: meta.Annotations,
 		},
-		Spec: svc.Spec,
+		Spec: *spec,
 	}
 }

--- a/internal/controller/add_service.go
+++ b/internal/controller/add_service.go
@@ -31,7 +31,7 @@ func (a *addService) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 		return subResult{err: emperror.Wrap(err, "failed to get emqx configs by api")}
 	}
 
-	conf, err := config.EMQXConf(configStr)
+	conf, err := config.EMQXConfig(configStr)
 	if err != nil {
 		return subResult{err: emperror.Wrap(err, "failed to load emqx config")}
 	}
@@ -50,7 +50,7 @@ func (a *addService) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 	return subResult{}
 }
 
-func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Service {
+func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.EMQX) *corev1.Service {
 	meta := &metav1.ObjectMeta{}
 	spec := &corev1.ServiceSpec{}
 	if instance.Spec.DashboardServiceTemplate != nil {
@@ -61,7 +61,7 @@ func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *co
 		spec = instance.Spec.DashboardServiceTemplate.Spec.DeepCopy()
 	}
 
-	ports := conf.GetDashboardServicePort()
+	ports := conf.GetDashboardServicePorts()
 	if len(ports) == 0 {
 		return nil
 	}
@@ -84,7 +84,7 @@ func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *co
 	}
 }
 
-func generateListenerService(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Service {
+func generateListenerService(instance *appsv2beta1.EMQX, conf *config.EMQX) *corev1.Service {
 	meta := &metav1.ObjectMeta{}
 	spec := &corev1.ServiceSpec{}
 	if instance.Spec.ListenersServiceTemplate != nil {

--- a/internal/controller/add_service.go
+++ b/internal/controller/add_service.go
@@ -53,7 +53,7 @@ func (a *addService) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Service {
 	svc := &corev1.Service{}
 	if instance.Spec.DashboardServiceTemplate != nil {
-		if !*instance.Spec.DashboardServiceTemplate.Enabled {
+		if !instance.Spec.DashboardServiceTemplate.IsEnabled() {
 			return nil
 		}
 		svc.ObjectMeta = *instance.Spec.DashboardServiceTemplate.ObjectMeta.DeepCopy()
@@ -86,7 +86,7 @@ func generateDashboardService(instance *appsv2beta1.EMQX, conf *config.Conf) *co
 func generateListenerService(instance *appsv2beta1.EMQX, conf *config.Conf) *corev1.Service {
 	svc := &corev1.Service{}
 	if instance.Spec.ListenersServiceTemplate != nil {
-		if !*instance.Spec.ListenersServiceTemplate.Enabled {
+		if !instance.Spec.ListenersServiceTemplate.IsEnabled() {
 			return nil
 		}
 		svc.ObjectMeta = *instance.Spec.ListenersServiceTemplate.ObjectMeta.DeepCopy()

--- a/internal/controller/add_service_test.go
+++ b/internal/controller/add_service_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func loadConf(data string) *config.Conf {
-	conf, _ := config.EMQXConf(config.MergeDefaults(data))
+	conf, _ := config.EMQXConf(data)
 	return conf
 }
 

--- a/internal/controller/add_service_test.go
+++ b/internal/controller/add_service_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func loadConf(data string) *config.Conf {
-	conf, _ := config.EMQXConf(data)
+func loadConf(data string) *config.EMQX {
+	conf, _ := config.EMQXConfigWithDefaults(data)
 	return conf
 }
 
@@ -272,7 +272,7 @@ func TestGenerateListenersService(t *testing.T) {
 
 	t.Run("check ports", func(t *testing.T) {
 		emqx := &appsv2beta1.EMQX{}
-		conf, _ := config.EMQXConf(`
+		conf, _ := config.EMQXConfigWithDefaults(`
 		gateway.lwm2m.listeners.udp.default.bind = 5783
 		`)
 		got := generateListenerService(emqx, conf)

--- a/internal/controller/api_requester.go
+++ b/internal/controller/api_requester.go
@@ -95,7 +95,7 @@ func (b *apiRequesterBuilder) forPod(pod *corev1.Pod) req.RequesterInterface {
 }
 
 func newAPIRequesterBuilder(
-	conf *config.Conf,
+	conf *config.EMQX,
 	bootstrapAPIKey *corev1.Secret,
 ) (*apiRequesterBuilder, error) {
 	username, password, err := getAPICredentials(bootstrapAPIKey)

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lithammer/dedent"
 	"github.com/rory-z/go-hocon"
 	corev1 "k8s.io/api/core/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -150,7 +149,7 @@ func (c *Conf) GetDashboardServicePort() []corev1.ServicePort {
 func (c *Conf) GetListenersServicePorts() []corev1.ServicePort {
 	portList := []corev1.ServicePort{}
 
-	// Should be non-empty, see `mergeDefaultConfig`
+	// May be empty
 	for t, listener := range c.config.GetObject("listeners") {
 		if listener.Type() != hocon.ObjectType {
 			continue
@@ -235,20 +234,6 @@ func (c *Conf) GetListenersServicePorts() []corev1.ServicePort {
 	})
 
 	return portList
-}
-
-func MergeDefaults(config string) string {
-	template := dedent.Dedent(`
-	# emqx-operator default config
-	listeners.tcp.default.bind = 1883
-	listeners.ssl.default.bind = 8883
-	listeners.ws.default.bind  = 8083
-	listeners.wss.default.bind = 8084
-
-	# user config
-	%s
-	`)
-	return fmt.Sprintf(template, config)
 }
 
 /* hocon.Config helper functions */

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -86,7 +86,7 @@ func TestStripReadOnlyConfig(t *testing.T) {
 		got := config.StripReadOnlyConfig()
 		assert.ElementsMatch(t, got, []string{
 			"node",
-			"cluster",
+			"cluster.name",
 			"durable_sessions",
 		})
 	})

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -45,7 +45,7 @@ type reconcileRound struct {
 	ctx context.Context
 	log logr.Logger
 	// Populated by `loadConfig` reconciler:
-	conf *config.Conf
+	conf *config.EMQX
 	// Populated by `setupAPIRequester` reconciler:
 	requester apiRequester
 	// Populated by loadState reconciler:

--- a/internal/controller/load_config.go
+++ b/internal/controller/load_config.go
@@ -11,7 +11,7 @@ type loadConfig struct {
 }
 
 func (l *loadConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) subResult {
-	conf, err := config.EMQXConf(config.MergeDefaults(instance.Spec.Config.Data))
+	conf, err := config.EMQXConf(instance.Spec.Config.Data)
 	if err != nil {
 		return subResult{
 			err: emperror.Wrap(err, "the .spec.config.data is not a valid HOCON config"),

--- a/internal/controller/load_config.go
+++ b/internal/controller/load_config.go
@@ -11,7 +11,7 @@ type loadConfig struct {
 }
 
 func (l *loadConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) subResult {
-	conf, err := config.EMQXConf(instance.Spec.Config.Data)
+	conf, err := config.EMQXConfigWithDefaults(instance.Spec.Config.Data)
 	if err != nil {
 		return subResult{
 			err: emperror.Wrap(err, "the .spec.config.data is not a valid HOCON config"),

--- a/internal/controller/rebalance_controller.go
+++ b/internal/controller/rebalance_controller.go
@@ -109,7 +109,7 @@ func (r *RebalanceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		return ctrl.Result{}, r.Client.Status().Update(ctx, rebalance)
 	}
 
-	conf, err := config.EMQXConf(emqx.Spec.Config.Data)
+	conf, err := config.EMQXConfigWithDefaults(emqx.Spec.Config.Data)
 	if err != nil {
 		return ctrl.Result{}, emperror.New("failed to parse config")
 	}

--- a/internal/controller/rebalance_controller.go
+++ b/internal/controller/rebalance_controller.go
@@ -109,7 +109,7 @@ func (r *RebalanceReconciler) Reconcile(ctx context.Context, request ctrl.Reques
 		return ctrl.Result{}, r.Client.Status().Update(ctx, rebalance)
 	}
 
-	conf, err := config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+	conf, err := config.EMQXConf(emqx.Spec.Config.Data)
 	if err != nil {
 		return ctrl.Result{}, emperror.New("failed to parse config")
 	}

--- a/internal/controller/resources/config.go
+++ b/internal/controller/resources/config.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
+	"github.com/emqx/emqx-operator/internal/controller/config"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const BaseConfigFile string = "base.hocon"
+const OverridesConfigFile string = "emqx.conf"
+
+const configVolumeName = "bootstrap-config"
+
+type emqxConfigResource struct {
+	*appsv2beta1.EMQX
+}
+
+func EMQXConfig(instance *appsv2beta1.EMQX) emqxConfigResource {
+	return emqxConfigResource{instance}
+}
+
+func (from emqxConfigResource) ConfigMap() *corev1.ConfigMap {
+	// NOTE
+	// Providing empty 'emqx.conf' to make sure no user-defined configuration is ignored or
+	// overridden during restarts.
+	baseConfigData := config.WithDefaults(from.Spec.Config.Data)
+	emqxConfData := ""
+	return from.ConfigMapWithData(baseConfigData, emqxConfData)
+}
+
+func (from emqxConfigResource) ConfigMapWithData(baseConfigData string, overridesConfigData string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      from.ConfigsNamespacedName().Name,
+			Namespace: from.Namespace,
+			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(from.EMQX), from.Labels),
+		},
+		Data: map[string]string{
+			BaseConfigFile:      baseConfigData,
+			OverridesConfigFile: overridesConfigData,
+		},
+	}
+}
+
+func (emqxConfigResource) VolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      configVolumeName,
+			MountPath: "/opt/emqx/etc/" + BaseConfigFile,
+			SubPath:   BaseConfigFile,
+			ReadOnly:  true,
+		},
+		{
+			Name:      configVolumeName,
+			MountPath: "/opt/emqx/etc/" + OverridesConfigFile,
+			SubPath:   OverridesConfigFile,
+			ReadOnly:  true,
+		},
+	}
+}
+
+func (from emqxConfigResource) Volume() corev1.Volume {
+	return corev1.Volume{
+		Name: configVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: from.ConfigsNamespacedName().Name,
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/resources/secrets.go
+++ b/internal/controller/resources/secrets.go
@@ -1,0 +1,102 @@
+package controller
+
+import (
+	"fmt"
+
+	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const boostrapApiKeysVolumeName = "bootstrap-api-keys"
+
+type cookieResource struct {
+	*appsv2beta1.EMQX
+}
+
+type bootstrapAPIKeyResource struct {
+	*appsv2beta1.EMQX
+}
+
+func BootstrapAPIKey(instance *appsv2beta1.EMQX) bootstrapAPIKeyResource {
+	return bootstrapAPIKeyResource{instance}
+}
+
+func Cookie(instance *appsv2beta1.EMQX) cookieResource {
+	return cookieResource{instance}
+}
+
+func (from bootstrapAPIKeyResource) Secret(content string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: from.Namespace,
+			Name:      from.BootstrapAPIKeyNamespacedName().Name,
+			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(from.EMQX), from.Labels),
+		},
+		StringData: map[string]string{
+			"bootstrap_api_key": content,
+		},
+	}
+}
+
+func (from bootstrapAPIKeyResource) VolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      boostrapApiKeysVolumeName,
+		MountPath: "/opt/emqx/etc/bootstrap_api_keys",
+		SubPath:   "bootstrap_api_key",
+		ReadOnly:  true,
+	}
+}
+
+func (from bootstrapAPIKeyResource) Volume() corev1.Volume {
+	return corev1.Volume{
+		Name: boostrapApiKeysVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: from.BootstrapAPIKeyNamespacedName().Name,
+			},
+		},
+	}
+}
+
+func (from bootstrapAPIKeyResource) EnvVar() corev1.EnvVar {
+	return corev1.EnvVar{
+		Name:  "EMQX_API_KEY__BOOTSTRAP_FILE",
+		Value: fmt.Sprintf(`"%s"`, from.VolumeMount().MountPath),
+	}
+}
+
+func (from cookieResource) Secret(content string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: from.Namespace,
+			Name:      from.NodeCookieNamespacedName().Name,
+			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(from.EMQX), from.Labels),
+		},
+		StringData: map[string]string{
+			"node_cookie": content,
+		},
+	}
+}
+
+func (from cookieResource) EnvVar() corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: "EMQX_NODE__COOKIE",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: from.NodeCookieNamespacedName().Name,
+				},
+				Key: "node_cookie",
+			},
+		},
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 	}()
 
 	emqxReconciler = NewEMQXReconciler(k8sManager)
-	emqxConf, err = config.EMQXConf(config.MergeDefaults(emqx.Spec.Config.Data))
+	emqxConf, err = config.EMQXConf(emqx.Spec.Config.Data)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(emqxConf).ToNot(BeNil())
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -62,7 +62,7 @@ var logger logr.Logger
 var timeout, interval time.Duration
 
 var emqxReconciler *EMQXReconciler
-var emqxConf *config.Conf
+var emqxConf *config.EMQX
 var emqx *appsv2beta1.EMQX = &appsv2beta1.EMQX{
 	ObjectMeta: metav1.ObjectMeta{
 		UID:  "fake-1234567890",
@@ -141,7 +141,7 @@ var _ = BeforeSuite(func() {
 	}()
 
 	emqxReconciler = NewEMQXReconciler(k8sManager)
-	emqxConf, err = config.EMQXConf(emqx.Spec.Config.Data)
+	emqxConf, err = config.EMQXConfigWithDefaults(emqx.Spec.Config.Data)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(emqxConf).ToNot(BeNil())
 })

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -5,7 +5,6 @@ import (
 
 	emperror "emperror.dev/errors"
 	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
-	config "github.com/emqx/emqx-operator/internal/controller/config"
 	"github.com/emqx/emqx-operator/internal/emqx/api"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,9 +17,8 @@ type syncConfig struct {
 }
 
 func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) subResult {
-	// Merge default config.
 	// Assuming the config is valid, otherwise master controller would bail out.
-	confStr := config.MergeDefaults(instance.Spec.Config.Data)
+	confStr := instance.Spec.Config.Data
 
 	// Make sure the config map exists
 	configMap := &corev1.ConfigMap{}

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -38,7 +38,7 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 	}
 
 	// If the config is different, update the config right away.
-	if configMap.Data["emqx.conf"] != confStr {
+	if configMap.Data[appsv2beta1.BaseConfigFile] != confStr {
 		if err := s.Client.Update(r.ctx, generateConfigMap(instance, confStr)); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update configMap")}
 		}
@@ -100,7 +100,7 @@ func generateConfigMap(instance *appsv2beta1.EMQX, data string) *corev1.ConfigMa
 			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(instance), instance.Labels),
 		},
 		Data: map[string]string{
-			"emqx.conf": data,
+			appsv2beta1.BaseConfigFile: data,
 		},
 	}
 }


### PR DESCRIPTION
Part of [EMQX-14562](https://emqx.atlassian.net/browse/EMQX-14562).

This PR:
* Maps `.Spec.Config` into `base.hocon` configuration file in EMQX containers.
* Replaces `emqx.conf` files with blank files in EMQX containers, to avoid accidentally redefining configuration supplied in `.Spec.Config`.
* Drops forceful redefinition of dashboard configuration through containers' environment variables.
* Refactors `addCoreSet` / `addReplicantSet` reconcilers to make them reuse common resources.
* Stops provisioning bootstrap API keys to replicant pods.
* Corrects read-only configuration entries criteria.

See individual commits for further details.