### PR TITLE
fix(config): apply configuration changes consistently

### DIFF
--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -164,6 +164,25 @@ func (c *EMQX) StripReadOnlyConfig() []string {
 	return stripped
 }
 
+func (c *EMQX) Strip(path string) bool {
+	object := c.GetRoot().(hocon.Object)
+	keys := strings.Split(path, ".")
+	l := len(keys)
+	for i, key := range keys {
+		value, ok := object[key]
+		if !ok {
+			return false
+		}
+		if i == l-1 {
+			delete(object, key)
+			return true
+		} else {
+			object = value.(hocon.Object)
+		}
+	}
+	return false
+}
+
 func (c *EMQX) GetNodeCookie() string {
 	return toString(byDefault(c.Get("node.cookie"), ""))
 }

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -75,7 +75,60 @@ func (c *EMQX) Copy() *EMQX {
 }
 
 func (c *EMQX) Print() string {
-	return c.String()
+	return printObject(c.GetRoot().(hocon.Object), true)
+}
+
+func printValue(v hocon.Value) string {
+	switch v.Type() {
+	case hocon.ObjectType:
+		return printObject(v.(hocon.Object), false)
+	case hocon.ArrayType:
+		return printArray(v.(hocon.Array))
+	default:
+		return v.String()
+	}
+}
+
+func printObject(o hocon.Object, root bool) string {
+	builder := strings.Builder{}
+	n := len(o)
+	if !root {
+		builder.WriteString("{")
+	}
+	keys := make([]string, 0, n)
+	for k := range o {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, key := range keys {
+		value := o[key]
+		builder.WriteString(key)
+		if value.Type() != hocon.ObjectType {
+			builder.WriteString(" = ")
+		} else {
+			builder.WriteString(" ")
+		}
+		builder.WriteString(printValue(value))
+		if i < n-1 {
+			builder.WriteString(", ")
+		}
+	}
+	if !root {
+		builder.WriteString("}")
+	}
+	return builder.String()
+}
+
+func printArray(a hocon.Array) string {
+	var builder strings.Builder
+	builder.WriteString("[")
+	builder.WriteString(a[0].String())
+	for _, value := range a[1:] {
+		builder.WriteString(", ")
+		builder.WriteString(value.String())
+	}
+	builder.WriteString("]")
+	return builder.String()
 }
 
 func (c *EMQX) StripReadOnlyConfig() []string {

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -168,17 +168,28 @@ func (c *EMQX) Strip(path string) bool {
 	object := c.GetRoot().(hocon.Object)
 	keys := strings.Split(path, ".")
 	l := len(keys)
-	for i, key := range keys {
-		value, ok := object[key]
-		if !ok {
-			return false
-		}
-		if i == l-1 {
+	if l > 0 {
+		return stripRecursive(object, keys, 0, l)
+	}
+	return false
+}
+
+func stripRecursive(object hocon.Object, keys []string, i int, l int) bool {
+	key := keys[i]
+	val, ok := object[key]
+	if !ok {
+		return false
+	}
+	if i == l-1 {
+		delete(object, key)
+		return true
+	}
+	inner, ok := val.(hocon.Object)
+	if ok && stripRecursive(inner, keys, i+1, l) {
+		if len(inner) == 0 {
 			delete(object, key)
-			return true
-		} else {
-			object = value.(hocon.Object)
 		}
+		return true
 	}
 	return false
 }

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -306,3 +306,39 @@ func TestGetListenersServicePorts(t *testing.T) {
 		}, got)
 	})
 }
