### PR TITLE
fix(sync): admit nodeless pod to scale down

### DIFF
--- a/internal/controller/cleanup_outdated_suite_test.go
+++ b/internal/controller/cleanup_outdated_suite_test.go
@@ -16,15 +16,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Reconciler syncSets", func() {
-	var s *syncSets
+var _ = Describe("Reconciler cleanupOutdatedSets", func() {
+	var s *cleanupOutdatedSets
 
 	var instance *appsv2beta1.EMQX = new(appsv2beta1.EMQX)
 	var ns *corev1.Namespace = &corev1.Namespace{}
 	var round *reconcileRound
 
 	BeforeEach(func() {
-		s = &syncSets{emqxReconciler}
+		s = &cleanupOutdatedSets{emqxReconciler}
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "controller-v2beta1-sync-sets-test-" + rand.String(5),

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -138,7 +138,7 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		&dsReflectPodCondition{r},
 		&syncReplicantSets{r},
 		&syncCoreSets{r},
-		&syncSets{r},
+		&cleanupOutdatedSets{r},
 		&dsCleanupSites{r},
 	} {
 		round.log = logger.WithValues("reconciler", subReconcilerName(subReconciler))

--- a/internal/controller/sync_core_sets.go
+++ b/internal/controller/sync_core_sets.go
@@ -150,8 +150,10 @@ func (s *syncCoreSets) chooseScaleDownCore(
 			break
 		}
 	}
+
+	// If the cluster lacks information about the node, there's very likely nothing to migrate.
 	if scaleDownNode == nil {
-		return scaleDownCore{}, emperror.Errorf("node is missing for pod %s", scaleDownPod.Name)
+		return scaleDownCore{Pod: scaleDownPod, Reason: "node is out of cluster"}, nil
 	}
 
 	// Scale down the node that is already stopped.


### PR DESCRIPTION
This PR introduces E2E tests of botched cluster-wide blue-green updates, and fixes one uncovered issue.
* Refactors `cleanupOutdatedSets` reconcile step to have better naming and more fail-proof logic.
* Stops treating lack of node information about a pod as reason to prevent scale-downs, node information may be missing because a pod was never part of the cluster.