### PR TITLE
chore: fix `setup-go` action version ref

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: azure/setup-helm@v5
 
-      - uses: actions/setup-go@v6.4
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 


### PR DESCRIPTION
https://github.com/emqx/emqx-operator/actions/runs/23897019187/job/69684102999

> Error: Unable to resolve action `actions/setup-go@v6.4`, unable to find version `v6.4`