+
+func TestPrint(t *testing.T) {
+	t.Run("empty config", func(t *testing.T) {
+		config, err := EMQXConfig("")
+		assert.Nil(t, err)
+		got := config.Print()
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("arrays", func(t *testing.T) {
+		config, err := EMQXConfig(`
+			node.name = "emqx@127.0.0.1"
+			cluster.core_nodes = ["emqx@node1.emqx.io", "emqx@node2.emqx.io"]
+		`)
+		assert.Nil(t, err)
+		got := config.Print()
+		expected := `cluster {core_nodes = ["emqx@node1.emqx.io", "emqx@node2.emqx.io"]}, node {name = "emqx@127.0.0.1"}`
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("complex nested structure", func(t *testing.T) {
+		config, err := EMQXConfig(`
+			durable_sessions.enable = true
+			gateway.coap.listeners.udp.default.bind = 5683
+			gateway.coap.listeners.dtls.default.bind = 5684
+			listeners.tcp.default.bind = 1883
+			listeners.ssl.default.bind = 8883
+			dashboard.listeners.http.bind = 18083
+			dashboard.listeners.https.bind = 18084
+		`)
+		assert.Nil(t, err)
+		got := config.Print()
+		expected := `dashboard {listeners {http {bind = 18083}, https {bind = 18084}}}, durable_sessions {enable = true}, gateway {coap {listeners {dtls {default {bind = 5684}}, udp {default {bind = 5683}}}}}, listeners {ssl {default {bind = 8883}}, tcp {default {bind = 1883}}}`
+		assert.Equal(t, expected, got)
+	})
+}

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -342,3 +342,43 @@ func TestPrint(t *testing.T) {
 		assert.Equal(t, expected, got)
 	})
 }
+
+func TestStrip(t *testing.T) {
+	t.Run("empty config", func(t *testing.T) {
+		config, err := EMQXConfig("")
+		assert.Nil(t, err)
+		got := config.Strip("dashboard.listeners.http.bind")
+		assert.Equal(t, got, false)
+		assert.Equal(t, config.Print(), "")
+	})
+
+	t.Run("delete non-existent key", func(t *testing.T) {
+		config, err := EMQXConfig(`
+		dashboard.listeners.http.bind = 18083
+		`)
+		assert.Nil(t, err)
+		got := config.Strip("dashboard.config.file")
+		assert.Equal(t, got, false)
+		assert.Equal(t, config.Print(), `dashboard {listeners {http {bind = 18083}}}`)
+	})
+
+	t.Run("delete whole root", func(t *testing.T) {
+		config, err := EMQXConfig(`
+		dashboard.listeners { http.bind = 18083, https.bind = 18084 }
+		`)
+		assert.Nil(t, err)
+		got := config.Strip("dashboard")
+		assert.Equal(t, got, true)
+		assert.Equal(t, config.Print(), "")
+	})
+
+	t.Run("delete empty leftover objects", func(t *testing.T) {
+		config, err := EMQXConfig(`
+		dashboard.listeners { http.bind = 18083, https.bind = 18084 }
+		`)
+		assert.Nil(t, err)
+		got := config.Strip("dashboard.listeners.https.bind")
+		assert.Equal(t, got, true)
+		assert.Equal(t, config.Print(), `dashboard {listeners {http {bind = 18083}}}`)
+	})
+}

--- a/internal/controller/load_config.go
+++ b/internal/controller/load_config.go
@@ -11,7 +11,7 @@ type loadConfig struct {
 }
 
 func (l *loadConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) subResult {
-	conf, err := config.EMQXConfigWithDefaults(instance.Spec.Config.Data)
+	conf, err := config.EMQXConfigWithDefaults(applicableConfig(instance))
 	if err != nil {
 		return subResult{
 			err: emperror.Wrap(err, "the .spec.config.data is not a valid HOCON config"),

--- a/internal/controller/resources/config.go
+++ b/internal/controller/resources/config.go
@@ -24,7 +24,7 @@ func (from emqxConfigResource) ConfigMap() *corev1.ConfigMap {
 	// NOTE
 	// Providing empty 'emqx.conf' to make sure no user-defined configuration is ignored or
 	// overridden during restarts.
-	baseConfigData := config.WithDefaults(from.Spec.Config.Data)
+	baseConfigData := from.BaseConfig()
 	emqxConfData := ""
 	return from.ConfigMapWithData(baseConfigData, emqxConfData)
 }
@@ -45,6 +45,14 @@ func (from emqxConfigResource) ConfigMapWithData(baseConfigData string, override
 			OverridesConfigFile: overridesConfigData,
 		},
 	}
+}
+
+func (from emqxConfigResource) BaseConfig() string {
+	return config.WithDefaults(from.Spec.Config.Data)
+}
+
+func (from emqxConfigResource) DiffersFrom(configMap *corev1.ConfigMap) bool {
+	return configMap.Data[BaseConfigFile] != from.BaseConfig() || configMap.Data[OverridesConfigFile] != ""
 }
 
 func (emqxConfigResource) VolumeMounts() []corev1.VolumeMount {

--- a/internal/controller/resources/config.go
+++ b/internal/controller/resources/config.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
-	"github.com/emqx/emqx-operator/internal/controller/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -20,16 +19,10 @@ func EMQXConfig(instance *appsv2beta1.EMQX) emqxConfigResource {
 	return emqxConfigResource{instance}
 }
 
-func (from emqxConfigResource) ConfigMap() *corev1.ConfigMap {
+func (from emqxConfigResource) ConfigMap(baseConfig string) *corev1.ConfigMap {
 	// NOTE
 	// Providing empty 'emqx.conf' to make sure no user-defined configuration is ignored or
 	// overridden during restarts.
-	baseConfigData := from.BaseConfig()
-	emqxConfData := ""
-	return from.ConfigMapWithData(baseConfigData, emqxConfData)
-}
-
-func (from emqxConfigResource) ConfigMapWithData(baseConfigData string, overridesConfigData string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -41,18 +34,10 @@ func (from emqxConfigResource) ConfigMapWithData(baseConfigData string, override
 			Labels:    appsv2beta1.CloneAndMergeMap(appsv2beta1.DefaultLabels(from.EMQX), from.Labels),
 		},
 		Data: map[string]string{
-			BaseConfigFile:      baseConfigData,
-			OverridesConfigFile: overridesConfigData,
+			BaseConfigFile:      baseConfig,
+			OverridesConfigFile: "",
 		},
 	}
-}
-
-func (from emqxConfigResource) BaseConfig() string {
-	return config.WithDefaults(from.Spec.Config.Data)
-}
-
-func (from emqxConfigResource) DiffersFrom(configMap *corev1.ConfigMap) bool {
-	return configMap.Data[BaseConfigFile] != from.BaseConfig() || configMap.Data[OverridesConfigFile] != ""
 }
 
 func (emqxConfigResource) VolumeMounts() []corev1.VolumeMount {

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -5,10 +5,12 @@ import (
 
 	emperror "emperror.dev/errors"
 	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
+	config "github.com/emqx/emqx-operator/internal/controller/config"
 	resources "github.com/emqx/emqx-operator/internal/controller/resources"
 	"github.com/emqx/emqx-operator/internal/emqx/api"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -18,10 +20,11 @@ type syncConfig struct {
 
 func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) subResult {
 	// Make sure the config map exists
+	resource := resources.EMQXConfig(instance)
 	configMap := &corev1.ConfigMap{}
-	err := s.Client.Get(r.ctx, instance.ConfigsNamespacedName(), configMap)
+	err := s.Client.Get(r.ctx, resource.ConfigsNamespacedName(), configMap)
 	if err != nil && k8sErrors.IsNotFound(err) {
-		configMap = resources.EMQXConfig(instance).ConfigMap()
+		configMap = resource.ConfigMap()
 		if err := ctrl.SetControllerReference(instance, configMap, s.Scheme); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to set controller reference for configMap")}
 		}
@@ -36,21 +39,24 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 
 	// If the config is different, update the config right away.
 	// Assuming the config is valid, otherwise master controller would bail out.
-	if configMap.Data[resources.BaseConfigFile] != instance.Spec.Config.Data {
-		configMap = resources.EMQXConfig(instance).ConfigMap()
+	if resource.DiffersFrom(configMap) {
+		configMap = resource.ConfigMap()
+		r.log.V(1).Info("updating config resource", "configMap", klog.KObj(configMap))
 		if err := s.Client.Update(r.ctx, configMap); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update configMap")}
 		}
 	}
 
+	confStr := resource.BaseConfig()
 	lastConfStr, ok := instance.Annotations[appsv2beta1.AnnotationsLastEMQXConfigKey]
 
 	// If the annotation is not set, set it to the current config and return.
+	// This reconciler is apparently running for the first time.
 	if !ok {
 		if instance.Annotations == nil {
 			instance.Annotations = map[string]string{}
 		}
-		instance.Annotations[appsv2beta1.AnnotationsLastEMQXConfigKey] = instance.Spec.Config.Data
+		instance.Annotations[appsv2beta1.AnnotationsLastEMQXConfigKey] = confStr
 		if err := s.Client.Update(r.ctx, instance); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update emqx instance annotation")}
 		}
@@ -58,13 +64,16 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 	}
 
 	// If the annotation is set, and the config is different, update the config.
-	if lastConfStr != instance.Spec.Config.Data {
+	if lastConfStr != confStr {
 		if !instance.Status.IsConditionTrue(appsv2beta1.CoreNodesReady) {
 			return subResult{}
 		}
 
 		// Delete readonly configs
-		conf := r.conf.Copy()
+		conf, err := config.EMQXConfig(confStr)
+		if err != nil {
+			return subResult{err: emperror.Wrap(err, "failed to parse .spec.config.data")}
+		}
 		stripped := conf.StripReadOnlyConfig()
 		if len(stripped) > 0 {
 			s.EventRecorder.Event(
@@ -74,15 +83,27 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 			)
 		}
 
+		r.log.V(1).Info("applying runtime config", "config", conf.Print())
 		if err := api.UpdateConfigs(r.oldestCoreRequester(), instance.Spec.Config.Mode, conf.Print()); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update emqx config through API")}
 		}
 
-		instance.Annotations[appsv2beta1.AnnotationsLastEMQXConfigKey] = instance.Spec.Config.Data
+		instance.Annotations[appsv2beta1.AnnotationsLastEMQXConfigKey] = confStr
 		if err := s.Client.Update(r.ctx, instance); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update emqx instance annotation")}
 		}
 	}
 
 	return subResult{}
+}
+
+func applicableConfig(instance *appsv2beta1.EMQX) string {
+	// If the annotation is set, use it: most of the time it's the config currently in use.
+	if instance.Annotations != nil {
+		if config := instance.Annotations[appsv2beta1.AnnotationsLastEMQXConfigKey]; config != "" {
+			return config
+		}
+	}
+	// If not, running for the first time, use spec's config.
+	return instance.Spec.Config.Data
 }

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -108,6 +108,9 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *appsv2beta1.EMQX) su
 		if err := s.Client.Update(r.ctx, instance); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update emqx instance annotation")}
 		}
+
+		// Restart reconciliation loop with consistent reconcile state.
+		return subResult{result: ctrl.Result{Requeue: true}}
 	}
 
 	return subResult{}

