### PR TITLE
fix(config): avoid losing ownerRef on update

### DIFF
--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -40,6 +40,7 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 		if err := ctrl.SetControllerReference(instance, configMap, s.Scheme); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to set controller reference for configMap")}
 		}
+		r.log.V(1).Info("creating config resource", "configMap", klog.KObj(configMap))
 		if err := s.Client.Create(r.ctx, configMap); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to create configMap")}
 		}
@@ -53,6 +54,9 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 	// Assuming the config is valid, otherwise master controller would bail out.
 	if configMap.Data[resources.BaseConfigFile] != confWithDefaults {
 		configMap = resource.ConfigMap(confWithDefaults)
+		if err := ctrl.SetControllerReference(instance, configMap, s.Scheme); err != nil {
+			return subResult{err: emperror.Wrap(err, "failed to set controller reference for configMap")}
+		}
 		r.log.V(1).Info("updating config resource", "configMap", klog.KObj(configMap))
 		if err := s.Client.Update(r.ctx, configMap); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update configMap")}


### PR DESCRIPTION
This PR fixes a bug where `emqx-configs` configMap loses owner reference on config update, in `syncConfig` reconcile step. This bug results in a permanent error condition in Kubernetes environments where `OwnerReferencesPermissionEnforcement` is enabled, e.g. OpenShift.