### PR TITLE
chore: refine descriptions of CRD API structures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,17 @@ build: manifests generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/main.go
 
+.PHONY: doc
+doc: crd-ref-docs manifests doc-crd-v2 ## Generate documentation for the CRDs.
+
+.PHONY: doc-crd-v2
+doc-crd-v2: ## Generate documentation for the `apps.emqx.io/v2` CRD.
+	$(CRD_REF_DOCS) \
+		--source-path=api/v2 \
+		--config=crd-ref-docs-config.yaml \
+		--output-path=docs/en_US/reference/v2-reference.md \
+		--renderer=markdown
+
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
@@ -178,12 +189,14 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.64.8
+CRD_REF_DOCS_VERSION ?= latest
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -204,6 +217,11 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: crd-ref-docs
+crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
+$(CRD_REF_DOCS): $(LOCALBIN)
+	$(call go-install-tool,$(CRD_REF_DOCS),github.com/elastic/crd-ref-docs,$(CRD_REF_DOCS_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/api/v2/emqx_types.go
+++ b/api/v2/emqx_types.go
@@ -27,18 +27,18 @@ import (
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.status==\"True\")].type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
-// EMQX is the Schema for the emqxes API.
+// Custom Resource representing an EMQX cluster.
 type EMQX struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   EMQXSpec   `json:"spec,omitempty"`
+	// Specification of the desired state of the EMQX cluster.
+	Spec EMQXSpec `json:"spec,omitempty"`
+	// Current status of the EMQX cluster.
 	Status EMQXStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
-
-// EMQXList contains a list of EMQX.
 type EMQXList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/v2/emqx_types_spec.go
+++ b/api/v2/emqx_types_spec.go
@@ -142,7 +142,7 @@ type EvacuationStrategy struct {
 }
 
 type EMQXCoreTemplate struct {
-	// Standard object's metadata.
+	// Standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the EMQX core node.
@@ -151,7 +151,7 @@ type EMQXCoreTemplate struct {
 }
 
 type EMQXReplicantTemplate struct {
-	// Standard object's metadata.
+	// Standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired behavior of the EMQX replicant node.
@@ -166,10 +166,8 @@ type EMQXCoreTemplateSpec struct {
 	// +kubebuilder:validation:XValidation:rule="has(self.minAvailable) && has(self.maxUnavailable) ? false : true",message="minAvailable cannot be set when maxUnavailable is specified. These fields are mutually exclusive in PodDisruptionBudget."
 	EMQXReplicantTemplateSpec `json:",inline"`
 
-	// This field is named VolumeClaimTemplates but actually it is PersistentVolumeClaimSpec. I'm sorry for the bad naming.
-	// PersistentVolumeClaimSpec describes the common attributes of storage devices
-	// and allows a Source for provider-specific attributes
-	// More than EMQXReplicantTemplateSpec
+	// PVC specification for a core node data storage.
+	// Note: this field named inconsistently, it is actually just a `PersistentVolumeClaimSpec`.
 	VolumeClaimTemplates corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplates,omitempty"`
 }
 

--- a/api/v2/emqx_types_spec.go
+++ b/api/v2/emqx_types_spec.go
@@ -24,13 +24,12 @@ import (
 
 // EMQXSpec defines the desired state of EMQX.
 type EMQXSpec struct {
-	// EMQX image name.
+	// EMQX container image.
 	// More info: https://kubernetes.io/docs/concepts/containers/images
 	Image string `json:"image"`
-	// Image pull policy.
-	// One of Always, Never, IfNotPresent.
-	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-	// Cannot be updated.
+	// Container image pull policy.
+	// One of `Always`, `Never`, `IfNotPresent`.
+	// Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
 	// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
@@ -38,42 +37,44 @@ type EMQXSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
-	// Service Account Name
-	// This associates the ReplicaSet or StatefulSet with the specified Service Account for authentication purposes.
+	// ServiceAccount name.
+	// Managed ReplicaSets and StatefulSets are associated with the specified ServiceAccount for authentication purposes.
 	// More info: https://kubernetes.io/docs/concepts/security/service-accounts
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// EMQX bootstrap user
+	// Bootstrap API keys to access EMQX API.
 	// Cannot be updated.
 	BootstrapAPIKeys []BootstrapAPIKey `json:"bootstrapAPIKeys,omitempty"`
 
-	// EMQX config
+	// EMQX Configuration.
 	Config Config `json:"config,omitempty"`
 
+	// Kubernetes cluster domain.
 	// +kubebuilder:default:="cluster.local"
 	ClusterDomain string `json:"clusterDomain,omitempty"`
 
-	// The number of old ReplicaSets, old StatefulSet and old PersistentVolumeClaim to retain to allow rollback.
+	// Number of old ReplicaSets, old StatefulSets and old PersistentVolumeClaims to retain to allow rollback.
 	// +kubebuilder:default:=3
 	RevisionHistoryLimit int32 `json:"revisionHistoryLimit,omitempty"`
 
-	// UpdateStrategy is the object that describes the EMQX blue-green update strategy
-	// +kubebuilder:default={type:Recreate,initialDelaySeconds:10,evacuationStrategy:{waitTakeover:10,connEvictRate:1000,sessEvictRate:1000}}
+	// Cluster upgrade strategy settings.
+	// +kubebuilder:default={type:Recreate}
 	UpdateStrategy UpdateStrategy `json:"updateStrategy,omitempty"`
 
-	// CoreTemplate is the object that describes the EMQX core node that will be created
+	// Template for Pods running EMQX core nodes.
 	// +kubebuilder:default={spec:{replicas:2}}
 	CoreTemplate EMQXCoreTemplate `json:"coreTemplate,omitempty"`
 
-	// ReplicantTemplate is the object that describes the EMQX replicant node that will be created
+	// Template for Pods running EMQX replicant nodes.
 	ReplicantTemplate *EMQXReplicantTemplate `json:"replicantTemplate,omitempty"`
 
-	// DashboardServiceTemplate is the object that describes the EMQX dashboard service that will be created
-	// This service always selector the EMQX core node
+	// Template for Service exposing the EMQX Dashboard.
+	// Dashboard Service always points to the set of EMQX core nodes.
 	DashboardServiceTemplate *ServiceTemplate `json:"dashboardServiceTemplate,omitempty"`
-	// ListenersServiceTemplate is the object that describes the EMQX listener service that will be created
-	// If the EMQX replicant node exist, this service will selector the EMQX replicant node
-	// Else this service will selector EMQX core node
+
+	// Template for Service exposing enabled EMQX listeners.
+	// Listeners Service points to the set of EMQX replicant nodes if they are enabled and exist.
+	// Otherwise, it points to the set of EMQX core nodes.
 	ListenersServiceTemplate *ServiceTemplate `json:"listenersServiceTemplate,omitempty"`
 }
 
@@ -82,39 +83,50 @@ type BootstrapAPIKey struct {
 	Key string `json:"key,omitempty"`
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=128
-	Secret    string     `json:"secret,omitempty"`
+	Secret string `json:"secret,omitempty"`
+	// Reference to a Secret entry containing the EMQX API Key.
 	SecretRef *SecretRef `json:"secretRef,omitempty"`
 }
 
 type SecretRef struct {
-	Key    KeyRef `json:"key"`
+	// Reference to a Secret entry containing the EMQX API Key.
+	Key KeyRef `json:"key"`
+	// Reference to a Secret entry containing the EMQX API Key's secret.
 	Secret KeyRef `json:"secret"`
 }
 
 type KeyRef struct {
+	// Name of the Secret object.
 	SecretName string `json:"secretName"`
+	// Entry within the Secret data.
 	// +kubebuilder:validation:Pattern:=`^[a-zA-Z\d-_]+$`
 	SecretKey string `json:"secretKey"`
 }
 
 type Config struct {
+	// Determines how configuration updates are applied.
+	// * `Merge`: Merge the new configuration into the existing configuration.
+	// * `Replace`: Replace the whole configuration.
 	// +kubebuilder:validation:Enum=Merge;Replace
 	// +kubebuilder:default=Merge
 	Mode string `json:"mode,omitempty"`
-	// Bootstrap EMQX config, in HOCON format.
-	// This configuration will be supplied as `base.hocon` to the container, see respective
+	// EMQX configuration, in HOCON format.
+	// This configuration will be supplied as `base.hocon` to the container. See respective
 	// [documentation](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#base-configuration-file).
 	Data string `json:"data,omitempty"`
 }
 
 type UpdateStrategy struct {
+	// Determines how cluster upgrade is performed.
+	// * `Recreate`: Perform blue-green upgrade.
 	// +kubebuilder:validation:Enum=Recreate
 	// +kubebuilder:default=Recreate
 	Type string `json:"type,omitempty"`
-	// Number of seconds before evacuation connection start.
+	// Number of seconds before connection evacuation starts.
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:default=10
 	InitialDelaySeconds int32 `json:"initialDelaySeconds,omitempty"`
-	// Evacuation strategy.
+	// Evacuation strategy settings.
 	EvacuationStrategy EvacuationStrategy `json:"evacuationStrategy,omitempty"`
 }
 
@@ -145,7 +157,7 @@ type EMQXCoreTemplate struct {
 	// Standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the EMQX core node.
+	// Specification of the desired state of a core node.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	Spec EMQXCoreTemplateSpec `json:"spec,omitempty"`
 }
@@ -154,15 +166,13 @@ type EMQXReplicantTemplate struct {
 	// Standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Specification of the desired behavior of the EMQX replicant node.
+	// Specification of the desired state of a replicant node.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// Controller tools does not support more complex validations (oneOf/anyOf/allOf/etc), so use validation rule instead. https://github.com/kubernetes-sigs/controller-tools/issues/461#issuecomment-1982741599
 	// +kubebuilder:validation:XValidation:rule="has(self.minAvailable) && has(self.maxUnavailable) ? false : true",message="minAvailable cannot be set when maxUnavailable is specified. These fields are mutually exclusive in PodDisruptionBudget."
 	Spec EMQXReplicantTemplateSpec `json:"spec,omitempty"`
 }
 
 type EMQXCoreTemplateSpec struct {
-	// Controller tools does not support more complex validations (oneOf/anyOf/allOf/etc), so use validation rule instead. https://github.com/kubernetes-sigs/controller-tools/issues/461#issuecomment-1982741599
 	// +kubebuilder:validation:XValidation:rule="has(self.minAvailable) && has(self.maxUnavailable) ? false : true",message="minAvailable cannot be set when maxUnavailable is specified. These fields are mutually exclusive in PodDisruptionBudget."
 	EMQXReplicantTemplateSpec `json:",inline"`
 
@@ -172,24 +182,24 @@ type EMQXCoreTemplateSpec struct {
 }
 
 type EMQXReplicantTemplateSpec struct {
-	// NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
+	// Selector which must be true for the pod to fit on a node.
+	// Must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/config/assign-pod-node/
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-	// NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+	// Request to schedule this pod onto a specific node.
+	// If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
 	NodeName string `json:"nodeName,omitempty"`
 	// Affinity for pod assignment
 	// ref: https://kubernetes.io/docs/concepts/config/assign-pod-node/#affinity-and-anti-affinity
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
-	// If specified, the pod's tolerations.
-	// The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator .
+	// Pod tolerations.
+	// If specified, Pod tolerates any taint that matches the triple <key,value,effect> using the matching operator.
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
-	// TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+	// Specifies how to spread matching pods among the given topology.
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
 
-	// Replicas is the desired number of replicas of the given Template.
-	// These are replicas in the sense that they are instantiations of the
-	// same Template, but individual replicas also have a consistent identity.
-	// Defaults to 2.
+	// Desired number of instances.
+	// In case of core nodes, each instance has a consistent identity.
 	// +kubebuilder:default:=2
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
@@ -208,49 +218,44 @@ type EMQXReplicantTemplateSpec struct {
 
 	// Entrypoint array. Not executed within a shell.
 	// The container image's ENTRYPOINT is used if this is not provided.
-	// Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-	// cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-	// to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-	// produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+	// Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable
+	// cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced
+	// to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will
+	// produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless
 	// of whether the variable exists or not. Cannot be updated.
 	// More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 	// +optional
 	Command []string `json:"command,omitempty"`
 	// Arguments to the entrypoint.
 	// The container image's CMD is used if this is not provided.
-	// Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-	// cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-	// to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-	// produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-	// of whether the variable exists or not. Cannot be updated.
+	// Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable
+	// cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced
+	// to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will
+	// produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless
+	// of whether the variable exists or not.
 	// More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
 	Args []string `json:"args,omitempty"`
-	// List of ports to expose from the container. Exposing a port here gives
-	// the system additional information about the network connections a
-	// container uses, but is primarily informational. Not specifying a port here
-	// DOES NOT prevent that port from being exposed. Any port which is
-	// listening on the default "0.0.0.0" address inside a container will be
-	// accessible from the network.
-	// Cannot be updated.
+	// List of ports to expose from the container.
+	// Exposing a port here gives the system additional information about the network connections a
+	// container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that
+	// port from being exposed. Any port which is listening on the default `0.0.0.0` address inside a
+	// container will be accessible from the network.
 	Ports []corev1.ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of environment variables to set in the container.
-	// Cannot be updated.
 	Env []corev1.EnvVar `json:"env,omitempty"`
-	// List of sources to populate environment variables in the container.
+	// List of sources to populate environment variables from in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
 	// will be reported as an event when the container is starting. When a key exists in multiple
 	// sources, the value associated with the last source will take precedence.
 	// Values defined by an Env with a duplicate key will take precedence.
-	// Cannot be updated.
 	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty" protobuf:"bytes,19,rep,name=envFrom"`
 	// Compute Resources required by this container.
-	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/config/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	// SecurityContext holds pod-level security attributes and common container settings.
+	// Pod-level security attributes and common container settings.
 	// +kubebuilder:default={runAsUser:1000,runAsGroup:1000,fsGroup:1000,fsGroupChangePolicy:Always,supplementalGroups: {1000}}
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
-	// SecurityContext defines the security options the container should be run with.
+	// Security options the container should be run with.
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 	// +kubebuilder:default={runAsUser:1000,runAsGroup:1000,runAsNonRoot:true}
@@ -265,51 +270,43 @@ type EMQXReplicantTemplateSpec struct {
 	// by finding the highest request/limit for each resource type, and then using the max of
 	// of that value or the sum of the normal containers. Limits are applied to init containers
 	// in a similar fashion.
-	// Init containers cannot currently be added or removed.
-	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
-	// ExtraContainers represents extra containers to be added to the pod.
-	// See https://github.com/emqx/emqx-operator/issues/252
+	// Additional containers to run alongside the main container.
 	ExtraContainers []corev1.Container `json:"extraContainers,omitempty"`
-	// See https://github.com/emqx/emqx-operator/pull/72
+	// Additional volumes to provide to a Pod.
 	ExtraVolumes []corev1.Volume `json:"extraVolumes,omitempty"`
-	// See https://github.com/emqx/emqx-operator/pull/72
+	// Specifies how additional volumes are mounted into the main container.
 	ExtraVolumeMounts []corev1.VolumeMount `json:"extraVolumeMounts,omitempty"`
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
-	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	// +kubebuilder:default={initialDelaySeconds:60,periodSeconds:30,failureThreshold:3,httpGet: {path:/status, port:"dashboard"}}
 	LivenessProbe *corev1.Probe `json:"livenessProbe,omitempty"`
 	// Periodic probe of container service readiness.
 	// Container will be removed from service endpoints if the probe fails.
-	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	// +kubebuilder:default={initialDelaySeconds:10,periodSeconds:5,failureThreshold:12,httpGet: {path:/status, port:"dashboard"}}
 	ReadinessProbe *corev1.Probe `json:"readinessProbe,omitempty"`
 	// StartupProbe indicates that the Pod has successfully initialized.
 	// If specified, no other probes are executed until this completes successfully.
-	// If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+	// If this probe fails, the Pod will be restarted, just as if the `livenessProbe` failed.
 	// This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
 	// when it might take a long time to load data or warm a cache, than during steady-state operation.
-	// This cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
 	StartupProbe *corev1.Probe `json:"startupProbe,omitempty"`
 	// Actions that the management system should take in response to container lifecycle events.
-	// Cannot be updated.
 	Lifecycle *corev1.Lifecycle `json:"lifecycle,omitempty" protobuf:"bytes,12,opt,name=lifecycle"`
 }
 
 type ServiceTemplate struct {
-	// EMQX Operator will create a service for EMQX nodes.
-	// This is a pointer to distinguish between `false` and not specified.
+	// Specifies whether the Service should be created.
 	// +kubebuilder:default:=true
 	Enabled *bool `json:"enabled,omitempty"`
-	// Standard object's metadata.
+	// Standard object metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Spec defines the behavior of a service.
+	// Specification of the desired state of a Service.
 	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	Spec corev1.ServiceSpec `json:"spec,omitempty"`
 }

--- a/api/v2/emqx_types_status.go
+++ b/api/v2/emqx_types_status.go
@@ -24,19 +24,25 @@ import (
 
 // EMQXStatus defines the observed state of EMQX
 type EMQXStatus struct {
-	// Represents the latest available observations of a EMQX Custom Resource current state.
+	// Conditions representing the current status of the EMQX Custom Resource.
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	CoreNodes       []EMQXNode      `json:"coreNodes,omitempty"`
+	// Status of each core node in the cluster.
+	CoreNodes []EMQXNode `json:"coreNodes,omitempty"`
+	// Summary status of the set of core nodes.
 	CoreNodesStatus EMQXNodesStatus `json:"coreNodesStatus,omitempty"`
 
-	ReplicantNodes       []EMQXNode      `json:"replicantNodes,omitempty"`
+	// Status of each replicant node in the cluster.
+	ReplicantNodes []EMQXNode `json:"replicantNodes,omitempty"`
+	// Summary status of the set of replicant nodes.
 	ReplicantNodesStatus EMQXNodesStatus `json:"replicantNodesStatus,omitempty"`
 
+	// Status of active node evacuations in the cluster.
 	NodeEvacuationsStatus []NodeEvacuationStatus `json:"nodeEvacuationsStatus,omitempty"`
-	DSReplication         DSReplicationStatus    `json:"dsReplication,omitempty"`
+	// Status of EMQX Durable Storage replication.
+	DSReplication DSReplicationStatus `json:"dsReplication,omitempty"`
 }
 
 type NodeEvacuationStatus struct {
@@ -48,9 +54,11 @@ type NodeEvacuationStatus struct {
 	State string `json:"state,omitempty"`
 	// Session recipients
 	// +kubebuilder:example={"emqx@10.0.0.2", "emqx@10.0.0.3"}
-	SessionRecipients      []string `json:"sessionRecipients,omitempty"`
-	SessionEvictionRate    int32    `json:"sessionEvictionRate,omitempty"`
-	ConnectionEvictionRate int32    `json:"connectionEvictionRate,omitempty"`
+	SessionRecipients []string `json:"sessionRecipients,omitempty"`
+	// Session eviction rate, in sessions per second.
+	SessionEvictionRate int32 `json:"sessionEvictionRate,omitempty"`
+	// Connection eviction rate, in connections per second.
+	ConnectionEvictionRate int32 `json:"connectionEvictionRate,omitempty"`
 	// Initial number of sessions on this node
 	InitialSessions int32 `json:"initialSessions,omitempty"`
 	// Initial number of connections to this node
@@ -58,14 +66,19 @@ type NodeEvacuationStatus struct {
 }
 
 type EMQXNodesStatus struct {
-	Replicas      int32 `json:"replicas,omitempty"`
+	// Total number of replicas.
+	Replicas int32 `json:"replicas,omitempty"`
+	// Number of ready replicas.
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
-
+	// Current revision of the respective core or replicant set.
 	CurrentRevision string `json:"currentRevision,omitempty"`
-	CurrentReplicas int32  `json:"currentReplicas,omitempty"`
-
+	// Number of replicas running current revision.
+	CurrentReplicas int32 `json:"currentReplicas,omitempty"`
+	// Update revision of the respective core or replicant set.
+	// When different from the current revision, the set is being updated.
 	UpdateRevision string `json:"updateRevision,omitempty"`
-	UpdateReplicas int32  `json:"updateReplicas,omitempty"`
+	// Number of replicas running update revision.
+	UpdateReplicas int32 `json:"updateReplicas,omitempty"`
 
 	CollisionCount *int32 `json:"collisionCount,omitempty"`
 }

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -119,7 +119,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      Standard object metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -7526,10 +7526,8 @@ spec:
                         type: array
                       volumeClaimTemplates:
                         description: |-
-                          This field is named VolumeClaimTemplates but actually it is PersistentVolumeClaimSpec. I'm sorry for the bad naming.
-                          PersistentVolumeClaimSpec describes the common attributes of storage devices
-                          and allows a Source for provider-specific attributes
-                          More than EMQXReplicantTemplateSpec
+                          PVC specification for a core node data storage.
+                          Note: this field named inconsistently, it is actually just a `PersistentVolumeClaimSpec`.
                         properties:
                           accessModes:
                             description: |-
@@ -8532,7 +8530,7 @@ spec:
                 properties:
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      Standard object metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -26,7 +26,7 @@ spec:
     name: v2
     schema:
       openAPIV3Schema:
-        description: EMQX is the Schema for the emqxes API.
+        description: Custom Resource representing an EMQX cluster.
         properties:
           apiVersion:
             description: |-
@@ -46,11 +46,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: EMQXSpec defines the desired state of EMQX.
+            description: Specification of the desired state of the EMQX cluster.
             properties:
               bootstrapAPIKeys:
                 description: |-
-                  EMQX bootstrap user
+                  Bootstrap API keys to access EMQX API.
                   Cannot be updated.
                 items:
                   properties:
@@ -62,24 +62,34 @@ spec:
                       minLength: 3
                       type: string
                     secretRef:
+                      description: Reference to a Secret entry containing the EMQX
+                        API Key.
                       properties:
                         key:
+                          description: Reference to a Secret entry containing the
+                            EMQX API Key.
                           properties:
                             secretKey:
+                              description: Entry within the Secret data.
                               pattern: ^[a-zA-Z\d-_]+$
                               type: string
                             secretName:
+                              description: Name of the Secret object.
                               type: string
                           required:
                           - secretKey
                           - secretName
                           type: object
                         secret:
+                          description: Reference to a Secret entry containing the
+                            EMQX API Key's secret.
                           properties:
                             secretKey:
+                              description: Entry within the Secret data.
                               pattern: ^[a-zA-Z\d-_]+$
                               type: string
                             secretName:
+                              description: Name of the Secret object.
                               type: string
                           required:
                           - secretKey
@@ -93,18 +103,23 @@ spec:
                 type: array
               clusterDomain:
                 default: cluster.local
+                description: Kubernetes cluster domain.
                 type: string
               config:
-                description: EMQX config
+                description: EMQX Configuration.
                 properties:
                   data:
                     description: |-
-                      Bootstrap EMQX config, in HOCON format.
-                      This configuration will be supplied as `base.hocon` to the container, see respective
+                      EMQX configuration, in HOCON format.
+                      This configuration will be supplied as `base.hocon` to the container. See respective
                       [documentation](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#base-configuration-file).
                     type: string
                   mode:
                     default: Merge
+                    description: |-
+                      Determines how configuration updates are applied.
+                      * `Merge`: Merge the new configuration into the existing configuration.
+                      * `Replace`: Replace the whole configuration.
                     enum:
                     - Merge
                     - Replace
@@ -114,8 +129,7 @@ spec:
                 default:
                   spec:
                     replicas: 2
-                description: CoreTemplate is the object that describes the EMQX core
-                  node that will be created
+                description: Template for Pods running EMQX core nodes.
                 properties:
                   metadata:
                     description: |-
@@ -141,7 +155,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      Specification of the desired behavior of the EMQX core node.
+                      Specification of the desired state of a core node.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       affinity:
@@ -1082,11 +1096,11 @@ spec:
                         description: |-
                           Arguments to the entrypoint.
                           The container image's CMD is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                          of whether the variable exists or not. Cannot be updated.
+                          Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced
+                          to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will
+                          produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless
+                          of whether the variable exists or not.
                           More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
@@ -1095,10 +1109,10 @@ spec:
                         description: |-
                           Entrypoint array. Not executed within a shell.
                           The container image's ENTRYPOINT is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced
+                          to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will
+                          produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless
                           of whether the variable exists or not. Cannot be updated.
                           More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
@@ -1110,7 +1124,7 @@ spec:
                           runAsNonRoot: true
                           runAsUser: 1000
                         description: |-
-                          SecurityContext defines the security options the container should be run with.
+                          Security options the container should be run with.
                           If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
@@ -1304,9 +1318,7 @@ spec:
                             type: object
                         type: object
                       env:
-                        description: |-
-                          List of environment variables to set in the container.
-                          Cannot be updated.
+                        description: List of environment variables to set in the container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -1427,12 +1439,11 @@ spec:
                         type: array
                       envFrom:
                         description: |-
-                          List of sources to populate environment variables in the container.
+                          List of sources to populate environment variables from in the container.
                           The keys defined within a source must be a C_IDENTIFIER. All invalid keys
                           will be reported as an event when the container is starting. When a key exists in multiple
                           sources, the value associated with the last source will take precedence.
                           Values defined by an Env with a duplicate key will take precedence.
-                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -1480,9 +1491,8 @@ spec:
                           type: object
                         type: array
                       extraContainers:
-                        description: |-
-                          ExtraContainers represents extra containers to be added to the pod.
-                          See https://github.com/emqx/emqx-operator/issues/252
+                        description: Additional containers to run alongside the main
+                          container.
                         items:
                           description: A single application container that you want
                             to run within a pod.
@@ -2918,7 +2928,8 @@ spec:
                           type: object
                         type: array
                       extraVolumeMounts:
-                        description: See https://github.com/emqx/emqx-operator/pull/72
+                        description: Specifies how additional volumes are mounted
+                          into the main container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -2982,7 +2993,7 @@ spec:
                           type: object
                         type: array
                       extraVolumes:
-                        description: See https://github.com/emqx/emqx-operator/pull/72
+                        description: Additional volumes to provide to a Pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -4789,8 +4800,6 @@ spec:
                           by finding the highest request/limit for each resource type, and then using the max of
                           of that value or the sum of the normal containers. Limits are applied to init containers
                           in a similar fashion.
-                          Init containers cannot currently be added or removed.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                         items:
                           description: A single application container that you want
@@ -6227,9 +6236,8 @@ spec:
                           type: object
                         type: array
                       lifecycle:
-                        description: |-
-                          Actions that the management system should take in response to container lifecycle events.
-                          Cannot be updated.
+                        description: Actions that the management system should take
+                          in response to container lifecycle events.
                         properties:
                           postStart:
                             description: |-
@@ -6462,7 +6470,6 @@ spec:
                         description: |-
                           Periodic probe of container liveness.
                           Container will be restarted if the probe fails.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
@@ -6636,16 +6643,16 @@ spec:
                           evictions by specifying "100%".
                         x-kubernetes-int-or-string: true
                       nodeName:
-                        description: NodeName is a request to schedule this pod onto
-                          a specific node. If it is non-empty, the scheduler simply
-                          schedules this pod onto that node, assuming that it fits
-                          resource requirements.
+                        description: |-
+                          Request to schedule this pod onto a specific node.
+                          If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                         type: string
                       nodeSelector:
                         additionalProperties:
                           type: string
                         description: |-
-                          NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
+                          Selector which must be true for the pod to fit on a node.
+                          Must match a node's labels for the pod to be scheduled on that node.
                           More info: https://kubernetes.io/docs/concepts/config/assign-pod-node/
                         type: object
                       podSecurityContext:
@@ -6656,8 +6663,8 @@ spec:
                           runAsUser: 1000
                           supplementalGroups:
                           - 1000
-                        description: SecurityContext holds pod-level security attributes
-                          and common container settings.
+                        description: Pod-level security attributes and common container
+                          settings.
                         properties:
                           appArmorProfile:
                             description: |-
@@ -6865,13 +6872,11 @@ spec:
                         type: object
                       ports:
                         description: |-
-                          List of ports to expose from the container. Exposing a port here gives
-                          the system additional information about the network connections a
-                          container uses, but is primarily informational. Not specifying a port here
-                          DOES NOT prevent that port from being exposed. Any port which is
-                          listening on the default "0.0.0.0" address inside a container will be
-                          accessible from the network.
-                          Cannot be updated.
+                          List of ports to expose from the container.
+                          Exposing a port here gives the system additional information about the network connections a
+                          container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that
+                          port from being exposed. Any port which is listening on the default `0.0.0.0` address inside a
+                          container will be accessible from the network.
                         items:
                           description: ContainerPort represents a network port in
                             a single container.
@@ -6921,7 +6926,6 @@ spec:
                         description: |-
                           Periodic probe of container service readiness.
                           Container will be removed from service endpoints if the probe fails.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
@@ -7077,17 +7081,14 @@ spec:
                       replicas:
                         default: 2
                         description: |-
-                          Replicas is the desired number of replicas of the given Template.
-                          These are replicas in the sense that they are instantiations of the
-                          same Template, but individual replicas also have a consistent identity.
-                          Defaults to 2.
+                          Desired number of instances.
+                          In case of core nodes, each instance has a consistent identity.
                         format: int32
                         minimum: 0
                         type: integer
                       resources:
                         description: |-
                           Compute Resources required by this container.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/config/manage-resources-containers/
                         properties:
                           claims:
@@ -7150,10 +7151,9 @@ spec:
                         description: |-
                           StartupProbe indicates that the Pod has successfully initialized.
                           If specified, no other probes are executed until this completes successfully.
-                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          If this probe fails, the Pod will be restarted, just as if the `livenessProbe` failed.
                           This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
                           when it might take a long time to load data or warm a cache, than during steady-state operation.
-                          This cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
@@ -7308,8 +7308,8 @@ spec:
                         type: object
                       tolerations:
                         description: |-
-                          If specified, the pod's tolerations.
-                          The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator .
+                          Pod tolerations.
+                          If specified, Pod tolerates any taint that matches the triple <key,value,effect> using the matching operator.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -7348,8 +7348,8 @@ spec:
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraint specifies how to spread
-                          matching pods among the given topology.
+                        description: Specifies how to spread matching pods among the
+                          given topology.
                         items:
                           description: TopologySpreadConstraint specifies how to spread
                             matching pods among the given topology.
@@ -7732,18 +7732,16 @@ spec:
                 type: object
               dashboardServiceTemplate:
                 description: |-
-                  DashboardServiceTemplate is the object that describes the EMQX dashboard service that will be created
-                  This service always selector the EMQX core node
+                  Template for Service exposing the EMQX Dashboard.
+                  Dashboard Service always points to the set of EMQX core nodes.
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      EMQX Operator will create a service for EMQX nodes.
-                      This is a pointer to distinguish between `false` and not specified.
+                    description: Specifies whether the Service should be created.
                     type: boolean
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      Standard object metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -7765,7 +7763,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      Spec defines the behavior of a service.
+                      Specification of the desired state of a Service.
                       https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       allocateLoadBalancerNodePorts:
@@ -8111,15 +8109,14 @@ spec:
                 type: object
               image:
                 description: |-
-                  EMQX image name.
+                  EMQX container image.
                   More info: https://kubernetes.io/docs/concepts/containers/images
                 type: string
               imagePullPolicy:
                 description: |-
-                  Image pull policy.
-                  One of Always, Never, IfNotPresent.
-                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
-                  Cannot be updated.
+                  Container image pull policy.
+                  One of `Always`, `Never`, `IfNotPresent`.
+                  Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.
                   More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                 type: string
               imagePullSecrets:
@@ -8146,19 +8143,17 @@ spec:
                 type: array
               listenersServiceTemplate:
                 description: |-
-                  ListenersServiceTemplate is the object that describes the EMQX listener service that will be created
-                  If the EMQX replicant node exist, this service will selector the EMQX replicant node
-                  Else this service will selector EMQX core node
+                  Template for Service exposing enabled EMQX listeners.
+                  Listeners Service points to the set of EMQX replicant nodes if they are enabled and exist.
+                  Otherwise, it points to the set of EMQX core nodes.
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      EMQX Operator will create a service for EMQX nodes.
-                      This is a pointer to distinguish between `false` and not specified.
+                    description: Specifies whether the Service should be created.
                     type: boolean
                   metadata:
                     description: |-
-                      Standard object's metadata.
+                      Standard object metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     properties:
                       annotations:
@@ -8180,7 +8175,7 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      Spec defines the behavior of a service.
+                      Specification of the desired state of a Service.
                       https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                     properties:
                       allocateLoadBalancerNodePorts:
@@ -8525,8 +8520,7 @@ spec:
                     type: object
                 type: object
               replicantTemplate:
-                description: ReplicantTemplate is the object that describes the EMQX
-                  replicant node that will be created
+                description: Template for Pods running EMQX replicant nodes.
                 properties:
                   metadata:
                     description: |-
@@ -8552,9 +8546,8 @@ spec:
                     type: object
                   spec:
                     description: |-
-                      Specification of the desired behavior of the EMQX replicant node.
+                      Specification of the desired state of a replicant node.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-                      Controller tools does not support more complex validations (oneOf/anyOf/allOf/etc), so use validation rule instead. https://github.com/kubernetes-sigs/controller-tools/issues/461#issuecomment-1982741599
                     properties:
                       affinity:
                         description: |-
@@ -9494,11 +9487,11 @@ spec:
                         description: |-
                           Arguments to the entrypoint.
                           The container image's CMD is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
-                          of whether the variable exists or not. Cannot be updated.
+                          Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced
+                          to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will
+                          produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless
+                          of whether the variable exists or not.
                           More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
@@ -9507,10 +9500,10 @@ spec:
                         description: |-
                           Entrypoint array. Not executed within a shell.
                           The container image's ENTRYPOINT is used if this is not provided.
-                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
-                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
-                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced
+                          to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will
+                          produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless
                           of whether the variable exists or not. Cannot be updated.
                           More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
@@ -9522,7 +9515,7 @@ spec:
                           runAsNonRoot: true
                           runAsUser: 1000
                         description: |-
-                          SecurityContext defines the security options the container should be run with.
+                          Security options the container should be run with.
                           If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
@@ -9716,9 +9709,7 @@ spec:
                             type: object
                         type: object
                       env:
-                        description: |-
-                          List of environment variables to set in the container.
-                          Cannot be updated.
+                        description: List of environment variables to set in the container.
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
@@ -9839,12 +9830,11 @@ spec:
                         type: array
                       envFrom:
                         description: |-
-                          List of sources to populate environment variables in the container.
+                          List of sources to populate environment variables from in the container.
                           The keys defined within a source must be a C_IDENTIFIER. All invalid keys
                           will be reported as an event when the container is starting. When a key exists in multiple
                           sources, the value associated with the last source will take precedence.
                           Values defined by an Env with a duplicate key will take precedence.
-                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -9892,9 +9882,8 @@ spec:
                           type: object
                         type: array
                       extraContainers:
-                        description: |-
-                          ExtraContainers represents extra containers to be added to the pod.
-                          See https://github.com/emqx/emqx-operator/issues/252
+                        description: Additional containers to run alongside the main
+                          container.
                         items:
                           description: A single application container that you want
                             to run within a pod.
@@ -11330,7 +11319,8 @@ spec:
                           type: object
                         type: array
                       extraVolumeMounts:
-                        description: See https://github.com/emqx/emqx-operator/pull/72
+                        description: Specifies how additional volumes are mounted
+                          into the main container.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
@@ -11394,7 +11384,7 @@ spec:
                           type: object
                         type: array
                       extraVolumes:
-                        description: See https://github.com/emqx/emqx-operator/pull/72
+                        description: Additional volumes to provide to a Pod.
                         items:
                           description: Volume represents a named volume in a pod that
                             may be accessed by any container in the pod.
@@ -13201,8 +13191,6 @@ spec:
                           by finding the highest request/limit for each resource type, and then using the max of
                           of that value or the sum of the normal containers. Limits are applied to init containers
                           in a similar fashion.
-                          Init containers cannot currently be added or removed.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                         items:
                           description: A single application container that you want
@@ -14639,9 +14627,8 @@ spec:
                           type: object
                         type: array
                       lifecycle:
-                        description: |-
-                          Actions that the management system should take in response to container lifecycle events.
-                          Cannot be updated.
+                        description: Actions that the management system should take
+                          in response to container lifecycle events.
                         properties:
                           postStart:
                             description: |-
@@ -14874,7 +14861,6 @@ spec:
                         description: |-
                           Periodic probe of container liveness.
                           Container will be restarted if the probe fails.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
@@ -15048,16 +15034,16 @@ spec:
                           evictions by specifying "100%".
                         x-kubernetes-int-or-string: true
                       nodeName:
-                        description: NodeName is a request to schedule this pod onto
-                          a specific node. If it is non-empty, the scheduler simply
-                          schedules this pod onto that node, assuming that it fits
-                          resource requirements.
+                        description: |-
+                          Request to schedule this pod onto a specific node.
+                          If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                         type: string
                       nodeSelector:
                         additionalProperties:
                           type: string
                         description: |-
-                          NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node.
+                          Selector which must be true for the pod to fit on a node.
+                          Must match a node's labels for the pod to be scheduled on that node.
                           More info: https://kubernetes.io/docs/concepts/config/assign-pod-node/
                         type: object
                       podSecurityContext:
@@ -15068,8 +15054,8 @@ spec:
                           runAsUser: 1000
                           supplementalGroups:
                           - 1000
-                        description: SecurityContext holds pod-level security attributes
-                          and common container settings.
+                        description: Pod-level security attributes and common container
+                          settings.
                         properties:
                           appArmorProfile:
                             description: |-
@@ -15277,13 +15263,11 @@ spec:
                         type: object
                       ports:
                         description: |-
-                          List of ports to expose from the container. Exposing a port here gives
-                          the system additional information about the network connections a
-                          container uses, but is primarily informational. Not specifying a port here
-                          DOES NOT prevent that port from being exposed. Any port which is
-                          listening on the default "0.0.0.0" address inside a container will be
-                          accessible from the network.
-                          Cannot be updated.
+                          List of ports to expose from the container.
+                          Exposing a port here gives the system additional information about the network connections a
+                          container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that
+                          port from being exposed. Any port which is listening on the default `0.0.0.0` address inside a
+                          container will be accessible from the network.
                         items:
                           description: ContainerPort represents a network port in
                             a single container.
@@ -15333,7 +15317,6 @@ spec:
                         description: |-
                           Periodic probe of container service readiness.
                           Container will be removed from service endpoints if the probe fails.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
@@ -15489,17 +15472,14 @@ spec:
                       replicas:
                         default: 2
                         description: |-
-                          Replicas is the desired number of replicas of the given Template.
-                          These are replicas in the sense that they are instantiations of the
-                          same Template, but individual replicas also have a consistent identity.
-                          Defaults to 2.
+                          Desired number of instances.
+                          In case of core nodes, each instance has a consistent identity.
                         format: int32
                         minimum: 0
                         type: integer
                       resources:
                         description: |-
                           Compute Resources required by this container.
-                          Cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/config/manage-resources-containers/
                         properties:
                           claims:
@@ -15562,10 +15542,9 @@ spec:
                         description: |-
                           StartupProbe indicates that the Pod has successfully initialized.
                           If specified, no other probes are executed until this completes successfully.
-                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          If this probe fails, the Pod will be restarted, just as if the `livenessProbe` failed.
                           This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
                           when it might take a long time to load data or warm a cache, than during steady-state operation.
-                          This cannot be updated.
                           More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
@@ -15720,8 +15699,8 @@ spec:
                         type: object
                       tolerations:
                         description: |-
-                          If specified, the pod's tolerations.
-                          The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator .
+                          Pod tolerations.
+                          If specified, Pod tolerates any taint that matches the triple <key,value,effect> using the matching operator.
                         items:
                           description: |-
                             The pod this Toleration is attached to tolerates any taint that matches
@@ -15760,8 +15739,8 @@ spec:
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraint specifies how to spread
-                          matching pods among the given topology.
+                        description: Specifies how to spread matching pods among the
+                          given topology.
                         items:
                           description: TopologySpreadConstraint specifies how to spread
                             matching pods among the given topology.
@@ -15945,29 +15924,23 @@ spec:
                 type: object
               revisionHistoryLimit:
                 default: 3
-                description: The number of old ReplicaSets, old StatefulSet and old
-                  PersistentVolumeClaim to retain to allow rollback.
+                description: Number of old ReplicaSets, old StatefulSets and old PersistentVolumeClaims
+                  to retain to allow rollback.
                 format: int32
                 type: integer
               serviceAccountName:
                 description: |-
-                  Service Account Name
-                  This associates the ReplicaSet or StatefulSet with the specified Service Account for authentication purposes.
+                  ServiceAccount name.
+                  Managed ReplicaSets and StatefulSets are associated with the specified ServiceAccount for authentication purposes.
                   More info: https://kubernetes.io/docs/concepts/security/service-accounts
                 type: string
               updateStrategy:
                 default:
-                  evacuationStrategy:
-                    connEvictRate: 1000
-                    sessEvictRate: 1000
-                    waitTakeover: 10
-                  initialDelaySeconds: 10
                   type: Recreate
-                description: UpdateStrategy is the object that describes the EMQX
-                  blue-green update strategy
+                description: Cluster upgrade strategy settings.
                 properties:
                   evacuationStrategy:
-                    description: Evacuation strategy.
+                    description: Evacuation strategy settings.
                     properties:
                       connEvictRate:
                         default: 1000
@@ -16003,12 +15976,16 @@ spec:
                         type: integer
                     type: object
                   initialDelaySeconds:
-                    description: Number of seconds before evacuation connection start.
+                    default: 10
+                    description: Number of seconds before connection evacuation starts.
                     format: int32
                     minimum: 0
                     type: integer
                   type:
                     default: Recreate
+                    description: |-
+                      Determines how cluster upgrade is performed.
+                      * `Recreate`: Perform blue-green upgrade.
                     enum:
                     - Recreate
                     type: string
@@ -16017,11 +15994,11 @@ spec:
             - image
             type: object
           status:
-            description: EMQXStatus defines the observed state of EMQX
+            description: Current status of the EMQX cluster.
             properties:
               conditions:
-                description: Represents the latest available observations of a EMQX
-                  Custom Resource current state.
+                description: Conditions representing the current status of the EMQX
+                  Custom Resource.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -16081,6 +16058,7 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               coreNodes:
+                description: Status of each core node in the cluster.
                 items:
                   properties:
                     connections:
@@ -16118,29 +16096,39 @@ spec:
                   type: object
                 type: array
               coreNodesStatus:
+                description: Summary status of the set of core nodes.
                 properties:
                   collisionCount:
                     format: int32
                     type: integer
                   currentReplicas:
+                    description: Number of replicas running current revision.
                     format: int32
                     type: integer
                   currentRevision:
+                    description: Current revision of the respective core or replicant
+                      set.
                     type: string
                   readyReplicas:
+                    description: Number of ready replicas.
                     format: int32
                     type: integer
                   replicas:
+                    description: Total number of replicas.
                     format: int32
                     type: integer
                   updateReplicas:
+                    description: Number of replicas running update revision.
                     format: int32
                     type: integer
                   updateRevision:
+                    description: |-
+                      Update revision of the respective core or replicant set.
+                      When different from the current revision, the set is being updated.
                     type: string
                 type: object
               dsReplication:
-                description: Summary of DS replication status per database.
+                description: Status of EMQX Durable Storage replication.
                 properties:
                   dbs:
                     items:
@@ -16188,9 +16176,11 @@ spec:
                     type: array
                 type: object
               nodeEvacuationsStatus:
+                description: Status of active node evacuations in the cluster.
                 items:
                   properties:
                     connectionEvictionRate:
+                      description: Connection eviction rate, in connections per second.
                       format: int32
                       type: integer
                     initialConnections:
@@ -16206,6 +16196,7 @@ spec:
                       example: emqx@10.0.0.1
                       type: string
                     sessionEvictionRate:
+                      description: Session eviction rate, in sessions per second.
                       format: int32
                       type: integer
                     sessionRecipients:
@@ -16223,6 +16214,7 @@ spec:
                   type: object
                 type: array
               replicantNodes:
+                description: Status of each replicant node in the cluster.
                 items:
                   properties:
                     connections:
@@ -16260,25 +16252,35 @@ spec:
                   type: object
                 type: array
               replicantNodesStatus:
+                description: Summary status of the set of replicant nodes.
                 properties:
                   collisionCount:
                     format: int32
                     type: integer
                   currentReplicas:
+                    description: Number of replicas running current revision.
                     format: int32
                     type: integer
                   currentRevision:
+                    description: Current revision of the respective core or replicant
+                      set.
                     type: string
                   readyReplicas:
+                    description: Number of ready replicas.
                     format: int32
                     type: integer
                   replicas:
+                    description: Total number of replicas.
                     format: int32
                     type: integer
                   updateReplicas:
+                    description: Number of replicas running update revision.
                     format: int32
                     type: integer
                   updateRevision:
+                    description: |-
+                      Update revision of the respective core or replicant set.
+                      When different from the current revision, the set is being updated.
                     type: string
                 type: object
             type: object

--- a/crd-ref-docs-config.yaml
+++ b/crd-ref-docs-config.yaml
@@ -1,0 +1,8 @@
+processor:
+  ignoreFields:
+    - "TypeMeta$"
+  ignoreTypes:
+    - "EMQXList$"
+
+render:
+  kubernetesVersion: 1.32

--- a/docs/en_US/reference/overview.md
+++ b/docs/en_US/reference/overview.md
@@ -1,0 +1,4 @@
+# API Reference
+
++ [apps.emqx.io/v2](./v2-reference.md)
++ [apps.emqx.io/v2beta1](./v2beta1-reference.md) (partially deprecated)

--- a/docs/en_US/reference/v2-reference.md
+++ b/docs/en_US/reference/v2-reference.md
@@ -1,0 +1,427 @@
+# API Reference
+
+## Packages
+- [apps.emqx.io/v2](#appsemqxiov2)
+
+
+## apps.emqx.io/v2
+
+package v2 contains API Schema definitions for the apps v2 API group.
+
+### Resource Types
+- [EMQX](#emqx)
+
+
+
+#### BootstrapAPIKey
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXSpec](#emqxspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `key` _string_ |  |  | Pattern: `^[a-zA-Z\d-_]+$` <br /> |
+| `secret` _string_ |  |  | MaxLength: 128 <br />MinLength: 3 <br /> |
+| `secretRef` _[SecretRef](#secretref)_ | Reference to a Secret entry containing the EMQX API Key. |  |  |
+
+
+#### Config
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXSpec](#emqxspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `mode` _string_ | Determines how configuration updates are applied.<br />* `Merge`: Merge the new configuration into the existing configuration.<br />* `Replace`: Replace the whole configuration. | Merge | Enum: [Merge Replace] <br /> |
+| `data` _string_ | EMQX configuration, in HOCON format.<br />This configuration will be supplied as `base.hocon` to the container. See respective<br />[documentation](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#base-configuration-file). |  |  |
+
+
+#### DSDBReplicationStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [DSReplicationStatus](#dsreplicationstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the database |  |  |
+| `numShards` _integer_ | Number of shards of the database |  |  |
+| `numShardReplicas` _integer_ | Total number of shard replicas |  |  |
+| `lostShardReplicas` _integer_ | Total number of shard replicas belonging to lost sites |  |  |
+| `numTransitions` _integer_ | Current number of shard ownership transitions |  |  |
+| `minReplicas` _integer_ | Minimum replication factor among database shards |  |  |
+| `maxReplicas` _integer_ | Maximum replication factor among database shards |  |  |
+
+
+#### DSReplicationStatus
+
+
+
+Summary of DS replication status per database.
+
+
+
+_Appears in:_
+- [EMQXStatus](#emqxstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `dbs` _[DSDBReplicationStatus](#dsdbreplicationstatus) array_ |  |  |  |
+
+
+#### EMQX
+
+
+
+Custom Resource representing an EMQX cluster.
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `apps.emqx.io/v2` | | |
+| `kind` _string_ | `EMQX` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[EMQXSpec](#emqxspec)_ | Specification of the desired state of the EMQX cluster. |  |  |
+| `status` _[EMQXStatus](#emqxstatus)_ | Current status of the EMQX cluster. |  |  |
+
+
+#### EMQXCoreTemplate
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXSpec](#emqxspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[EMQXCoreTemplateSpec](#emqxcoretemplatespec)_ | Specification of the desired state of a core node.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status |  |  |
+
+
+#### EMQXCoreTemplateSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXCoreTemplate](#emqxcoretemplate)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `nodeSelector` _object (keys:string, values:string)_ | Selector which must be true for the pod to fit on a node.<br />Must match a node's labels for the pod to be scheduled on that node.<br />More info: https://kubernetes.io/docs/concepts/config/assign-pod-node/ |  |  |
+| `nodeName` _string_ | Request to schedule this pod onto a specific node.<br />If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements. |  |  |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | Affinity for pod assignment<br />ref: https://kubernetes.io/docs/concepts/config/assign-pod-node/#affinity-and-anti-affinity |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | Pod tolerations.<br />If specified, Pod tolerates any taint that matches the triple <key,value,effect> using the matching operator. |  |  |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | Specifies how to spread matching pods among the given topology. |  |  |
+| `replicas` _integer_ | Desired number of instances.<br />In case of core nodes, each instance has a consistent identity. | 2 | Minimum: 0 <br /> |
+| `minAvailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#intorstring-intstr-util)_ | An eviction is allowed if at least "minAvailable" pods selected by<br />"selector" will still be available after the eviction, i.e. even in the<br />absence of the evicted pod.  So for example you can prevent all voluntary<br />evictions by specifying "100%". |  | XIntOrString: \{\} <br /> |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#intorstring-intstr-util)_ | An eviction is allowed if at most "maxUnavailable" pods selected by<br />"selector" are unavailable after the eviction, i.e. even in absence of<br />the evicted pod. For example, one can prevent all voluntary evictions<br />by specifying 0. This is a mutually exclusive setting with "minAvailable". |  | XIntOrString: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The container image's ENTRYPOINT is used if this is not provided.<br />Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced<br />to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will<br />produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  |  |
+| `args` _string array_ | Arguments to the entrypoint.<br />The container image's CMD is used if this is not provided.<br />Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced<br />to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will<br />produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless<br />of whether the variable exists or not.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  |  |
+| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#containerport-v1-core) array_ | List of ports to expose from the container.<br />Exposing a port here gives the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that<br />port from being exposed. Any port which is listening on the default `0.0.0.0` address inside a<br />container will be accessible from the network. |  |  |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#envvar-v1-core) array_ | List of environment variables to set in the container. |  |  |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#envfromsource-v1-core) array_ | List of sources to populate environment variables from in the container.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence. |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | Compute Resources required by this container.<br />More info: https://kubernetes.io/docs/concepts/config/manage-resources-containers/ |  |  |
+| `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core)_ | Pod-level security attributes and common container settings. | \{ fsGroup:1000 fsGroupChangePolicy:Always runAsGroup:1000 runAsUser:1000 supplementalGroups:[1000] \} |  |
+| `containerSecurityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core)_ | Security options the container should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ | \{ runAsGroup:1000 runAsNonRoot:true runAsUser:1000 \} |  |
+| `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#container-v1-core) array_ | List of initialization containers belonging to the pod.<br />Init containers are executed in order prior to containers being started. If any<br />init container fails, the pod is considered to have failed and is handled according<br />to its restartPolicy. The name for an init container or normal container must be<br />unique among all containers.<br />Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.<br />The resourceRequirements of an init container are taken into account during scheduling<br />by finding the highest request/limit for each resource type, and then using the max of<br />of that value or the sum of the normal containers. Limits are applied to init containers<br />in a similar fashion.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ |  |  |
+| `extraContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#container-v1-core) array_ | Additional containers to run alongside the main container. |  |  |
+| `extraVolumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volume-v1-core) array_ | Additional volumes to provide to a Pod. |  |  |
+| `extraVolumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volumemount-v1-core) array_ | Specifies how additional volumes are mounted into the main container. |  |  |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#probe-v1-core)_ | Periodic probe of container liveness.<br />Container will be restarted if the probe fails.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes | \{ failureThreshold:3 httpGet:map[path:/status port:dashboard] initialDelaySeconds:60 periodSeconds:30 \} |  |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#probe-v1-core)_ | Periodic probe of container service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes | \{ failureThreshold:12 httpGet:map[path:/status port:dashboard] initialDelaySeconds:10 periodSeconds:5 \} |  |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#probe-v1-core)_ | StartupProbe indicates that the Pod has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the `livenessProbe` failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  |  |
+| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#lifecycle-v1-core)_ | Actions that the management system should take in response to container lifecycle events. |  |  |
+| `volumeClaimTemplates` _[PersistentVolumeClaimSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#persistentvolumeclaimspec-v1-core)_ | PVC specification for a core node data storage.<br />Note: this field named inconsistently, it is actually just a `PersistentVolumeClaimSpec`. |  |  |
+
+
+#### EMQXNode
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXStatus](#emqxstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Node name |  |  |
+| `podName` _string_ | Corresponding pod name |  |  |
+| `status` _string_ | Node status |  |  |
+| `otpRelease` _string_ | Erlang/OTP version node is running on |  |  |
+| `version` _string_ | EMQX version |  |  |
+| `role` _string_ | Node role, either "core" or "replicant" |  |  |
+| `sessions` _integer_ | Number of MQTT sessions |  |  |
+| `connections` _integer_ | Number of connected MQTT clients |  |  |
+
+
+#### EMQXNodesStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXStatus](#emqxstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `replicas` _integer_ | Total number of replicas. |  |  |
+| `readyReplicas` _integer_ | Number of ready replicas. |  |  |
+| `currentRevision` _string_ | Current revision of the respective core or replicant set. |  |  |
+| `currentReplicas` _integer_ | Number of replicas running current revision. |  |  |
+| `updateRevision` _string_ | Update revision of the respective core or replicant set.<br />When different from the current revision, the set is being updated. |  |  |
+| `updateReplicas` _integer_ | Number of replicas running update revision. |  |  |
+| `collisionCount` _integer_ |  |  |  |
+
+
+#### EMQXReplicantTemplate
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXSpec](#emqxspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[EMQXReplicantTemplateSpec](#emqxreplicanttemplatespec)_ | Specification of the desired state of a replicant node.<br />More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status |  |  |
+
+
+#### EMQXReplicantTemplateSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXCoreTemplateSpec](#emqxcoretemplatespec)
+- [EMQXReplicantTemplate](#emqxreplicanttemplate)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `nodeSelector` _object (keys:string, values:string)_ | Selector which must be true for the pod to fit on a node.<br />Must match a node's labels for the pod to be scheduled on that node.<br />More info: https://kubernetes.io/docs/concepts/config/assign-pod-node/ |  |  |
+| `nodeName` _string_ | Request to schedule this pod onto a specific node.<br />If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements. |  |  |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#affinity-v1-core)_ | Affinity for pod assignment<br />ref: https://kubernetes.io/docs/concepts/config/assign-pod-node/#affinity-and-anti-affinity |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | Pod tolerations.<br />If specified, Pod tolerates any taint that matches the triple <key,value,effect> using the matching operator. |  |  |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#topologyspreadconstraint-v1-core) array_ | Specifies how to spread matching pods among the given topology. |  |  |
+| `replicas` _integer_ | Desired number of instances.<br />In case of core nodes, each instance has a consistent identity. | 2 | Minimum: 0 <br /> |
+| `minAvailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#intorstring-intstr-util)_ | An eviction is allowed if at least "minAvailable" pods selected by<br />"selector" will still be available after the eviction, i.e. even in the<br />absence of the evicted pod.  So for example you can prevent all voluntary<br />evictions by specifying "100%". |  | XIntOrString: \{\} <br /> |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#intorstring-intstr-util)_ | An eviction is allowed if at most "maxUnavailable" pods selected by<br />"selector" are unavailable after the eviction, i.e. even in absence of<br />the evicted pod. For example, one can prevent all voluntary evictions<br />by specifying 0. This is a mutually exclusive setting with "minAvailable". |  | XIntOrString: \{\} <br /> |
+| `command` _string array_ | Entrypoint array. Not executed within a shell.<br />The container image's ENTRYPOINT is used if this is not provided.<br />Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced<br />to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will<br />produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless<br />of whether the variable exists or not. Cannot be updated.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  |  |
+| `args` _string array_ | Arguments to the entrypoint.<br />The container image's CMD is used if this is not provided.<br />Variable references `$(VAR_NAME)` are expanded using the container's environment. If a variable<br />cannot be resolved, the reference in the input string will be unchanged. Double `$$` are reduced<br />to a single `$`, which allows for escaping the `$(VAR_NAME)` syntax: i.e. `$$(VAR_NAME)` will<br />produce the string literal `$(VAR_NAME)`. Escaped references will never be expanded, regardless<br />of whether the variable exists or not.<br />More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell |  |  |
+| `ports` _[ContainerPort](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#containerport-v1-core) array_ | List of ports to expose from the container.<br />Exposing a port here gives the system additional information about the network connections a<br />container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that<br />port from being exposed. Any port which is listening on the default `0.0.0.0` address inside a<br />container will be accessible from the network. |  |  |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#envvar-v1-core) array_ | List of environment variables to set in the container. |  |  |
+| `envFrom` _[EnvFromSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#envfromsource-v1-core) array_ | List of sources to populate environment variables from in the container.<br />The keys defined within a source must be a C_IDENTIFIER. All invalid keys<br />will be reported as an event when the container is starting. When a key exists in multiple<br />sources, the value associated with the last source will take precedence.<br />Values defined by an Env with a duplicate key will take precedence. |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | Compute Resources required by this container.<br />More info: https://kubernetes.io/docs/concepts/config/manage-resources-containers/ |  |  |
+| `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#podsecuritycontext-v1-core)_ | Pod-level security attributes and common container settings. | \{ fsGroup:1000 fsGroupChangePolicy:Always runAsGroup:1000 runAsUser:1000 supplementalGroups:[1000] \} |  |
+| `containerSecurityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#securitycontext-v1-core)_ | Security options the container should be run with.<br />If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.<br />More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ | \{ runAsGroup:1000 runAsNonRoot:true runAsUser:1000 \} |  |
+| `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#container-v1-core) array_ | List of initialization containers belonging to the pod.<br />Init containers are executed in order prior to containers being started. If any<br />init container fails, the pod is considered to have failed and is handled according<br />to its restartPolicy. The name for an init container or normal container must be<br />unique among all containers.<br />Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.<br />The resourceRequirements of an init container are taken into account during scheduling<br />by finding the highest request/limit for each resource type, and then using the max of<br />of that value or the sum of the normal containers. Limits are applied to init containers<br />in a similar fashion.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/ |  |  |
+| `extraContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#container-v1-core) array_ | Additional containers to run alongside the main container. |  |  |
+| `extraVolumes` _[Volume](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volume-v1-core) array_ | Additional volumes to provide to a Pod. |  |  |
+| `extraVolumeMounts` _[VolumeMount](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volumemount-v1-core) array_ | Specifies how additional volumes are mounted into the main container. |  |  |
+| `livenessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#probe-v1-core)_ | Periodic probe of container liveness.<br />Container will be restarted if the probe fails.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes | \{ failureThreshold:3 httpGet:map[path:/status port:dashboard] initialDelaySeconds:60 periodSeconds:30 \} |  |
+| `readinessProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#probe-v1-core)_ | Periodic probe of container service readiness.<br />Container will be removed from service endpoints if the probe fails.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes | \{ failureThreshold:12 httpGet:map[path:/status port:dashboard] initialDelaySeconds:10 periodSeconds:5 \} |  |
+| `startupProbe` _[Probe](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#probe-v1-core)_ | StartupProbe indicates that the Pod has successfully initialized.<br />If specified, no other probes are executed until this completes successfully.<br />If this probe fails, the Pod will be restarted, just as if the `livenessProbe` failed.<br />This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,<br />when it might take a long time to load data or warm a cache, than during steady-state operation.<br />More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes |  |  |
+| `lifecycle` _[Lifecycle](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#lifecycle-v1-core)_ | Actions that the management system should take in response to container lifecycle events. |  |  |
+
+
+#### EMQXSpec
+
+
+
+EMQXSpec defines the desired state of EMQX.
+
+
+
+_Appears in:_
+- [EMQX](#emqx)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ | EMQX container image.<br />More info: https://kubernetes.io/docs/concepts/containers/images |  |  |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#pullpolicy-v1-core)_ | Container image pull policy.<br />One of `Always`, `Never`, `IfNotPresent`.<br />Defaults to `Always` if `:latest` tag is specified, or `IfNotPresent` otherwise.<br />More info: https://kubernetes.io/docs/concepts/containers/images#updating-images |  |  |
+| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#localobjectreference-v1-core) array_ | ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.<br />If specified, these secrets will be passed to individual puller implementations for them to use.<br />More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod |  |  |
+| `serviceAccountName` _string_ | ServiceAccount name.<br />Managed ReplicaSets and StatefulSets are associated with the specified ServiceAccount for authentication purposes.<br />More info: https://kubernetes.io/docs/concepts/security/service-accounts |  |  |
+| `bootstrapAPIKeys` _[BootstrapAPIKey](#bootstrapapikey) array_ | Bootstrap API keys to access EMQX API.<br />Cannot be updated. |  |  |
+| `config` _[Config](#config)_ | EMQX Configuration. |  |  |
+| `clusterDomain` _string_ | Kubernetes cluster domain. | cluster.local |  |
+| `revisionHistoryLimit` _integer_ | Number of old ReplicaSets, old StatefulSets and old PersistentVolumeClaims to retain to allow rollback. | 3 |  |
+| `updateStrategy` _[UpdateStrategy](#updatestrategy)_ | Cluster upgrade strategy settings. | \{ type:Recreate \} |  |
+| `coreTemplate` _[EMQXCoreTemplate](#emqxcoretemplate)_ | Template for Pods running EMQX core nodes. | \{ spec:map[replicas:2] \} |  |
+| `replicantTemplate` _[EMQXReplicantTemplate](#emqxreplicanttemplate)_ | Template for Pods running EMQX replicant nodes. |  |  |
+| `dashboardServiceTemplate` _[ServiceTemplate](#servicetemplate)_ | Template for Service exposing the EMQX Dashboard.<br />Dashboard Service always points to the set of EMQX core nodes. |  |  |
+| `listenersServiceTemplate` _[ServiceTemplate](#servicetemplate)_ | Template for Service exposing enabled EMQX listeners.<br />Listeners Service points to the set of EMQX replicant nodes if they are enabled and exist.<br />Otherwise, it points to the set of EMQX core nodes. |  |  |
+
+
+#### EMQXStatus
+
+
+
+EMQXStatus defines the observed state of EMQX
+
+
+
+_Appears in:_
+- [EMQX](#emqx)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#condition-v1-meta) array_ | Conditions representing the current status of the EMQX Custom Resource. |  |  |
+| `coreNodes` _[EMQXNode](#emqxnode) array_ | Status of each core node in the cluster. |  |  |
+| `coreNodesStatus` _[EMQXNodesStatus](#emqxnodesstatus)_ | Summary status of the set of core nodes. |  |  |
+| `replicantNodes` _[EMQXNode](#emqxnode) array_ | Status of each replicant node in the cluster. |  |  |
+| `replicantNodesStatus` _[EMQXNodesStatus](#emqxnodesstatus)_ | Summary status of the set of replicant nodes. |  |  |
+| `nodeEvacuationsStatus` _[NodeEvacuationStatus](#nodeevacuationstatus) array_ | Status of active node evacuations in the cluster. |  |  |
+| `dsReplication` _[DSReplicationStatus](#dsreplicationstatus)_ | Status of EMQX Durable Storage replication. |  |  |
+
+
+#### EvacuationStrategy
+
+
+
+
+
+
+
+_Appears in:_
+- [UpdateStrategy](#updatestrategy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `connEvictRate` _integer_ | Client disconnect rate (number per second).<br />Same as `conn-evict-rate` in [EMQX Node Evacuation](https://docs.emqx.com/en/emqx/v5.10/deploy/cluster/rebalancing.html#node-evacuation). | 1000 | Minimum: 1 <br /> |
+| `sessEvictRate` _integer_ | Session evacuation rate (number per second).<br />Same as `sess-evict-rate` in [EMQX Node Evacuation](https://docs.emqx.com/en/emqx/v5.10/deploy/cluster/rebalancing.html#node-evacuation). | 1000 | Minimum: 1 <br /> |
+| `waitTakeover` _integer_ | Amount of time (in seconds) to wait before starting session evacuation.<br />Same as `wait-takeover` in [EMQX Node Evacuation](https://docs.emqx.com/en/emqx/v5.10/deploy/cluster/rebalancing.html#node-evacuation). | 10 | Minimum: 0 <br /> |
+| `waitHealthCheck` _integer_ | Duration (in seconds) during which the node waits for the Load Balancer to remove it from the active backend node list.<br />Same as `wait-health-check` in [EMQX Node Evacuation](https://docs.emqx.com/en/emqx/v5.10/deploy/cluster/rebalancing.html#node-evacuation). | 60 | Minimum: 0 <br /> |
+
+
+#### KeyRef
+
+
+
+
+
+
+
+_Appears in:_
+- [SecretRef](#secretref)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `secretName` _string_ | Name of the Secret object. |  |  |
+| `secretKey` _string_ | Entry within the Secret data. |  | Pattern: `^[a-zA-Z\d-_]+$` <br /> |
+
+
+#### NodeEvacuationStatus
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXStatus](#emqxstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `nodeName` _string_ | Evacuated node name |  |  |
+| `state` _string_ | Evacuation state |  |  |
+| `sessionRecipients` _string array_ | Session recipients |  |  |
+| `sessionEvictionRate` _integer_ | Session eviction rate, in sessions per second. |  |  |
+| `connectionEvictionRate` _integer_ | Connection eviction rate, in connections per second. |  |  |
+| `initialSessions` _integer_ | Initial number of sessions on this node |  |  |
+| `initialConnections` _integer_ | Initial number of connections to this node |  |  |
+
+
+#### SecretRef
+
+
+
+
+
+
+
+_Appears in:_
+- [BootstrapAPIKey](#bootstrapapikey)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `key` _[KeyRef](#keyref)_ | Reference to a Secret entry containing the EMQX API Key. |  |  |
+| `secret` _[KeyRef](#keyref)_ | Reference to a Secret entry containing the EMQX API Key's secret. |  |  |
+
+
+#### ServiceTemplate
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXSpec](#emqxspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | Specifies whether the Service should be created. | true |  |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[ServiceSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#servicespec-v1-core)_ | Specification of the desired state of a Service.<br />https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status |  |  |
+
+
+#### UpdateStrategy
+
+
+
+
+
+
+
+_Appears in:_
+- [EMQXSpec](#emqxspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _string_ | Determines how cluster upgrade is performed.<br />* `Recreate`: Perform blue-green upgrade. | Recreate | Enum: [Recreate] <br /> |
+| `initialDelaySeconds` _integer_ | Number of seconds before connection evacuation starts. | 10 | Minimum: 0 <br /> |
+| `evacuationStrategy` _[EvacuationStrategy](#evacuationstrategy)_ | Evacuation strategy settings. |  |  |
+
+


### PR DESCRIPTION
* Keep the `apps.emqx.io/v2` auto-generated CRD reference in the tree.