--- a/internal/controller/sync_emqx_config_test.go
+++ b/internal/controller/sync_emqx_config_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripNonChangeableConfig(t *testing.T) {
+	t.Run("empty configs", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig("", "")
+		assert.Equal(t, "", config)
+		assert.Equal(t, []string{}, stripped)
+	})
+
+	t.Run("http port changed", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig(
+			"dashboard.listeners.http.bind = 18083",
+			"dashboard.listeners.http.bind = 18084",
+		)
+		assert.Equal(t, "", config)
+		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
+	})
+
+	t.Run("http port unchanged", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig(
+			"dashboard.listeners.http.bind = 18083",
+			"dashboard.listeners.http.bind = 18083",
+		)
+		assert.Equal(t, "dashboard.listeners.http.bind = 18083", config)
+		assert.Equal(t, []string{}, stripped)
+	})
+
+	t.Run("https port changed", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig(
+			"dashboard.listeners.https.bind = 18083",
+			"dashboard.listeners.https.bind = 18084",
+		)
+		assert.Equal(t, "", config)
+		assert.Equal(t, []string{"dashboard.listeners.https.bind"}, stripped)
+	})
+
+	t.Run("https port enabled", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig(
+			"dashboard.listeners.https.bind = 18883",
+			"dashboard.listeners.https.bind = 0",
+		)
+		assert.Equal(t, "dashboard.listeners.https.bind = 18883", config)
+		assert.Equal(t, []string{}, stripped)
+	})
+
+	t.Run("both ports changed", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig(
+			"dashboard.listeners { http.bind = 18883, https.bind = 18884 }",
+			"dashboard.listeners { http.bind = 18083, https.bind = 18084 }",
+		)
+		assert.Equal(t, "dashboard {listeners {https {bind = 18884}}}", config)
+		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
+	})
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -118,7 +118,8 @@ var _ = AfterSuite(func() {
 func PrintDiagnosticReport(namespace string) {
 	controllerLogs, err := util.KubectlOut("logs",
 		"--selector", "control-plane=controller-manager",
-		"--namespace", namespace)
+		"--namespace", namespace,
+		"--tail", "-1")
 	if err == nil {
 		GinkgoWriter.Print("Controller logs:\n", controllerLogs)
 	} else {

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -70,6 +70,7 @@ func configDS() string {
 	`
 }
 
+//nolint:unparam
 func configListener(ty string, name string, enabled bool, bind string) string {
 	return fmt.Sprintf(`
 		listeners.%s.%s {

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -206,7 +206,7 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 				configListener("quic", "default", true, "14567"),
 				configListener("ws", "default", false, "0"),
 				configListener("wss", "default", false, "0"),
-				// And also change where EMQX API is served
+				// And also change dashboard config, should be skipped:
 				"dashboard.listeners.http { bind = 28083, num_acceptors = 1 }",
 			))
 			Expect(Kubectl("patch", "emqx", "emqx",

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -1,10 +1,14 @@
 package e2e
 
 import (
+	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	appsv2beta1 "github.com/emqx/emqx-operator/api/v2beta1"
 	. "github.com/emqx/emqx-operator/test/util"
+	"github.com/lithammer/dedent"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -30,19 +34,49 @@ func withImage(image string) []byte {
 	return fmt.Appendf(nil, `{"spec": {"image": "%s"}}`, image)
 }
 
-func withDS() []byte {
-	return FromYAML([]byte(`
-spec:
-  config:
-    data: |
-      license { key = "evaluation" }
-      durable_sessions { enable = true }
-      durable_storage { 
-        messages {
-          backend = builtin_raft
-          n_shards = 8
-        }
-      }`))
+func withConfig(snippets ...string) []byte {
+	defaults := []string{configLicense(), configConsoleLog("info")}
+	config := slices.Concat(defaults, snippets)
+	return fmt.Appendf(nil, `{"spec": {"config": {"data": %s}}}`, intoJsonString(config...))
+}
+
+func intoJsonString(snippets ...string) []byte {
+	configStr := dedent.Dedent(strings.Join(snippets, ""))
+	jsonStr, _ := json.Marshal(configStr)
+	return jsonStr
+}
+
+func configLicense() string {
+	return `
+		license { key = "evaluation" }
+	`
+}
+
+func configConsoleLog(level string) string {
+	return `
+		log.console { level = "` + level + `" }
+	`
+}
+
+func configDS() string {
+	return `
+		durable_sessions { enable = true }
+		durable_storage { 
+			messages {
+				backend = builtin_raft
+				n_shards = 8
+			}
+		}
+	`
+}
+
+func configListener(ty string, name string, enabled bool, bind string) string {
+	return fmt.Sprintf(`
+		listeners.%s.%s {
+			enabled = %t
+			bind = "%s"
+		}
+	`, ty, name, enabled, bind)
 }
 
 //nolint:errcheck
@@ -100,6 +134,7 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 				FromYAMLFile(emqxCRBasic),
 				withImage(emqxImage),
 				withCores(coreReplicas),
+				withConfig(),
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")
@@ -162,6 +197,45 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			Expect(out).To(Equal("0"))
 		})
 
+		It("change config", func() {
+			By("change EMQX config")
+			configChange := string(intoJsonString(
+				// Change listener ports:
+				configListener("tcp", "default", true, "11883"),
+				configListener("quic", "default", true, "14567"),
+				configListener("ws", "default", false, "0"),
+				configListener("wss", "default", false, "0"),
+				// And also change where EMQX API is served
+				"dashboard.listeners.http { bind = 28083, num_acceptors = 1 }",
+			))
+			Expect(Kubectl("patch", "emqx", "emqx",
+				"--type", "json",
+				"--patch", `[{"op": "replace", "path": "/spec/config/data", "value": `+configChange+`}]`)).
+				To(Succeed())
+			By("wait for EMQX cluster to be ready")
+			Eventually(checkEMQXReady).Should(Succeed())
+			By("wait for services to be updated")
+			var servicePorts []corev1.ServicePort
+			Eventually(KubectlOut).WithArguments("get", "service", "emqx-listeners", "-o", "jsonpath={.spec.ports}").
+				Should(BeUnmarshalledAs(&servicePorts, ConsistOf(
+					And(
+						HaveField("Name", Equal("tcp-default")),
+						HaveField("Port", Equal(int32(11883))),
+						HaveField("Protocol", Equal(corev1.ProtocolTCP)),
+					),
+					And(
+						HaveField("Name", Equal("ssl-default")),
+						HaveField("Port", Equal(int32(8883))),
+						HaveField("Protocol", Equal(corev1.ProtocolTCP)),
+					),
+					And(
+						HaveField("Name", Equal("quic-default")),
+						HaveField("Port", Equal(int32(14567))),
+						HaveField("Protocol", Equal(corev1.ProtocolUDP)),
+					),
+				)))
+		})
+
 		It("delete cluster", func() {
 			Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
 			Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")
@@ -180,6 +254,7 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 				withImage(emqxImage),
 				withCores(coreReplicas),
 				withReplicants(replicantReplicas),
+				withConfig(),
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")
@@ -284,7 +359,7 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 				withImage(emqxImage),
 				withCores(coreReplicas),
 				withReplicants(replicantReplicas),
-				withDS(),
+				withConfig(configDS()),
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 

--- a/test/e2e/emqx_upgrade_test.go
+++ b/test/e2e/emqx_upgrade_test.go
@@ -71,7 +71,7 @@ var _ = Describe("EMQX Upgrade Test", Ordered, func() {
 			withImage(emqxImageInitial),
 			withCores(coreReplicas),
 			withReplicants(replicantReplicas),
-			withDS(),
+			withConfig(configDS()),
 		)
 		Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 		By("wait for EMQX cluster to be ready")

--- a/test/util/gomega.go
+++ b/test/util/gomega.go
@@ -19,11 +19,25 @@ func HaveCondition(conditionType string, matcher types.GomegaMatcher) types.Gome
 	)
 }
 
+func HaveLabel(label string, matcher types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.HaveField("Labels", gomega.HaveKeyWithValue(label, matcher))
+}
+
 func UnmarshalInto(v any) types.GomegaMatcher {
 	return gomega.WithTransform(
 		func(in string) error {
 			return json.Unmarshal([]byte(in), v)
 		},
 		gomega.Succeed(),
+	)
+}
+
+func BeUnmarshalledAs(v any, matcher types.GomegaMatcher) types.GomegaMatcher {
+	return gomega.WithTransform(
+		func(in string) (any, error) {
+			err := json.Unmarshal([]byte(in), &v)
+			return v, err
+		},
+		gomega.HaveValue(matcher),
 	)
 }


### PR DESCRIPTION
This PR introduces E2E tests of cluster configuration changes, and fixes few uncovered issues.

Important changes:
1. A couple of critical configuration options (dashboard listener ports) are now considered unchangeable through `.spec.config`, see `stripNonChangeableConfig` for details.
2. Current state of EMQX config loaded into reconcile state is computed more carefully.