### PR TITLE
feat(scale): fix subresource compatibility + HPA integration

### DIFF
--- a/api/v3alpha1/emqx_types.go
+++ b/api/v3alpha1/emqx_types.go
@@ -23,7 +23,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=emqx,path=emqxes
-// +kubebuilder:subresource:scale:specpath=.spec.replicantTemplate.spec.replicas,statuspath=.status.replicantNodeReplicas
+// +kubebuilder:subresource:scale:specpath=.spec.replicantTemplate.spec.replicas,statuspath=.status.replicantReplicas,selectorpath=.status.replicantSelector
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.status==\"True\")].type"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 

--- a/api/v3alpha1/emqx_types_status.go
+++ b/api/v3alpha1/emqx_types_status.go
@@ -29,6 +29,20 @@ type EMQXStatus struct {
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
+	// Observed replica count for the core set.
+	CoreReplicas int32 `json:"coreReplicas"`
+
+	// Serialized label selector matching core pods.
+	CoreSelector string `json:"coreSelector,omitempty"`
+
+	// Observed replica count for the replicant set pods.
+	// Used by the scale subresource.
+	ReplicantReplicas int32 `json:"replicantReplicas"`
+
+	// Serialized label selector matching replicant pods.
+	// Used by the scale subresource for HPA pod discovery.
+	ReplicantSelector string `json:"replicantSelector,omitempty"`
+
 	// Status of each core node in the cluster.
 	CoreNodes []EMQXNode `json:"coreNodes,omitempty"`
 	// Summary status of the set of core nodes.

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -16193,6 +16193,13 @@ spec:
                 - readyReplicas
                 - updatedReplicas
                 type: object
+              coreReplicas:
+                description: Observed replica count for the core set.
+                format: int32
+                type: integer
+              coreSelector:
+                description: Serialized label selector matching core pods.
+                type: string
               dsReplication:
                 description: Status of EMQX Durable Storage replication.
                 properties:
@@ -16351,12 +16358,27 @@ spec:
                 - readyReplicas
                 - updateReplicas
                 type: object
+              replicantReplicas:
+                description: |-
+                  Observed replica count for the replicant set pods.
+                  Used by the scale subresource.
+                format: int32
+                type: integer
+              replicantSelector:
+                description: |-
+                  Serialized label selector matching replicant pods.
+                  Used by the scale subresource for HPA pod discovery.
+                type: string
+            required:
+            - coreReplicas
+            - replicantReplicas
             type: object
         type: object
     served: true
     storage: true
     subresources:
       scale:
+        labelSelectorPath: .status.replicantSelector
         specReplicasPath: .spec.replicantTemplate.spec.replicas
-        statusReplicasPath: .status.replicantNodeReplicas
+        statusReplicasPath: .status.replicantReplicas
       status: {}

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -155,8 +155,6 @@ func generateReplicaSet(instance *crd.EMQX) *appsv1.ReplicaSet {
 	template := instance.Spec.ReplicantTemplate
 
 	// Add a PreStop hook to leave the cluster when the pod is asked to stop.
-	// This is especially important when DS Raft is enabled, otherwise there will be a
-	// lot of leftover records in the DS cluster metadata.
 	lifecycle := &corev1.Lifecycle{}
 	if template.Spec.Lifecycle != nil {
 		lifecycle = template.Spec.Lifecycle.DeepCopy()
@@ -167,9 +165,8 @@ func generateReplicaSet(instance *crd.EMQX) *appsv1.ReplicaSet {
 		},
 	}
 
-	readinessProbe := resources.EvacuationReadinessProbe()
-
 	// Prefer evacuation-aware probe over older-version defaults.
+	readinessProbe := resources.EvacuationReadinessProbe()
 	if template.Spec.ReadinessProbe != nil {
 		if template.Spec.ReadinessProbe.HTTPGet != nil &&
 			template.Spec.ReadinessProbe.HTTPGet.Path != "/status" {

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"reflect"
 
 	emperror "emperror.dev/errors"
 	crd "github.com/emqx/emqx-operator/api/v3alpha1"
@@ -28,11 +29,14 @@ type reconcileStatePodFilter interface {
 }
 
 type podsManagedBy struct {
-	metav1.Object
+	manager metav1.Object
 }
 
 func (self podsManagedBy) passes(pod *corev1.Pod) bool {
-	return self.Object != nil && util.IsPodManagedBy(pod, self.Object)
+	if self.manager == nil && reflect.ValueOf(self.manager).IsNil() {
+		return false
+	}
+	return util.IsPodManagedBy(pod, self.manager)
 }
 
 type podsWithRole struct {

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -195,6 +195,14 @@ func (r *reconcileState) outdatedReplicantPods(instance *crd.EMQX) []*corev1.Pod
 	return out
 }
 
+func (r *reconcileState) numReplicants() int32 {
+	out := int32(0)
+	for _, rs := range r.replicantSets {
+		out += rs.Status.Replicas
+	}
+	return out
+}
+
 func (r *reconcileState) numReadyReplicants() int32 {
 	out := int32(0)
 	for _, rs := range r.replicantSets {

--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -45,31 +45,34 @@ func (s *syncReplicantSets) reconcile(r *reconcileRound, instance *crd.EMQX) sub
 	}
 
 	// Steady state: handle scale-up and scale-down.
+	specReplicas := ptr.Deref(updateRs.Spec.Replicas, 0)
 	desiredReplicas := instance.Spec.NumReplicantReplicas()
-	currentReplicas := ptr.Deref(updateRs.Spec.Replicas, 0)
+	currentReplicas := updateRs.Status.Replicas
 
-	if currentReplicas < desiredReplicas {
+	if specReplicas < desiredReplicas {
 		r.log.V(1).Info("scaling up replicantSet",
 			"replicaSet", klog.KObj(updateRs),
-			"from", currentReplicas,
+			"from", specReplicas,
 			"to", desiredReplicas,
 		)
 		return s.scaleUp(r, updateRs, desiredReplicas)
 	}
 
-	if currentReplicas > desiredReplicas {
+	if specReplicas > desiredReplicas {
 		r.log.V(1).Info("scaling down replicantSet",
 			"replicaSet", klog.KObj(updateRs),
-			"from", currentReplicas,
+			"from", specReplicas,
 			"to", desiredReplicas,
 		)
-		return s.scaleDown(r, instance, updateRs, currentReplicas, desiredReplicas)
+		return s.scaleDown(r, instance, updateRs, specReplicas, desiredReplicas)
 	}
 
 	// Steady state: clean up stale artifacts.
-	err := s.ensureConsistency(r, instance, updateRs)
-	if err != nil {
-		return reconcileError(emperror.Wrap(err, "failed to restore replicant consistency"))
+	if currentReplicas == specReplicas {
+		err := s.ensureConsistency(r, instance, updateRs)
+		if err != nil {
+			return reconcileError(emperror.Wrap(err, "failed to restore replicant consistency"))
+		}
 	}
 
 	return subResult{}
@@ -142,7 +145,7 @@ func (s *syncReplicantSets) ensureConsistency(
 	instance *crd.EMQX,
 	updateRs *appsv1.ReplicaSet,
 ) error {
-	for _, pod := range r.state.podsManagedBy(updateRs) {
+	for _, pod := range r.state.listPods(podsManagedBy{updateRs}, podsAlive{}) {
 		// 1. Check if pod has stale scale-down annotations.
 		dirty := s.removeStaleReplicantAnnotations(pod)
 		if !dirty {

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -25,12 +25,14 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 	coreSet := r.state.coreSet()
 	status.CoreNodesStatus.UpdatedReplicas = 0
 	status.CoreNodesStatus.CurrentReplicas = 0
-	for _, pod := range r.state.podsManagedBy(r.state.coreSet()) {
-		if r.state.partOfCoreSetRevision(pod, coreSet.Status.UpdateRevision) {
-			status.CoreNodesStatus.UpdatedReplicas++
-		}
-		if r.state.partOfCoreSetRevision(pod, coreSet.Status.CurrentRevision) {
-			status.CoreNodesStatus.CurrentReplicas++
+	if coreSet != nil {
+		for _, pod := range r.state.podsManagedBy(coreSet) {
+			if r.state.partOfCoreSetRevision(pod, coreSet.Status.UpdateRevision) {
+				status.CoreNodesStatus.UpdatedReplicas++
+			}
+			if r.state.partOfCoreSetRevision(pod, coreSet.Status.CurrentRevision) {
+				status.CoreNodesStatus.CurrentReplicas++
+			}
 		}
 	}
 

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/emqx/emqx-operator/internal/emqx/api"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 )
 
@@ -23,6 +24,8 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 
 	// Core: count pods on each revision for rolling update progress.
 	coreSet := r.state.coreSet()
+	status.CoreReplicas = 0
+	status.CoreSelector = labels.Set(instance.DefaultLabelsWith(crd.CoreLabels())).String()
 	status.CoreNodesStatus.UpdatedReplicas = 0
 	status.CoreNodesStatus.CurrentReplicas = 0
 	if coreSet != nil {
@@ -34,6 +37,13 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 				status.CoreNodesStatus.CurrentReplicas++
 			}
 		}
+	}
+
+	status.ReplicantReplicas = 0
+	status.ReplicantSelector = ""
+	if instance.Spec.HasReplicants() {
+		status.ReplicantReplicas = r.state.numReplicants()
+		status.ReplicantSelector = labels.Set(instance.DefaultLabelsWith(crd.ReplicantLabels())).String()
 	}
 
 	// Replicant: multi-ReplicaSet pattern retained.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -85,6 +85,9 @@ var _ = BeforeSuite(func() {
 	By("load emqx-operator docker image into kind cluster")
 	Expect(util.LoadImageToKindClusterWithName(projectImage)).To(Succeed())
 
+	By("install Metrics Server")
+	Expect(util.InstallMetricsServer()).To(Succeed())
+
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with Prometheus or CertManager already installed,
 	// we check for their presence before execution.
@@ -101,7 +104,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	// Teardown Prometheus and CertManager after the suite if not skipped and if they were not already installed
+	util.UnnstallMetricsServer()
 	if !skipPrometheusInstall && isPrometheusInstalled {
 		By("uninstall Prometheus Operator")
 		util.UninstallPrometheusOperator()

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -88,24 +88,15 @@ var _ = BeforeSuite(func() {
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with Prometheus or CertManager already installed,
 	// we check for their presence before execution.
-	// Setup Prometheus and CertManager before the suite if not skipped and if not already installed
 	if !skipPrometheusInstall {
-		if !util.IsPrometheusCRDsInstalled() {
-			By("install Prometheus Operator")
-			Expect(util.InstallPrometheusOperator()).To(Succeed())
-			isPrometheusInstalled = true
-		} else {
-			GinkgoWriter.Println("WARNING: Prometheus Operator is already installed, skipping installation.")
-		}
+		By("install Prometheus Operator")
+		Expect(util.InstallPrometheusOperator()).To(Succeed())
+		isPrometheusInstalled = true
 	}
 	if !skipCertManagerInstall {
-		if !util.IsCertManagerCRDsInstalled() {
-			By("install CertManager")
-			Expect(util.InstallCertManager()).To(Succeed())
-			isCertManagerInstalled = true
-		} else {
-			GinkgoWriter.Println("WARNING: CertManager is already installed, skipping installation.")
-		}
+		By("install CertManager")
+		Expect(util.InstallCertManager()).To(Succeed())
+		isCertManagerInstalled = true
 	}
 })
 

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -725,6 +725,11 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 				withReplicants(replicantReplicas),
 				withReplicantResources("500m", "512Mi", "1", "2Gi"),
 				withConfig(),
+				// Make EMQX react to scaling decisions quicker:
+				[]byte(`
+                {"spec": {"updateStrategy": {
+                    "replicants": {"maxUnavailable": 3, "maxSurge": 1}
+                }}}`),
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -27,6 +29,16 @@ func withReplicants(numReplicas int) []byte {
 	return fmt.Appendf(nil,
 		`{"spec": {"replicantTemplate": {"spec": {"minReadySeconds": 3, "replicas": %d}}}}`,
 		numReplicas,
+	)
+}
+
+func withReplicantResources(cpuRequest, memRequest, cpuLimit, memLimit string) []byte {
+	return fmt.Appendf(nil,
+		`{"spec": {"replicantTemplate": {"spec": {"resources": {
+			"requests": {"cpu": "%s", "memory": "%s"},
+			"limits": {"cpu": "%s", "memory": "%s"}
+		}}}}}`,
+		cpuRequest, memRequest, cpuLimit, memLimit,
 	)
 }
 
@@ -689,6 +701,145 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 		})
 
 		It("delete EMQX cluster", func() {
+			Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
+			Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")
+		})
+
+	})
+
+	Context("EMQX Cluster Scaling / HPA", Label("scale", "hpa"), func() {
+		// Initial number of core and replicant replicas:
+		var coreReplicas int = 2
+		var replicantReplicas int = 2
+
+		const (
+			hpaName = "emqx-replicant"
+		)
+
+		It("deploy core-replicant cluster", func() {
+			By("create EMQX cluster with resource requests for HPA")
+			emqxCR := PatchDocument(
+				FromYAMLFile(emqxCRBasic),
+				withImage(emqxImage),
+				withCores(coreReplicas),
+				withReplicants(replicantReplicas),
+				withReplicantResources("500m", "512Mi", "1", "2Gi"),
+				withConfig(),
+			)
+			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
+			By("wait for EMQX cluster to be ready")
+			Eventually(checkEMQXReady).Should(Succeed())
+			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+		})
+
+		It("scale subresource reports correct replica counts and selector", func() {
+			By("read the scale subresource via kubectl")
+			var scale autoscalingv1.Scale
+			Eventually(KubectlOut).WithArguments(
+				"get", "--raw", "/apis/apps.emqx.io/v3alpha1/namespaces/default/emqxes/emqx/scale",
+			).Should(BeUnmarshalledAs(&scale, And(
+				HaveField("Spec.Replicas", BeEquivalentTo(replicantReplicas)),
+				HaveField("Status.Replicas", BeEquivalentTo(replicantReplicas)),
+				HaveField("Status.Selector", Not(BeEmpty())),
+			)), "Scale subresource should report replicant replica counts and a non-empty selector")
+
+			By("verify the selector matches replicant pods")
+			Expect(scale.Status.Selector).To(
+				ContainSubstring(crd.LabelDBRole+"=replicant"),
+				"Scale selector should include the replicant role label",
+			)
+			Expect(scale.Status.Selector).To(
+				ContainSubstring(crd.LabelInstance+"=emqx"),
+				"Scale selector should include the instance label",
+			)
+
+			By("verify replicant pods match the scale selector")
+			var podList corev1.PodList
+			Expect(KubectlOut("get", "pods",
+				"--selector", scale.Status.Selector,
+				"-o", "json",
+			)).To(UnmarshalInto(&podList), "Failed to list pods matching scale selector")
+			Expect(podList.Items).To(
+				HaveLen(replicantReplicas),
+				"Scale selector should match exactly %d replicant pods", replicantReplicas,
+			)
+		})
+
+		It("kubectl scale changes replicant replica count", func() {
+			newReplicas := 4
+			By("scale replicants via kubectl scale")
+			Expect(Kubectl("scale", "emqx", "emqx", "--replicas="+fmt.Sprint(newReplicas))).
+				To(Succeed(), "kubectl scale should succeed")
+
+			By("wait for EMQX cluster to be ready after scaling")
+			Eventually(checkEMQXReady).Should(Succeed())
+			Eventually(checkReplicantStatus).WithArguments(newReplicas).Should(Succeed())
+
+			By("verify scale subresource reflects the new replica count")
+			var scale autoscalingv1.Scale
+			Eventually(KubectlOut).WithArguments(
+				"get", "--raw", "/apis/apps.emqx.io/v3alpha1/namespaces/default/emqxes/emqx/scale",
+			).Should(BeUnmarshalledAs(&scale, And(
+				HaveField("Spec.Replicas", BeEquivalentTo(newReplicas)),
+				HaveField("Status.Replicas", BeEquivalentTo(newReplicas)),
+			)), "Scale subresource should reflect the new replica count after kubectl scale")
+
+			replicantReplicas = newReplicas
+		})
+
+		It("create HPA targeting replicants", func() {
+			By("create a HorizontalPodAutoscaler")
+			hpaCreatedAt := metav1.Now()
+			minReplicas := 1
+			maxReplicas := 6
+			hpa := FromYAMLString(`
+			apiVersion: autoscaling/v2
+			kind: HorizontalPodAutoscaler
+			metadata:
+			  name: ` + hpaName + `
+			spec:
+			  minReplicas: ` + fmt.Sprint(minReplicas) + `
+			  maxReplicas: ` + fmt.Sprint(maxReplicas) + `
+			  scaleTargetRef:
+			    apiVersion: apps.emqx.io/v3alpha1
+			    kind: EMQX
+			    name: emqx
+			  metrics:
+			  - type: Resource
+			    resource:
+			      name: cpu
+			      target:
+			        averageUtilization: 80
+			        type: Utilization
+			  behavior:
+			    scaleUp:
+				  stabilizationWindowSeconds: 0
+			    scaleDown:
+				  stabilizationWindowSeconds: 30
+			`)
+			Expect(KubectlStdin(hpa, "apply", "-f", "-")).To(Succeed(), "Failed to create HPA")
+
+			By("verify HPA can read the scale subresource")
+			var hpaOut autoscalingv2.HorizontalPodAutoscaler
+			Eventually(KubectlOut).WithArguments("get", "hpa", hpaName, "-o", "json").
+				Should(BeUnmarshalledAs(&hpaOut, And(
+					HaveField("Status.DesiredReplicas", BeEquivalentTo(replicantReplicas)),
+					HaveField("Status.CurrentReplicas", BeEquivalentTo(replicantReplicas)),
+				)), "HPA should observe current replicant replica count via scale subresource")
+
+			By("verify HPA eventually scales replicants down")
+			Eventually(KubectlOut).WithArguments("get", "hpa", hpaName, "-o", "json").
+				Should(BeUnmarshalledAs(&hpaOut,
+					HaveField("Status.CurrentReplicas", BeEquivalentTo(minReplicas)),
+				), "HPA should scale replicant set down")
+
+			Eventually(checkEMQXReady).WithArguments(hpaCreatedAt).Should(Succeed())
+			Eventually(checkReplicantStatus).WithArguments(minReplicas).Should(Succeed())
+		})
+
+		It("delete cluster and HPA", func() {
+			Expect(Kubectl("delete", "hpa", hpaName)).To(Succeed())
 			Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
 			Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")
 		})

--- a/test/e2e/files/resources/metrics-server.yaml
+++ b/test/e2e/files/resources/metrics-server.yaml
@@ -1,0 +1,206 @@
+# Source:
+# https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.1/components.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  ports:
+  - appProtocol: https
+    name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
+    spec:
+      containers:
+      - args:
+        - --cert-dir=/tmp
+        - --secure-port=10250
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        - --kubelet-use-node-status-port
+        - --metric-resolution=15s
+        # Flags required to work under Kind:
+        - --kubelet-insecure-tls
+        image: registry.k8s.io/metrics-server/metrics-server:v0.8.1
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+        name: metrics-server
+        ports:
+        - containerPort: 10250
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 20
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+      - emptyDir: {}
+        name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -34,10 +34,11 @@ import (
 const (
 	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
-		"releases/download/%s/bundle.yaml"
+		"releases/download/" + prometheusOperatorVersion + "/bundle.yaml"
 
 	certmanagerVersion = "v1.16.0"
-	certmanagerURLTmpl = "https://github.com/jetstack/cert-manager/releases/download/%s/cert-manager.yaml"
+	certmanagerURL     = "https://github.com/jetstack/cert-manager/" +
+		"releases/download/" + certmanagerVersion + "/cert-manager.yaml"
 )
 
 func warnError(err error) {
@@ -139,49 +140,12 @@ func PatchDocument(document []byte, patches ...[]byte) []byte {
 
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
 func InstallPrometheusOperator() error {
-	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	return Kubectl("create", "-f", url)
+	return Kubectl("create", "-f", prometheusOperatorURL)
 }
 
 // UninstallPrometheusOperator uninstalls the prometheus
 func UninstallPrometheusOperator() {
-	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	err := Kubectl("delete", "-f", url)
-	if err != nil {
-		warnError(err)
-	}
-}
-
-// IsPrometheusCRDsInstalled checks if any Prometheus CRDs are installed
-// by verifying the existence of key CRDs related to Prometheus.
-func IsPrometheusCRDsInstalled() bool {
-	// List of common Prometheus CRDs
-	prometheusCRDs := []string{
-		"prometheuses.monitoring.coreos.com",
-		"prometheusrules.monitoring.coreos.com",
-		"prometheusagents.monitoring.coreos.com",
-	}
-
-	output, err := KubectlOut("get", "crds", "-o", "custom-columns=NAME:.metadata.name")
-	if err != nil {
-		return false
-	}
-	crdList := GetNonEmptyLines(output)
-	for _, crd := range prometheusCRDs {
-		for _, line := range crdList {
-			if strings.Contains(line, crd) {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// UninstallCertManager uninstalls the cert manager
-func UninstallCertManager() {
-	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	err := Kubectl("delete", "-f", url)
+	err := Kubectl("delete", "-f", prometheusOperatorURL)
 	if err != nil {
 		warnError(err)
 	}
@@ -189,8 +153,7 @@ func UninstallCertManager() {
 
 // InstallCertManager installs the cert manager bundle.
 func InstallCertManager() error {
-	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	err := Kubectl("apply", "-f", url)
+	err := Kubectl("apply", "-f", certmanagerURL)
 	if err != nil {
 		return err
 	}
@@ -203,36 +166,12 @@ func InstallCertManager() error {
 	)
 }
 
-// IsCertManagerCRDsInstalled checks if any Cert Manager CRDs are installed
-// by verifying the existence of key CRDs related to Cert Manager.
-func IsCertManagerCRDsInstalled() bool {
-	// List of common Cert Manager CRDs
-	certManagerCRDs := []string{
-		"certificates.cert-manager.io",
-		"issuers.cert-manager.io",
-		"clusterissuers.cert-manager.io",
-		"certificaterequests.cert-manager.io",
-		"orders.acme.cert-manager.io",
-		"challenges.acme.cert-manager.io",
-	}
-
-	// Execute the kubectl command to get all CRDs
-	output, err := KubectlOut("get", "crds")
+// UninstallCertManager uninstalls the cert manager
+func UninstallCertManager() {
+	err := Kubectl("delete", "-f", certmanagerURL)
 	if err != nil {
-		return false
+		warnError(err)
 	}
-
-	// Check if any of the Cert Manager CRDs are present
-	crdList := GetNonEmptyLines(output)
-	for _, crd := range certManagerCRDs {
-		for _, line := range crdList {
-			if strings.Contains(line, crd) {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // LoadImageToKindClusterWithName loads a local docker image to the kind cluster

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -27,11 +27,14 @@ import (
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/lithammer/dedent"
 	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive
 	"sigs.k8s.io/yaml"
 )
 
 const (
+	metricsServerYAML = "test/e2e/files/resources/metrics-server.yaml"
+
 	prometheusOperatorVersion = "v0.77.1"
 	prometheusOperatorURL     = "https://github.com/prometheus-operator/prometheus-operator/" +
 		"releases/download/" + prometheusOperatorVersion + "/bundle.yaml"
@@ -114,6 +117,12 @@ func FromYAMLFile(filePath string) []byte {
 	return FromYAML(document)
 }
 
+func FromYAMLString(document string) []byte {
+	document = strings.ReplaceAll(document, "\t", "    ")
+	document = dedent.Dedent(document)
+	return FromYAML([]byte(document))
+}
+
 func FromYAML(document []byte) []byte {
 	json, err := yaml.YAMLToJSON(document)
 	if err != nil {
@@ -136,6 +145,25 @@ func PatchDocument(document []byte, patches ...[]byte) []byte {
 		}
 	}
 	return patched
+}
+
+func InstallMetricsServer() error {
+	err := Kubectl("apply", "-f", metricsServerYAML)
+	if err != nil {
+		return err
+	}
+	return Kubectl("wait", "deployment", "metrics-server",
+		"--for", "condition=Available",
+		"--namespace", "kube-system",
+		"--timeout", "1m",
+	)
+}
+
+func UnnstallMetricsServer() {
+	err := Kubectl("delete", "-f", metricsServerYAML)
+	if err != nil {
+		warnError(err)
+	}
 }
 
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.

--- a/test/util/util_test.go
+++ b/test/util/util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromYAMLString(t *testing.T) {
+	t.Run("FromYAMLString", func(t *testing.T) {
+		json := FromYAMLString(`
+			apiVersion: autoscaling/v2
+			kind: HorizontalPodAutoscaler
+			metadata:
+			  name: test-json
+			spec:
+			  minReplicas: 1
+			  maxReplicas: 42
+			  scaleTargetRef:
+			    apiVersion: apps.emqx.io/v3alpha1
+			    kind: EMQX
+			    name: emqx
+			  metrics:
+			  - type: Resource
+			    resource:
+			      name: cpu
+			      target:
+			        averageUtilization: 80
+			        type: Utilization
+			  behavior:
+			    scaleUp:
+				  stabilizationWindowSeconds: 0
+			    scaleDown:
+				  stabilizationWindowSeconds: 30
+			`)
+		assert.NotEmpty(t, json)
+	})
+}


### PR DESCRIPTION
## Summary

This PR unbreaks and enriches _Scale_ subresource of EMQX CRs.
1. Updated definition makes it directly compatible with `autoscaling.v1` / `autoscaling.v2` APIs, and therefore HPAs.
2. EMQX CR Status now carries few extra fields necessary for _Scale_ subresource to work correctly.
3. A new E2E test context verifies that HPA-driven autoscaling works.
4. Also few minor bugfixes for #1184.