### PR TITLE
test(e2e): add simple stress test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,52 @@ jobs:
           if-no-files-found: ignore
           retention-days: 1
 
+  test-stress:
+    name: E2E Stress Tests
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - profile: short
+            steps: 5
+            interval: 5s
+          - profile: long
+            steps: 15
+            interval: 10s
+
+    runs-on: ubuntu-latest
+    env:
+      TEST_E2E_DIAGNOSTIC_REPORT_PATH: ${{ github.workspace }}/test-report
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - run: go mod tidy
+
+      - run: make test-e2e-stress
+        env:
+          TEST_E2E_STRESS_STEPS: ${{ matrix.steps }}
+          TEST_E2E_STRESS_STEP_INTERVAL: ${{ matrix.interval }}
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-report-stress-${{ matrix.profile }}
+          path: ${{ env.TEST_E2E_DIAGNOSTIC_REPORT_PATH }}
+          if-no-files-found: ignore
+
+      - run: go tool covdata textfmt -i /tmp/kind/data/emqx-operator-system/test-e2e-coverage -o ${{ github.workspace }}/cover.stress.out
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverprofile-stress-${{ matrix.profile }}
+          path: ${{ github.workspace }}/cover.stress.out
+          if-no-files-found: ignore
+          retention-days: 1
+
   test-upgrade:
     name: E2E Upgrade Tests - ${{ matrix.profile }}
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ test-e2e: manifests generate e2e-test-cluster ## Run general E2E tests. Expected
 	go test ./test/e2e/ -v -ginkgo.v -timeout 60m
 
 test-e2e-upgrade: manifests generate e2e-test-cluster ## Run E2E upgrade tests. Expected an isolated environment using Kind.
-	go test ./test/e2e/ -v -ginkgo.v -timeout 20m -ginkgo.focus="EMQX Upgrade Test" \
+	go test ./test/e2e/upgrade -v -ginkgo.v -timeout 20m \
 		-emqx-image-initial=$(TEST_E2E_UPGRADE_IMAGE_INITIAL) \
 		-emqx-image-upgrade=$(TEST_E2E_UPGRADE_IMAGE_UPGRADE)
 

--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,11 @@ doc-crd-v3: ## Generate documentation for the `apps.emqx.io/v3beta1` CRD.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
-docker-build: ## Build docker image with the manager.
+docker-build: generate ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build -t ${OPERATOR_IMAGE} .
 
 .PHONY: docker-build-coverage
-docker-build-coverage: Dockerfile.coverage ## Build docker image with the manager and code coverage enabled.
+docker-build-coverage: Dockerfile.coverage generate ## Build docker image with the manager and code coverage enabled.
 	$(CONTAINER_TOOL) build -t ${OPERATOR_IMAGE} -f Dockerfile.coverage .
 
 .PHONY: docker-push
@@ -159,7 +159,7 @@ docker-push: ## Push docker image with the manager.
 #   OPERATOR_IMAGE=<myregistry/image:<tag>> then the export will fail)
 PLATFORMS ?= linux/arm64,linux/amd64
 .PHONY: docker-buildx
-docker-buildx: Dockerfile.cross ## Build and push docker image for the manager for cross-platform support
+docker-buildx: Dockerfile.cross generate ## Build and push docker image for the manager for cross-platform support
 	- $(CONTAINER_TOOL) buildx create --name emqx-operator-builder
 	$(CONTAINER_TOOL) buildx use emqx-operator-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${OPERATOR_IMAGE} -f Dockerfile.cross .

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 TEST_E2E_UPGRADE_IMAGE_INITIAL ?= emqx/emqx:5.10.2
 TEST_E2E_UPGRADE_IMAGE_UPGRADE ?= emqx/emqx:6.1.0
 
+TEST_E2E_STRESS_STEPS ?= 8
+TEST_E2E_STRESS_STEP_INTERVAL ?= 5s
+TEST_E2E_STRESS_IMAGE ?= emqx/emqx:6.1.0
+
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $$(go list ./... | grep -v /e2e) -coverprofile ./cover.out
@@ -96,6 +100,12 @@ test-e2e-upgrade: manifests generate e2e-test-cluster ## Run E2E upgrade tests. 
 	go test ./test/e2e/upgrade -v -ginkgo.v -timeout 20m \
 		-emqx-image-initial=$(TEST_E2E_UPGRADE_IMAGE_INITIAL) \
 		-emqx-image-upgrade=$(TEST_E2E_UPGRADE_IMAGE_UPGRADE)
+
+test-e2e-stress: manifests generate e2e-test-cluster ## Run E2E stress tests. Expected an isolated environment using Kind.
+	go test ./test/e2e/stress -v -ginkgo.v -timeout 20m \
+		-stress-steps=$(TEST_E2E_STRESS_STEPS) \
+		-step-interval=$(TEST_E2E_STRESS_STEP_INTERVAL) \
+		-emqx-image=$(TEST_E2E_STRESS_IMAGE)
 
 .PHONY: test-e2e-helm
 test-e2e-helm: e2e-test-cluster ## Run Helm chart E2E tests. Expected an isolated environment using Kind.

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,8 @@ TEST_E2E_UPGRADE_IMAGE_UPGRADE ?= emqx/emqx:6.1.0
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $$(go list ./... | grep -v /e2e) -coverprofile ./cover.out
 
-# TODO(user): To use a different vendor for e2e tests, modify the setup under 'tests/e2e'.
-# The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
-# Prometheus and CertManager are installed by default; skip with:
-# - PROMETHEUS_INSTALL_SKIP=true
-# - CERT_MANAGER_INSTALL_SKIP=true
+# Prometheus is installed by default; skip with:
+# - TEST_E2E_SKIP_PROMETHEUS_INSTALL=true
 .PHONY: test-e2e
 test-e2e: manifests generate e2e-test-cluster ## Run general E2E tests. Expected an isolated environment using Kind.
 	go test ./test/e2e/ -v -ginkgo.v -timeout 60m

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -151,16 +151,6 @@ func (r *reconcileState) updateReplicantSet(instance *crd.EMQX) *appsv1.ReplicaS
 	return nil
 }
 
-// partOfReplicantSets checks if a pod belongs to any replicant ReplicaSet.
-func (r *reconcileState) partOfReplicantSet(pod *corev1.Pod) bool {
-	for _, rs := range r.replicantSets {
-		if util.IsPodManagedBy(pod, rs) {
-			return true
-		}
-	}
-	return false
-}
-
 // outdatedReplicantReplicaSets returns all replicant ReplicaSets except the update revision set,
 // sorted by creation timestamp (oldest first).
 func (r *reconcileState) outdatedReplicantSets(instance *crd.EMQX) []*appsv1.ReplicaSet {

--- a/internal/controller/sync_core_set.go
+++ b/internal/controller/sync_core_set.go
@@ -372,27 +372,28 @@ func (s *syncCoreSet) startEvacuation(
 // migrationTargetNodes returns the list of EMQX nodes to migrate workloads to.
 // * In core-only cluster, targets are pods of the core set.
 // * In core-replicant cluster, targets are:
-//   - pods in the "update" replicant set, if it has at least 1 ready replica,
+//   - pods in the "update" replicant set, if it has at least 1 node up and running,
 //   - pods in any replicant set otherwise.
 func migrationTargetNodes(r *reconcileRound, instance *crd.EMQX) []string {
 	targets := []string{}
+	fallback := []string{}
 	if instance.Spec.HasReplicants() {
 		updateReplicantSet := r.state.updateReplicantSet(instance)
 		if updateReplicantSet == nil {
 			return targets
 		}
-		updateReady := updateReplicantSet.Status.ReadyReplicas > 0
 		for _, node := range instance.Status.ReplicantNodes {
 			pod := r.state.podWithName(node.PodName)
 			if pod == nil {
 				continue
 			}
-			if updateReady && util.IsPodManagedBy(pod, updateReplicantSet) {
+			if util.IsPodManagedBy(pod, updateReplicantSet) {
 				targets = append(targets, node.Name)
 			}
-			if r.state.partOfReplicantSet(pod) {
-				targets = append(targets, node.Name)
-			}
+			fallback = append(fallback, node.Name)
+		}
+		if len(targets) == 0 {
+			return fallback
 		}
 	} else {
 		for _, node := range instance.Status.CoreNodes {

--- a/test/e2e/assert.go
+++ b/test/e2e/assert.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/assert.go
+++ b/test/e2e/assert.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func checkEMQXReady(g Gomega, afterTime ...metav1.Time) {
+func EMQXReady(g Gomega, afterTime ...metav1.Time) {
 	var cond metav1.Condition
 	g.Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")]}")).
 		To(UnmarshalInto(&cond), "Failed to get emqx status")
@@ -24,7 +24,7 @@ func checkEMQXReady(g Gomega, afterTime ...metav1.Time) {
 	}
 }
 
-func checkEMQXStatus(g Gomega, coreReplicas int) {
+func CoresStable(g Gomega, coreReplicas int) {
 	var status crd.CoreNodesStatus
 	var nodes []crd.EMQXNode
 	var podList corev1.PodList
@@ -75,7 +75,7 @@ func checkEMQXStatus(g Gomega, coreReplicas int) {
 	)
 }
 
-func checkNoReplicants(g Gomega) {
+func NoReplicants(g Gomega) {
 	g.Expect(KubectlOut("get", "emqx", "emqx",
 		"-o", "jsonpath={.status.replicantNodesStatus.currentReplicas}",
 	)).To(Equal("0"), "EMQX cluster status has replicant replicas")
@@ -84,7 +84,7 @@ func checkNoReplicants(g Gomega) {
 	)).To(BeEmpty(), "EMQX cluster status lists replicant nodes")
 }
 
-func checkReplicantStatus(g Gomega, replicantReplicas int) {
+func ReplicantsStable(g Gomega, replicantReplicas int) {
 	var status crd.ReplicantNodesStatus
 	g.Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.replicantNodesStatus}")).
 		To(UnmarshalInto(&status), "Failed to get EMQX replicant nodes status")
@@ -96,10 +96,6 @@ func checkReplicantStatus(g Gomega, replicantReplicas int) {
 		),
 		"EMQX status does not have expected number of replicant nodes",
 	)
-	checkReplicantNodesStatusRevision(g, status, replicantReplicas)
-}
-
-func checkReplicantNodesStatusRevision(g Gomega, status crd.ReplicantNodesStatus, replicas int) {
 	var podList corev1.PodList
 	g.Expect(status).To(
 		And(
@@ -118,12 +114,12 @@ func checkReplicantNodesStatusRevision(g Gomega, status crd.ReplicantNodesStatus
 		"-o", "json",
 	)).To(UnmarshalInto(&podList), "Failed to list replicant pods")
 	g.Expect(podList.Items).To(
-		HaveLen(replicas),
-		"EMQX cluster does not have %d current revision replicant pods", replicas,
+		HaveLen(replicantReplicas),
+		"EMQX cluster does not have %d current revision replicant pods", replicantReplicas,
 	)
 }
 
-func checkDSReplicationStatus(g Gomega, coreReplicas int) {
+func DSReplicationStable(g Gomega, coreReplicas int) {
 	status := &crd.DSReplicationStatus{}
 	replicationFactor := min(3, coreReplicas)
 	g.Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.dsReplication}")).
@@ -146,7 +142,7 @@ func checkDSReplicationStatus(g Gomega, coreReplicas int) {
 	)
 }
 
-func checkDSReplicationHealthy(g Gomega) {
+func DSReplicationHealthy(g Gomega) {
 	g.Expect(KubectlOut("exec", "service/emqx-listeners", "--", "emqx", "ctl", "ds", "info")).
 		NotTo(
 			ContainSubstring("(!)"),

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 const (

--- a/test/e2e/const.go
+++ b/test/e2e/const.go
@@ -1,0 +1,6 @@
+package e2e
+
+const (
+	// namespace where the project is deployed in
+	Namespace = "emqx-operator-system"
+)

--- a/test/e2e/diagnostic.go
+++ b/test/e2e/diagnostic.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/diagnostic.go
+++ b/test/e2e/diagnostic.go
@@ -1,0 +1,141 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/emqx/emqx-operator/test/util"
+	. "github.com/emqx/emqx-operator/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// diagnosticReportPath is the path to dump the diagnostic report on failure
+var diagnosticReportPath = util.Env("TEST_E2E_DIAGNOSTIC_REPORT_PATH", "test/_reports")
+
+func PrintDiagnosticReport(namespace string) {
+	controllerLogs, err := KubectlOut("logs",
+		"--selector", "control-plane=controller-manager",
+		"--namespace", namespace,
+		"--tail", "-1")
+	if err == nil {
+		GinkgoWriter.Print("Controller logs:\n", controllerLogs)
+	} else {
+		GinkgoWriter.Printf("Failed to get Controller logs: %s", err)
+	}
+	resources, err := KubectlOut("get", "all",
+		"--selector", "apps.emqx.io/managed-by=emqx-operator")
+	if err == nil {
+		GinkgoWriter.Print("Managed EMQX resources:\n", resources)
+	} else {
+		GinkgoWriter.Printf("Failed to list managed resources: %s", err)
+	}
+	emqxCR, err := KubectlOut("get", "emqx", "emqx", "--output", "yaml")
+	if err == nil {
+		GinkgoWriter.Print("EMQX CR:\n", emqxCR)
+	} else {
+		GinkgoWriter.Printf("Failed to get EMQX CR: %s", err)
+	}
+	emqxLogs, err := KubectlOut("logs",
+		"--selector", "apps.emqx.io/instance=emqx,apps.emqx.io/managed-by=emqx-operator")
+	if err == nil {
+		GinkgoWriter.Print("EMQX logs:\n", emqxLogs)
+	} else {
+		GinkgoWriter.Printf("Failed to get EMQX logs: %s", err)
+	}
+	eventsOutput, err := KubectlOut("get", "events", "--sort-by=.lastTimestamp")
+	if err == nil {
+		GinkgoWriter.Print("Kubernetes events:\n", eventsOutput)
+	} else {
+		GinkgoWriter.Printf("Failed to get Kubernetes events: %s", err)
+	}
+}
+
+func DumpDiagnosticReport(namespace string, name string, time time.Time) {
+	path := filepath.Join(diagnosticReportPath, name, time.Format("20060102150405"))
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		GinkgoWriter.Printf("Failed to create diagnostic report path: %s", err)
+		return
+	}
+
+	GinkgoWriter.Println("Dumping diagnostic report: ", path)
+
+	controllerLogs, err := KubectlOut("logs",
+		"--selector", "control-plane=controller-manager",
+		"--namespace", namespace,
+		"--tail", "-1")
+	if err == nil {
+		_ = dumpString(path, "controller.log", controllerLogs)
+	} else {
+		GinkgoWriter.Println("Failed to get Controller logs:", err)
+	}
+
+	operatorManagedLabel := "apps.emqx.io/managed-by=emqx-operator"
+	resources, err := KubectlOut("get", "all", "--selector", operatorManagedLabel)
+	if err == nil {
+		_ = dumpString(path, "resources", resources)
+	} else {
+		GinkgoWriter.Println("Failed to list managed resources:", err)
+	}
+
+	emqxCRs, err := KubectlOut("get", "emqx", "--output", "yaml")
+	if err == nil {
+		_ = dumpString(path, "emqx-crs.yaml", emqxCRs)
+	} else {
+		GinkgoWriter.Println("Failed to list EMQX CRs:", err)
+	}
+
+	emqxPods, err := KubectlOut("get", "pod", "--selector", operatorManagedLabel, "-o", "yaml")
+	if err == nil {
+		_ = dumpString(path, "emqx-pods.yaml", emqxPods)
+	} else {
+		GinkgoWriter.Println("Failed to list EMQX pods:", err)
+	}
+
+	emqxStatefulSets, err := KubectlOut("get", "statefulset", "--selector", operatorManagedLabel, "-o", "yaml")
+	if err == nil {
+		_ = dumpString(path, "emqx-statefulsets.yaml", emqxStatefulSets)
+	} else {
+		GinkgoWriter.Println("Failed to list EMQX StatefulSets:", err)
+	}
+
+	emqxReplicaSets, err := KubectlOut("get", "replicaset", "--selector", operatorManagedLabel, "-o", "yaml")
+	if err == nil {
+		_ = dumpString(path, "emqx-replicasets.yaml", emqxReplicaSets)
+	} else {
+		GinkgoWriter.Println("Failed to list EMQX ReplicaSets:", err)
+	}
+
+	var podList corev1.PodList
+	err = json.Unmarshal(FromYAML([]byte(emqxPods)), &podList)
+	if err != nil {
+		GinkgoWriter.Println("Failed to unmarshal EMQX pods:", err)
+	}
+	for _, pod := range podList.Items {
+		logs, err := KubectlOut("logs", pod.Name, "--tail", "-1")
+		if err == nil {
+			_ = dumpString(path, pod.Name+".log", logs)
+		} else {
+			GinkgoWriter.Println("Failed to get logs for pod: %s", pod.Name, err)
+		}
+	}
+
+	dsInfo, _ := KubectlOut("exec", "service/emqx-listeners", "--", "emqx", "ctl", "ds", "info")
+	if dsInfo != "" {
+		_ = dumpString(path, "emqx.ctl.ds-info", dsInfo)
+	}
+
+	events, err := KubectlOut("get", "events", "--sort-by=.lastTimestamp")
+	if err == nil {
+		_ = dumpString(path, "events", events)
+	} else {
+		GinkgoWriter.Println("Failed to get Kubernetes events:", err)
+	}
+}
+
+func dumpString(path string, name string, content string) error {
+	return os.WriteFile(filepath.Join(path, name), []byte(content), 0644)
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -17,27 +17,23 @@ limitations under the License.
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/emqx/emqx-operator/test/util"
 )
 
-var (
+const (
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "emqx/emqx-operator:0.0.1"
 
-	// diagnosticReportPath is the path to dump the diagnostic report on failure
-	diagnosticReportPath = util.Env("TEST_E2E_DIAGNOSTIC_REPORT_PATH", "test/_reports")
+	// namespace where the project is deployed in
+	namespace = Namespace
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -45,15 +41,14 @@ var (
 // The default setup requires Kind, builds/loads the Manager Docker image locally.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
-	_, _ = fmt.Fprintf(GinkgoWriter, "Starting emqx-operator integration test suite\n")
+	// Set the default timeout and interval for async assertions
+	SetDefaultEventuallyTimeout(time.Minute * 5)
+	SetDefaultEventuallyPollingInterval(time.Second * 3)
+	// Run tests
 	RunSpecs(t, "e2e suite")
 }
 
 var _ = BeforeSuite(func() {
-	// Set the default timeout and interval for async assertions
-	SetDefaultEventuallyTimeout(time.Minute * 5)
-	SetDefaultEventuallyPollingInterval(time.Second * 3)
-
 	By("generate manifests")
 	Expect(util.Run("make", "manifests")).To(Succeed())
 
@@ -70,130 +65,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	util.UnistallMetricsServer()
+	util.UninstallMetricsServer()
 })
-
-func PrintDiagnosticReport(namespace string) {
-	controllerLogs, err := util.KubectlOut("logs",
-		"--selector", "control-plane=controller-manager",
-		"--namespace", namespace,
-		"--tail", "-1")
-	if err == nil {
-		GinkgoWriter.Print("Controller logs:\n", controllerLogs)
-	} else {
-		GinkgoWriter.Printf("Failed to get Controller logs: %s", err)
-	}
-	resources, err := util.KubectlOut("get", "all",
-		"--selector", "apps.emqx.io/managed-by=emqx-operator")
-	if err == nil {
-		GinkgoWriter.Print("Managed EMQX resources:\n", resources)
-	} else {
-		GinkgoWriter.Printf("Failed to list managed resources: %s", err)
-	}
-	emqxCR, err := util.KubectlOut("get", "emqx", "emqx", "--output", "yaml")
-	if err == nil {
-		GinkgoWriter.Print("EMQX CR:\n", emqxCR)
-	} else {
-		GinkgoWriter.Printf("Failed to get EMQX CR: %s", err)
-	}
-	emqxLogs, err := util.KubectlOut("logs",
-		"--selector", "apps.emqx.io/instance=emqx,apps.emqx.io/managed-by=emqx-operator")
-	if err == nil {
-		GinkgoWriter.Print("EMQX logs:\n", emqxLogs)
-	} else {
-		GinkgoWriter.Printf("Failed to get EMQX logs: %s", err)
-	}
-	eventsOutput, err := util.KubectlOut("get", "events", "--sort-by=.lastTimestamp")
-	if err == nil {
-		GinkgoWriter.Print("Kubernetes events:\n", eventsOutput)
-	} else {
-		GinkgoWriter.Printf("Failed to get Kubernetes events: %s", err)
-	}
-}
-
-func DumpDiagnosticReport(namespace string, name string, time time.Time) {
-	path := filepath.Join(diagnosticReportPath, name, time.Format("20060102150405"))
-	err := os.MkdirAll(path, 0755)
-	if err != nil {
-		GinkgoWriter.Printf("Failed to create diagnostic report path: %s", err)
-		return
-	}
-
-	GinkgoWriter.Println("Dumping diagnostic report: ", path)
-
-	controllerLogs, err := util.KubectlOut("logs",
-		"--selector", "control-plane=controller-manager",
-		"--namespace", namespace,
-		"--tail", "-1")
-	if err == nil {
-		_ = dumpString(path, "controller.log", controllerLogs)
-	} else {
-		GinkgoWriter.Println("Failed to get Controller logs:", err)
-	}
-
-	operatorManagedLabel := "apps.emqx.io/managed-by=emqx-operator"
-	resources, err := util.KubectlOut("get", "all", "--selector", operatorManagedLabel)
-	if err == nil {
-		_ = dumpString(path, "resources", resources)
-	} else {
-		GinkgoWriter.Println("Failed to list managed resources:", err)
-	}
-
-	emqxCRs, err := util.KubectlOut("get", "emqx", "--output", "yaml")
-	if err == nil {
-		_ = dumpString(path, "emqx-crs.yaml", emqxCRs)
-	} else {
-		GinkgoWriter.Println("Failed to list EMQX CRs:", err)
-	}
-
-	emqxPods, err := util.KubectlOut("get", "pod", "--selector", operatorManagedLabel, "-o", "yaml")
-	if err == nil {
-		_ = dumpString(path, "emqx-pods.yaml", emqxPods)
-	} else {
-		GinkgoWriter.Println("Failed to list EMQX pods:", err)
-	}
-
-	emqxStatefulSets, err := util.KubectlOut("get", "statefulset", "--selector", operatorManagedLabel, "-o", "yaml")
-	if err == nil {
-		_ = dumpString(path, "emqx-statefulsets.yaml", emqxStatefulSets)
-	} else {
-		GinkgoWriter.Println("Failed to list EMQX StatefulSets:", err)
-	}
-
-	emqxReplicaSets, err := util.KubectlOut("get", "replicaset", "--selector", operatorManagedLabel, "-o", "yaml")
-	if err == nil {
-		_ = dumpString(path, "emqx-replicasets.yaml", emqxReplicaSets)
-	} else {
-		GinkgoWriter.Println("Failed to list EMQX ReplicaSets:", err)
-	}
-
-	var podList corev1.PodList
-	err = json.Unmarshal(util.FromYAML([]byte(emqxPods)), &podList)
-	if err != nil {
-		GinkgoWriter.Println("Failed to unmarshal EMQX pods:", err)
-	}
-	for _, pod := range podList.Items {
-		logs, err := util.KubectlOut("logs", pod.Name, "--tail", "-1")
-		if err == nil {
-			_ = dumpString(path, pod.Name+".log", logs)
-		} else {
-			GinkgoWriter.Println("Failed to get logs for pod: %s", pod.Name, err)
-		}
-	}
-
-	dsInfo, _ := util.KubectlOut("exec", "service/emqx-listeners", "--", "emqx", "ctl", "ds", "info")
-	if dsInfo != "" {
-		_ = dumpString(path, "emqx.ctl.ds-info", dsInfo)
-	}
-
-	events, err := util.KubectlOut("get", "events", "--sort-by=.lastTimestamp")
-	if err == nil {
-		_ = dumpString(path, "events", events)
-	} else {
-		GinkgoWriter.Println("Failed to get Kubernetes events:", err)
-	}
-}
-
-func dumpString(path string, name string, content string) error {
-	return os.WriteFile(filepath.Join(path, name), []byte(content), 0644)
-}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -54,9 +54,6 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(time.Minute * 5)
 	SetDefaultEventuallyPollingInterval(time.Second * 3)
 
-	By("generate files")
-	Expect(util.Run("make", "generate")).To(Succeed())
-
 	By("generate manifests")
 	Expect(util.Run("make", "manifests")).To(Succeed())
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,9 +39,6 @@ var (
 	// re-installation and conflicts.
 	skipPrometheusInstall = os.Getenv("PROMETHEUS_INSTALL_SKIP") == "true"
 
-	// skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
-	skipCertManagerInstall = true
-
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "emqx/emqx-operator:0.0.1"
@@ -51,7 +48,6 @@ var (
 )
 
 var isPrometheusInstalled = false
-var isCertManagerInstalled = false
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary environment to validate project changes with the the purposed to be used in CI jobs.
@@ -96,11 +92,6 @@ var _ = BeforeSuite(func() {
 		Expect(util.InstallPrometheusOperator()).To(Succeed())
 		isPrometheusInstalled = true
 	}
-	if !skipCertManagerInstall {
-		By("install CertManager")
-		Expect(util.InstallCertManager()).To(Succeed())
-		isCertManagerInstalled = true
-	}
 })
 
 var _ = AfterSuite(func() {
@@ -108,10 +99,6 @@ var _ = AfterSuite(func() {
 	if !skipPrometheusInstall && isPrometheusInstalled {
 		By("uninstall Prometheus Operator")
 		util.UninstallPrometheusOperator()
-	}
-	if !skipCertManagerInstall && isCertManagerInstalled {
-		By("uninstall CertManager")
-		util.UninstallCertManager()
 	}
 })
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -32,13 +32,6 @@ import (
 )
 
 var (
-	// Optional Environment Variables:
-	// - PROMETHEUS_INSTALL_SKIP=true: Skips Prometheus Operator installation during test setup.
-	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
-	// These variables are useful if Prometheus or CertManager is already installed, avoiding
-	// re-installation and conflicts.
-	skipPrometheusInstall = os.Getenv("PROMETHEUS_INSTALL_SKIP") == "true"
-
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
 	projectImage = "emqx/emqx-operator:0.0.1"
@@ -47,12 +40,9 @@ var (
 	diagnosticReportPath = util.Env("TEST_E2E_DIAGNOSTIC_REPORT_PATH", "test/_reports")
 )
 
-var isPrometheusInstalled = false
-
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
 // temporary environment to validate project changes with the the purposed to be used in CI jobs.
-// The default setup requires Kind, builds/loads the Manager Docker image locally, and installs
-// CertManager and Prometheus.
+// The default setup requires Kind, builds/loads the Manager Docker image locally.
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
 	_, _ = fmt.Fprintf(GinkgoWriter, "Starting emqx-operator integration test suite\n")
@@ -63,9 +53,6 @@ var _ = BeforeSuite(func() {
 	// Set the default timeout and interval for async assertions
 	SetDefaultEventuallyTimeout(time.Minute * 5)
 	SetDefaultEventuallyPollingInterval(time.Second * 3)
-
-	By("ensure Prometheus is enabled")
-	_ = util.UncommentCode("config/default/kustomization.yaml", "#- ../prometheus", "#")
 
 	By("generate files")
 	Expect(util.Run("make", "generate")).To(Succeed())
@@ -83,23 +70,10 @@ var _ = BeforeSuite(func() {
 
 	By("install Metrics Server")
 	Expect(util.InstallMetricsServer()).To(Succeed())
-
-	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
-	// To prevent errors when tests run in environments with Prometheus or CertManager already installed,
-	// we check for their presence before execution.
-	if !skipPrometheusInstall {
-		By("install Prometheus Operator")
-		Expect(util.InstallPrometheusOperator()).To(Succeed())
-		isPrometheusInstalled = true
-	}
 })
 
 var _ = AfterSuite(func() {
-	util.UnnstallMetricsServer()
-	if !skipPrometheusInstall && isPrometheusInstalled {
-		By("uninstall Prometheus Operator")
-		util.UninstallPrometheusOperator()
-	}
+	util.UnistallMetricsServer()
 })
 
 func PrintDiagnosticReport(namespace string) {

--- a/test/e2e/emqx_mutation_test.go
+++ b/test/e2e/emqx_mutation_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"time"
+
+	. "github.com/emqx/emqx-operator/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Mutation testing: generate a deterministic, pseudo-random sequence of CR
+// changes from a known seed, then apply them in quick succession against a
+// fixed EMQX cluster. The reconciliation loop is expected to survive the
+// whole sequence and eventually drive the cluster back to a fully ready
+// state matching the final desired replica counts.
+//
+// The cluster always runs with Durable Storage enabled:
+// core scaling on a DS-enabled cluster exercises shard-replication bookkeeping
+// on top of plain StatefulSet rollout, which is where most subtle reconciler
+// regressions tend to surface.
+
+// Mutation test parameters. Exposed as go-test flags so CI can shard runs
+// across different seeds / sequence lengths without recompilation.
+var (
+	mutationSeed     int64
+	mutationSteps    int
+	mutationInterval time.Duration
+	mutationImage    string
+)
+
+func init() {
+	flag.Int64Var(&mutationSeed, "mutation-seed", 1,
+		"Seed for the pseudo-random mutation sequence")
+	flag.IntVar(&mutationSteps, "mutation-steps", 8,
+		"Number of individual mutations to apply in sequence")
+	flag.DurationVar(&mutationInterval, "mutation-interval", 5*time.Second,
+		"Delay between individual mutations. Tight intervals are deliberate: "+
+			"they stack changes on the reconciler while previous rollouts are "+
+			"still in-flight and exercise transitional states.")
+	// NOTE: `checkDSReplicationHealthy` needs EMQX 6.0.0 or newer.
+	flag.StringVar(&mutationImage, "mutation-image", "emqx/emqx:6.1.1",
+		"EMQX container image (with tag) to deploy for the mutation test")
+}
+
+type mutationKind int
+
+const (
+	mutateScaleCores mutationKind = iota
+	mutateScaleReplicants
+)
+
+func (k mutationKind) String() string {
+	switch k {
+	case mutateScaleCores:
+		return "scale-cores"
+	case mutateScaleReplicants:
+		return "scale-replicants"
+	}
+	return "unknown"
+}
+
+// mutation is one planned CR change: a kind (which dimension to scale) and
+// an absolute target replica count.
+type mutation struct {
+	kind  mutationKind
+	value int
+}
+
+// clusterState is the minimal projection of the CR relevant to mutations.
+type clusterState struct {
+	cores      int
+	replicants int
+}
+
+// mutationChoices is the static set of mutations the planner draws from.
+// Each entry is one concrete (kind, value) pair; to add a new mutation type,
+// just append more entries to this slice.
+var mutationChoices = []mutation{
+	{mutateScaleCores, 2},
+	{mutateScaleCores, 3},
+	{mutateScaleCores, 4},
+	{mutateScaleCores, 5},
+	{mutateScaleReplicants, 1},
+	{mutateScaleReplicants, 2},
+	{mutateScaleReplicants, 3},
+	{mutateScaleReplicants, 4},
+	{mutateScaleReplicants, 5},
+}
+
+// planMutations draws `steps` mutations uniformly at random from
+// `mutationChoices`. An identical consecutive mutation (same kind and
+// same value as the one just emitted) is resampled, so the plan never
+// contains a truly no-op patch back-to-back; non-adjacent duplicates are
+// kept as-is because they still exercise the reconciler against a
+// different intermediate state.
+func planMutations(seed int64, steps int) []mutation {
+	rnd := rand.New(rand.NewSource(seed))
+	out := make([]mutation, 0, steps)
+	for len(out) < steps {
+		m := mutationChoices[rnd.Intn(len(mutationChoices))]
+		if len(out) > 0 && out[len(out)-1] == m {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// finalState walks the plan to compute the cluster's desired state after
+// the last mutation is applied, starting from `initial`.
+func finalState(plan []mutation, initial clusterState) clusterState {
+	s := initial
+	for _, m := range plan {
+		switch m.kind {
+		case mutateScaleCores:
+			s.cores = m.value
+		case mutateScaleReplicants:
+			s.replicants = m.value
+		}
+	}
+	return s
+}
+
+// mutationPatch returns the JSON merge-patch that applies `m` to the CR.
+func mutationPatch(m mutation) string {
+	switch m.kind {
+	case mutateScaleCores:
+		return fmt.Sprintf(
+			`{"spec":{"coreTemplate":{"spec":{"replicas":%d}}}}`,
+			m.value,
+		)
+	case mutateScaleReplicants:
+		return fmt.Sprintf(
+			`{"spec":{"replicantTemplate":{"spec":{"replicas":%d}}}}`,
+			m.value,
+		)
+	}
+	panic(fmt.Sprintf("unknown mutation kind: %v", m.kind))
+}
+
+//nolint:errcheck
+var _ = Describe("EMQX Cluster / Mutation Testing", Label("emqx", "mutation"), Ordered, func() {
+
+	const emqxCRBasic = "test/e2e/files/resources/emqx.yaml"
+
+	initial := clusterState{cores: 2, replicants: 2}
+
+	BeforeAll(func() {
+		By("create manager namespace")
+		Expect(Kubectl("create", "ns", namespace)).To(Succeed())
+
+		By("install CRDs")
+		Expect(Run("make", "install")).To(Succeed())
+
+		By("deploy emqx-operator")
+		Expect(Run("make", "deploy",
+			fmt.Sprintf("OPERATOR_IMAGE=%s", projectImage),
+			fmt.Sprintf("KUSTOMIZATION_FILE_PATH=%s", "test/e2e/files/manager"),
+		)).To(Succeed())
+		Expect(Kubectl("wait", "deployment", "emqx-operator-controller-manager",
+			"--for", "condition=Available",
+			"--namespace", namespace,
+			"--timeout", "1m",
+		)).To(Succeed(), "Timed out waiting for emqx-operator deployment")
+	})
+
+	AfterAll(func() {
+		By("undeploy emqx-operator")
+		_ = Run("make", "undeploy")
+
+		By("uninstall CRDs")
+		_ = Run("make", "uninstall")
+
+		By("delete manager namespace")
+		_ = Kubectl("delete", "ns", namespace)
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			DumpDiagnosticReport(namespace, "emqx-mutation", CurrentSpecReport().StartTime)
+		}
+	})
+
+	// The plan is captured up-front so the test reports can show the exact
+	// sequence that was exercised, which is crucial for reproducing failures
+	// discovered by a given seed.
+	plan := planMutations(mutationSeed, mutationSteps)
+
+	It("deploy cluster", func() {
+		By(fmt.Sprintf(
+			"planned mutation sequence (seed=%d, steps=%d, interval=%s, image=%s):",
+			mutationSeed, mutationSteps, mutationInterval, mutationImage,
+		))
+		for i, m := range plan {
+			By(fmt.Sprintf("  [%d] %s=%d", i+1, m.kind, m.value))
+		}
+
+		By("create EMQX cluster")
+		emqxCR := PatchDocument(
+			FromYAMLFile(emqxCRBasic),
+			withImage(mutationImage),
+			withCores(initial.cores),
+			withReplicants(initial.replicants),
+			withConfig(configDS()),
+		)
+		Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
+		By("wait for EMQX cluster to be ready")
+		Eventually(checkEMQXReady).Should(Succeed())
+		Eventually(checkEMQXStatus).WithArguments(initial.cores).Should(Succeed())
+		Eventually(checkReplicantStatus).WithArguments(initial.replicants).Should(Succeed())
+		Eventually(checkDSReplicationStatus).WithArguments(initial.cores).Should(Succeed())
+		Eventually(checkDSReplicationHealthy).Should(Succeed())
+	})
+
+	It("apply mutation sequence", func() {
+		if len(plan) == 0 {
+			Skip("mutation plan is empty")
+		}
+
+		// MQTTX holds ~25 long-lived MQTT connections against the cluster
+		// service. That load is what turns a plain core scale-down into a
+		// real node evacuation (the operator drains connections from the
+		// doomed node via EMQX's load-rebalance API before deleting the
+		// pod), so keeping a workload attached throughout the mutation
+		// sequence is what actually exercises `.status.nodeEvacuations`.
+		By("create MQTT workload")
+		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
+		defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml") //nolint:errcheck
+		Expect(Kubectl("wait", "pod",
+			"--selector=app=mqttx",
+			"--for=condition=Ready",
+			"--timeout=1m",
+		)).To(Succeed(), "Timed out waiting for MQTTX to be ready")
+
+		sequenceStartedAt := metav1.Now()
+		for i, m := range plan {
+			By(fmt.Sprintf("[%d/%d] apply %s=%d", i+1, len(plan), m.kind, m.value))
+			Expect(Kubectl("patch", "emqx", "emqx",
+				"--type", "merge",
+				"--patch", mutationPatch(m),
+			)).To(Succeed(), "Failed to apply mutation %d (%s=%d)", i+1, m.kind, m.value)
+			// Deliberately do _not_ wait for readiness between mutations: the
+			// point of the test is to stack changes while reconciliation is
+			// still in-flight. A fixed delay gives the controller a chance to
+			// observe each change but keeps the queue pressured.
+			if i < len(plan)-1 {
+				time.Sleep(mutationInterval)
+			}
+		}
+
+		final := finalState(plan, initial)
+
+		By(fmt.Sprintf(
+			"wait for EMQX cluster to settle at final state (cores=%d, replicants=%d)",
+			final.cores, final.replicants,
+		))
+		Eventually(checkEMQXReady).
+			WithArguments(sequenceStartedAt).
+			Should(Succeed())
+		Eventually(checkEMQXStatus).
+			WithArguments(final.cores).
+			Should(Succeed())
+		Eventually(checkReplicantStatus).
+			WithArguments(final.replicants).
+			Should(Succeed())
+		Eventually(checkDSReplicationHealthy).
+			Should(Succeed())
+		Eventually(checkDSReplicationStatus).
+			WithArguments(final.cores).
+			Should(Succeed())
+
+		By("verify all node evacuations have completed")
+		Eventually(KubectlOut).
+			WithArguments("get", "emqx", "emqx", "-o", "jsonpath={.status.nodeEvacuations}").
+			Should(BeEmpty(),
+				"EMQX cluster still has pending node evacuations after settle")
+	})
+
+	It("delete cluster", func() {
+		Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
+		Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")
+	})
+})

--- a/test/e2e/emqx_spec.go
+++ b/test/e2e/emqx_spec.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/emqx_spec.go
+++ b/test/e2e/emqx_spec.go
@@ -1,0 +1,98 @@
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/emqx/emqx-operator/test/util"
+	"github.com/lithammer/dedent"
+)
+
+type specBuilder struct {
+	base     []byte
+	overlays [][]byte
+}
+
+func SpecFromYAMLFile(filename string) *specBuilder {
+	return &specBuilder{base: util.FromYAMLFile(filename)}
+}
+
+func (sb *specBuilder) WithCores(numReplicas int) *specBuilder {
+	sb.overlays = append(sb.overlays, withCores(numReplicas))
+	return sb
+}
+
+func (sb *specBuilder) WithReplicants(numReplicas int) *specBuilder {
+	sb.overlays = append(sb.overlays, withReplicants(numReplicas))
+	return sb
+}
+
+func (sb *specBuilder) WithImage(image string) *specBuilder {
+	sb.overlays = append(sb.overlays, withImage(image))
+	return sb
+}
+
+func (sb *specBuilder) WithConfig(snippets ...string) *specBuilder {
+	sb.overlays = append(sb.overlays, withConfig(snippets...))
+	return sb
+}
+
+func (sb *specBuilder) ToJSONDocument() []byte {
+	return util.PatchDocument(sb.base, sb.overlays...)
+}
+
+func withCores(numReplicas int) []byte {
+	return fmt.Appendf(nil,
+		`{"spec": {"coreTemplate": {"spec": {"replicas": %d}}}}`,
+		numReplicas,
+	)
+}
+
+func withReplicants(numReplicas int) []byte {
+	return fmt.Appendf(nil,
+		`{"spec": {"replicantTemplate": {"spec": {"minReadySeconds": 3, "replicas": %d}}}}`,
+		numReplicas,
+	)
+}
+
+func withImage(image string) []byte {
+	return fmt.Appendf(nil, `{"spec": {"image": "%s"}}`, image)
+}
+
+func withConfig(snippets ...string) []byte {
+	defaults := []string{ConfigLicense(), ConfigConsoleLog("info")}
+	config := slices.Concat(defaults, snippets)
+	return fmt.Appendf(nil, `{"spec": {"config": {"data": %s}}}`, intoJsonString(config...))
+}
+
+func intoJsonString(snippets ...string) []byte {
+	configStr := dedent.Dedent(strings.Join(snippets, ""))
+	jsonStr, _ := json.Marshal(configStr)
+	return jsonStr
+}
+
+func ConfigLicense() string {
+	return `
+		license { key = "evaluation" }
+	`
+}
+
+func ConfigConsoleLog(level string) string {
+	return `
+		log.console { level = "` + level + `" }
+	`
+}
+
+func ConfigDS() string {
+	return `
+		durable_sessions { enable = true }
+		durable_storage { 
+			messages {
+				backend = builtin_raft
+				n_shards = 8
+			}
+		}
+	`
+}

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -1,14 +1,10 @@
 package e2e
 
 import (
-	"encoding/json"
 	"fmt"
-	"slices"
-	"strings"
 
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	. "github.com/emqx/emqx-operator/test/util"
-	"github.com/lithammer/dedent"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -18,20 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func withCores(numReplicas int) []byte {
-	return fmt.Appendf(nil,
-		`{"spec": {"coreTemplate": {"spec": {"replicas": %d}}}}`,
-		numReplicas,
-	)
-}
-
-func withReplicants(numReplicas int) []byte {
-	return fmt.Appendf(nil,
-		`{"spec": {"replicantTemplate": {"spec": {"minReadySeconds": 3, "replicas": %d}}}}`,
-		numReplicas,
-	)
-}
-
 func withReplicantResources(cpuRequest, memRequest, cpuLimit, memLimit string) []byte {
 	return fmt.Appendf(nil,
 		`{"spec": {"replicantTemplate": {"spec": {"resources": {
@@ -40,46 +22,6 @@ func withReplicantResources(cpuRequest, memRequest, cpuLimit, memLimit string) [
 		}}}}}`,
 		cpuRequest, memRequest, cpuLimit, memLimit,
 	)
-}
-
-func withImage(image string) []byte {
-	return fmt.Appendf(nil, `{"spec": {"image": "%s"}}`, image)
-}
-
-func withConfig(snippets ...string) []byte {
-	defaults := []string{configLicense(), configConsoleLog("info")}
-	config := slices.Concat(defaults, snippets)
-	return fmt.Appendf(nil, `{"spec": {"config": {"data": %s}}}`, intoJsonString(config...))
-}
-
-func intoJsonString(snippets ...string) []byte {
-	configStr := dedent.Dedent(strings.Join(snippets, ""))
-	jsonStr, _ := json.Marshal(configStr)
-	return jsonStr
-}
-
-func configLicense() string {
-	return `
-		license { key = "evaluation" }
-	`
-}
-
-func configConsoleLog(level string) string {
-	return `
-		log.console { level = "` + level + `" }
-	`
-}
-
-func configDS() string {
-	return `
-		durable_sessions { enable = true }
-		durable_storage { 
-			messages {
-				backend = builtin_raft
-				n_shards = 8
-			}
-		}
-	`
 }
 
 //nolint:unparam
@@ -139,9 +81,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			checkNoReplicants(Default)
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(NoReplicants).Should(Succeed())
 		})
 
 		It("scale cluster up", func() {
@@ -154,9 +96,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 					coreReplicas,
 				),
 			)).To(Succeed(), "Failed to scale up EMQX cluster")
-			Eventually(checkEMQXReady).WithArguments(scaleupStartedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			checkNoReplicants(Default)
+			Eventually(EMQXReady).WithArguments(scaleupStartedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(NoReplicants).Should(Succeed())
 		})
 
 		It("scale cluster down", func() {
@@ -169,9 +111,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 					coreReplicas,
 				),
 			)).To(Succeed(), "Failed to scale down EMQX cluster")
-			Eventually(checkEMQXReady).WithArguments(scaledownStartedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			checkNoReplicants(Default)
+			Eventually(EMQXReady).WithArguments(scaledownStartedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(NoReplicants).Should(Succeed())
 		})
 
 		It("change image to trigger rolling update", func() {
@@ -205,9 +147,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				WithArguments("get", "emqx", "emqx", "-o", "jsonpath={.status.nodeEvacuations}").
 				Should(BeEmpty())
 
-			Eventually(checkEMQXReady).WithArguments(changedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			checkNoReplicants(Default)
+			Eventually(EMQXReady).WithArguments(changedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(NoReplicants).Should(Succeed())
 
 			By("verify exactly one core StatefulSet was updated")
 			var stsList appsv1.StatefulSetList
@@ -241,7 +183,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				"--patch", `[{"op": "replace", "path": "/spec/config/data", "value": `+configChange+`}]`)).
 				To(Succeed())
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
 			By("wait for services to be updated")
 			var servicePorts []corev1.ServicePort
 			Eventually(KubectlOut).WithArguments("get", "service", "emqx-listeners", "-o", "jsonpath={.spec.ports}").
@@ -284,8 +226,8 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
 		})
 
 		It("trigger botched rolling updates", func() {
@@ -300,7 +242,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 
 			By("lookup initial EMQX status")
 			var statusInitial crd.CoreNodesStatus
-			Eventually(checkEMQXReady).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
 			Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.coreNodesStatus}")).
 				To(UnmarshalInto(&statusInitial))
 
@@ -312,7 +254,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 					{"op": "replace", "path": "/spec/image", "value": "emqx/emqx:5.Y.ZZZ"}
 				]`)).
 				To(Succeed())
-			Consistently(checkEMQXReady, "30s", "3s").WithArguments(changedAt1).Should(Not(Succeed()))
+			Consistently(EMQXReady, "30s", "3s").WithArguments(changedAt1).Should(Not(Succeed()))
 
 			By("specify broken EMQX config")
 			changedAt2 := metav1.Now()
@@ -324,7 +266,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 					{"op": "replace", "path": "/spec/image", "value": "`+emqxImageUpgrade+`"},
 				]`)).
 				To(Succeed())
-			Consistently(checkEMQXReady, "30s", "3s").WithArguments(changedAt2).Should(Not(Succeed()))
+			Consistently(EMQXReady, "30s", "3s").WithArguments(changedAt2).Should(Not(Succeed()))
 
 			var status crd.CoreNodesStatus
 			Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.coreNodesStatus}")).
@@ -345,8 +287,8 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 					{"op": "replace", "path": "/spec/image", "value": "`+imageForceChange+`"},
 				]`)).
 				To(Succeed())
-			Eventually(checkEMQXReady).WithArguments(changedAt3).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(changedAt3).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
 		})
 
 		It("delete cluster", func() {
@@ -370,9 +312,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 		})
 
 		It("scale cluster up", func() {
@@ -390,9 +332,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				"--patch", `[{"op": "replace", "path": "/spec/replicantTemplate/spec/replicas", "value": 3}]`)).
 				To(Succeed(), "Failed to scale emqx cluster")
 			By("wait for EMQX cluster to be ready after scaling")
-			Eventually(checkEMQXReady).WithArguments(scaleupStartedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(scaleupStartedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 		})
 
 		It("scale cluster down", func() {
@@ -410,9 +352,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				"--patch", `[{"op": "replace", "path": "/spec/replicantTemplate/spec/replicas", "value": 2}]`)).
 				To(Succeed(), "Failed to scale emqx cluster")
 			By("wait for EMQX cluster to be ready after scaling")
-			Eventually(checkEMQXReady).WithArguments(scaledownStartedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(scaledownStartedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 		})
 
 		It("change image to trigger rolling update", func() {
@@ -456,9 +398,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				ShouldNot(ContainSubstring("connection_eviction_rate"))
 
 			By("wait for EMQX cluster to be ready again")
-			Eventually(checkEMQXReady).WithArguments(changingTime).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(changingTime).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 
 			By("verify exactly one core StatefulSet was updated")
 			var stsList appsv1.StatefulSetList
@@ -500,16 +442,16 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				withImage(emqxImage),
 				withCores(coreReplicas),
 				withReplicants(replicantReplicas),
-				withConfig(configDS()),
+				withConfig(ConfigDS()),
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
-			Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkDSReplicationHealthy).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(DSReplicationHealthy).Should(Succeed())
 
 			By("verify EMQX pods have relevant conditions")
 			var pods corev1.PodList
@@ -543,11 +485,11 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				"--patch", `[{"op": "replace", "path": "/spec/coreTemplate/spec/replicas", "value": 4}]`,
 			)).To(Succeed())
 			By("wait for EMQX cluster to be ready after scaling")
-			Eventually(checkEMQXReady).WithArguments(scaleStartedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
-			Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkDSReplicationHealthy).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(scaleStartedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(DSReplicationHealthy).Should(Succeed())
 		})
 
 		It("scale down core EMQX cluster", func() {
@@ -559,12 +501,12 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				"--patch", `[{"op": "replace", "path": "/spec/coreTemplate/spec/replicas", "value": 2}]`,
 			)).To(Succeed())
 			By("wait for EMQX cluster to be ready after scaling")
-			Eventually(checkEMQXReady).WithArguments(scaleStartedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
-			Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(scaleStartedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
 			// EMQX 5.10.1: Lost sites are expected to hang around.
-			// Eventually(checkDSReplicationHealthy).Should(Succeed())
+			// Eventually(DSReplicationHealthy).Should(Succeed())
 		})
 
 		It("perform a rolling update", func() {
@@ -588,9 +530,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)).To(Succeed())
 
 			By("wait for EMQX cluster to be ready again")
-			Eventually(checkEMQXReady).WithArguments(changedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(changedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 
 			By("verify exactly one core StatefulSet was updated")
 			var stsList appsv1.StatefulSetList
@@ -609,9 +551,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)
 
 			By("wait for DS replication status to be stable")
-			Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
 			// EMQX 5.10.1: Lost sites are expected to hang around.
-			// Eventually(checkDSReplicationHealthy).Should(Succeed())
+			// Eventually(DSReplicationHealthy).Should(Succeed())
 		})
 
 		It("delete core-replicant EMQX cluster", func() {
@@ -640,14 +582,14 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 		})
 
 		It("enable DS replication", func() {
 			By("change config + add label to trigger rolling update")
-			configDs := string(intoJsonString(configDS()))
+			configDs := string(intoJsonString(ConfigDS()))
 			changedAt := metav1.Now()
 			Expect(Kubectl("patch", "emqx", "emqx",
 				"--type", "json",
@@ -658,12 +600,12 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)).To(Succeed())
 
 			By("wait for EMQX cluster to become ready again")
-			Eventually(checkEMQXReady).WithArguments(changedAt).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
-			Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(changedAt).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
 			// EMQX 5.10.1: Initial cluster's sites are expected to hang around.
-			// Eventually(checkDSReplicationHealthy).Should(Succeed())
+			// Eventually(DSReplicationHealthy).Should(Succeed())
 
 			By("verify EMQX pods have relevant conditions")
 			var pods corev1.PodList
@@ -721,9 +663,9 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)
 			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 			By("wait for EMQX cluster to be ready")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
 		})
 
 		It("scale subresource reports correct replica counts and selector", func() {
@@ -766,8 +708,8 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 				To(Succeed(), "kubectl scale should succeed")
 
 			By("wait for EMQX cluster to be ready after scaling")
-			Eventually(checkEMQXReady).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(newReplicas).Should(Succeed())
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(newReplicas).Should(Succeed())
 
 			By("verify scale subresource reflects the new replica count")
 			var scale autoscalingv1.Scale
@@ -827,8 +769,8 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 					HaveField("Status.CurrentReplicas", BeEquivalentTo(minReplicas)),
 				), "HPA should scale replicant set down")
 
-			Eventually(checkEMQXReady).WithArguments(hpaCreatedAt).Should(Succeed())
-			Eventually(checkReplicantStatus).WithArguments(minReplicas).Should(Succeed())
+			Eventually(EMQXReady).WithArguments(hpaCreatedAt).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(minReplicas).Should(Succeed())
 		})
 
 		It("delete cluster and HPA", func() {

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025-2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package e2e
 
 import (

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -102,13 +102,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 	)
 
 	BeforeAll(func() {
-		By("create manager namespace")
-		Expect(Kubectl("create", "ns", namespace)).To(Succeed())
-
-		By("install CRDs")
-		Expect(Run("make", "install")).To(Succeed())
-
-		By("deploy emqx-operator")
+		By("deploy EMQX Operator")
 		Expect(Run("make", "deploy",
 			fmt.Sprintf("OPERATOR_IMAGE=%s", projectImage),
 			fmt.Sprintf("KUSTOMIZATION_FILE_PATH=%s", "test/e2e/files/manager"),
@@ -121,14 +115,8 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 	})
 
 	AfterAll(func() {
-		By("undeploy emqx-operator")
+		By("undeploy EMQX Operator")
 		_ = Run("make", "undeploy")
-
-		By("uninstall CRDs")
-		_ = Run("make", "uninstall")
-
-		By("delete manager namespace")
-		_ = Kubectl("delete", "ns", namespace)
 	})
 
 	AfterEach(func() {

--- a/test/e2e/files/prometheus/kustomization.yaml
+++ b/test/e2e/files/prometheus/kustomization.yaml
@@ -1,0 +1,3 @@
+namespace: emqx-operator-system
+resources:
+- ../../../../config/prometheus

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025.
+Copyright 2025-2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/emqx/emqx-operator/test/util"
 	. "github.com/emqx/emqx-operator/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,28 +33,40 @@ import (
 // namespace where the project is deployed in
 const namespace = "emqx-operator-system"
 
-// serviceAccountName created for the project
-const serviceAccountName = "emqx-operator-controller-manager"
-
-// metricsServiceName is the name of the metrics service of the project
-const metricsServiceName = "emqx-operator-controller-manager-metrics-service"
-
-// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
-const metricsRoleBindingName = "emqx-operator-metrics-binding"
+var (
+	// Optional Environment Variables:
+	// - TEST_E2E_SKIP_PROMETHEUS_INSTALL=true:
+	//   Skips Prometheus Operator installation during test setup.
+	//   Useful if applications are already installed, avoiding re-installation and conflicts.
+	skipPrometheusInstall = os.Getenv("TEST_E2E_SKIP_PROMETHEUS_INSTALL") == "true"
+	isPrometheusInstalled = false
+)
 
 var _ = Describe("Manager", Ordered, func() {
-	var controllerPodName string
+	const (
+		// Kustomize manifest defining Service Monitor
+		serviceMonitorManifest = "test/e2e/files/prometheus"
+
+		// serviceAccountName created for the project
+		serviceAccountName = "emqx-operator-controller-manager"
+
+		// metricsServiceName is the name of the metrics service of the project
+		metricsServiceName = "emqx-operator-controller-manager-metrics-service"
+
+		// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
+		metricsRoleBindingName = "emqx-operator-metrics-binding"
+	)
 
 	// Before running the tests, set up the environment by creating the namespace,
 	// installing CRDs, and deploying the controller.
 	BeforeAll(func() {
-		By("create manager namespace")
-		Expect(Kubectl("create", "ns", namespace)).To(Succeed())
+		if !skipPrometheusInstall {
+			By("install Prometheus Operator")
+			Expect(util.InstallPrometheusOperator()).To(Succeed())
+			isPrometheusInstalled = true
+		}
 
-		By("install CRDs")
-		Expect(Run("make", "install")).To(Succeed())
-
-		By("deploy emqx-operator")
+		By("deploy EMQX Operator")
 		Expect(Run("make", "deploy",
 			fmt.Sprintf("OPERATOR_IMAGE=%s", projectImage),
 			fmt.Sprintf("KUSTOMIZATION_FILE_PATH=%s", "test/e2e/files/manager"),
@@ -68,14 +81,12 @@ var _ = Describe("Manager", Ordered, func() {
 	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
 	// and deleting the namespace.
 	AfterAll(func() {
-		By("undeploy emqx-operator")
+		By("undeploy EMQX Operator")
 		_ = Run("make", "undeploy")
-
-		By("uninstall CRDs")
-		_ = Run("make", "uninstall")
-
-		By("delete manager namespace")
-		_ = Kubectl("delete", "ns", namespace)
+		if !skipPrometheusInstall && isPrometheusInstalled {
+			By("uninstall Prometheus Operator")
+			util.UninstallPrometheusOperator()
+		}
 	})
 
 	// After each test, check for failures and collect logs, events,
@@ -87,21 +98,17 @@ var _ = Describe("Manager", Ordered, func() {
 	})
 
 	It("emqx-operator pod should run successfully", func() {
-		Eventually(func(g Gomega) {
-			// Get the name of the controller-manager pod
-			var podList corev1.PodList
-			g.Expect(KubectlOut("get", "pods",
-				"--namespace", namespace,
-				"--selector", "control-plane=controller-manager",
-				"-o", "json",
-			)).To(UnmarshalInto(&podList), "Failed to list controller-manager pods")
-			g.Expect(podList.Items).To(HaveLen(1), "expected 1 controller pod running")
-			g.Expect(podList.Items[0]).To(And(
-				HaveField("Name", ContainSubstring("controller-manager")),
-				HaveField("Status.Phase", Equal(corev1.PodRunning)),
-			))
-			controllerPodName = podList.Items[0].Name
-		}).Should(Succeed())
+		Eventually(KubectlOut).WithArguments("get", "pods",
+			"--namespace", namespace,
+			"--selector", "control-plane=controller-manager",
+			"-o", "json",
+		).Should(
+			BeUnmarshalledAs(&corev1.PodList{}, HaveField("Items", ConsistOf(
+				And(
+					HaveField("Name", ContainSubstring("controller-manager")),
+					HaveField("Status.Phase", Equal(corev1.PodRunning)),
+				)),
+			)))
 	})
 
 	It("metrics endpoint should be serving metrics", func() {
@@ -110,15 +117,18 @@ var _ = Describe("Manager", Ordered, func() {
 			"--clusterrole=emqx-operator-metrics-reader",
 			fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
 		)).To(Succeed())
+		defer Kubectl("delete", "clusterrolebinding", metricsRoleBindingName) // nolint:errcheck
 
 		By("verify metrics service is available")
 		Expect(Kubectl("get", "service", metricsServiceName, "--namespace", namespace)).To(Succeed())
 
-		By("verify Prometheus ServiceMonitor is deployed in the namespace")
+		By("deploy Prometheus ServiceMonitor")
+		Expect(Kubectl("apply", "-k", serviceMonitorManifest)).To(Succeed())
 		Expect(Kubectl("get", "ServiceMonitor", "--namespace", namespace)).To(Succeed())
+		defer Kubectl("delete", "-k", serviceMonitorManifest) // nolint:errcheck
 
 		By("fetch service account token")
-		token, err := serviceAccountToken()
+		token, err := serviceAccountToken(serviceAccountName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(token).NotTo(BeEmpty())
 
@@ -126,11 +136,6 @@ var _ = Describe("Manager", Ordered, func() {
 		Eventually(KubectlOut).
 			WithArguments("get", "endpoints", metricsServiceName, "--namespace", namespace).
 			Should(ContainSubstring("8443"))
-
-		By("verify emqx-operator is serving metrics")
-		Eventually(KubectlOut).
-			WithArguments("logs", controllerPodName, "--namespace", namespace).
-			Should(ContainSubstring("controller-runtime.metrics\tServing metrics server"))
 
 		By("create curl-metrics pod to access the metrics endpoint")
 		Expect(Kubectl("run", "curl-metrics", "--restart=Never",
@@ -157,7 +162,7 @@ var _ = Describe("Manager", Ordered, func() {
 // serviceAccountToken returns a token for the specified service account in the given namespace.
 // It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
 // and parsing the resulting token from the API response.
-func serviceAccountToken() (string, error) {
+func serviceAccountToken(serviceAccountName string) (string, error) {
 	const tokenRequestRawString = `{
 		"apiVersion": "authentication.k8s.io/v1",
 		"kind": "TokenRequest"

--- a/test/e2e/manager_test.go
+++ b/test/e2e/manager_test.go
@@ -30,9 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// namespace where the project is deployed in
-const namespace = "emqx-operator-system"
-
 var (
 	// Optional Environment Variables:
 	// - TEST_E2E_SKIP_PROMETHEUS_INSTALL=true:

--- a/test/e2e/rebalance_test.go
+++ b/test/e2e/rebalance_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Rebalance Test", Label("rebalance"), Ordered, Pending, func() 
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/emqx.yaml")).To(Succeed())
 		defer Kubectl("delete", "-f", "test/e2e/files/resources/emqx.yaml")
 		By("wait for EMQX to be ready")
-		Eventually(checkEMQXReady).Should(Succeed())
+		Eventually(EMQXReady).Should(Succeed())
 
 		By("create Rebalance CR")
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/rebalance.yaml")).
@@ -96,7 +96,7 @@ var _ = Describe("Rebalance Test", Label("rebalance"), Ordered, Pending, func() 
 		By("create EMQX CR")
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/emqx.yaml")).To(Succeed())
 		defer Kubectl("delete", "emqx", "emqx")
-		Eventually(checkEMQXReady).Should(Succeed())
+		Eventually(EMQXReady).Should(Succeed())
 
 		By("create MQTTX client workload")
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
@@ -114,8 +114,8 @@ var _ = Describe("Rebalance Test", Label("rebalance"), Ordered, Pending, func() 
 		)).To(Succeed())
 
 		By("wait for EMQX to be ready after scaling")
-		Eventually(checkEMQXReady).Should(Succeed())
-		Eventually(checkEMQXStatus).WithArguments(3).Should(Succeed())
+		Eventually(EMQXReady).Should(Succeed())
+		Eventually(CoresStable).WithArguments(3).Should(Succeed())
 
 		By("create Rebalance CR")
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/rebalance.yaml")).To(Succeed())

--- a/test/e2e/stress/emqx_stress_test.go
+++ b/test/e2e/stress/emqx_stress_test.go
@@ -14,66 +14,64 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package stress
 
 import (
 	"flag"
 	"fmt"
 	"math/rand"
+	"testing"
 	"time"
 
+	. "github.com/emqx/emqx-operator/test/e2e"
 	. "github.com/emqx/emqx-operator/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Mutation testing: generate a deterministic, pseudo-random sequence of CR
+// Stress testing: generate a deterministic, pseudo-random sequence of CR
 // changes from a known seed, then apply them in quick succession against a
 // fixed EMQX cluster. The reconciliation loop is expected to survive the
 // whole sequence and eventually drive the cluster back to a fully ready
 // state matching the final desired replica counts.
-//
-// The cluster always runs with Durable Storage enabled:
-// core scaling on a DS-enabled cluster exercises shard-replication bookkeeping
-// on top of plain StatefulSet rollout, which is where most subtle reconciler
-// regressions tend to surface.
 
 // Mutation test parameters. Exposed as go-test flags so CI can shard runs
 // across different seeds / sequence lengths without recompilation.
 var (
-	mutationSeed     int64
-	mutationSteps    int
-	mutationInterval time.Duration
-	mutationImage    string
+	stressSteps  int
+	stepInterval time.Duration
+	emqxImage    string
 )
 
 func init() {
-	flag.Int64Var(&mutationSeed, "mutation-seed", 1,
-		"Seed for the pseudo-random mutation sequence")
-	flag.IntVar(&mutationSteps, "mutation-steps", 8,
+	flag.IntVar(&stressSteps, "stress-steps", 8,
 		"Number of individual mutations to apply in sequence")
-	flag.DurationVar(&mutationInterval, "mutation-interval", 5*time.Second,
-		"Delay between individual mutations. Tight intervals are deliberate: "+
+	flag.DurationVar(&stepInterval, "step-interval", 5*time.Second,
+		"Delay between individual changes. Tight intervals are deliberate: "+
 			"they stack changes on the reconciler while previous rollouts are "+
 			"still in-flight and exercise transitional states.")
 	// NOTE: `checkDSReplicationHealthy` needs EMQX 6.0.0 or newer.
-	flag.StringVar(&mutationImage, "mutation-image", "emqx/emqx:6.1.1",
+	flag.StringVar(&emqxImage, "emqx-image", "emqx/emqx:6.1.1",
 		"EMQX container image (with tag) to deploy for the mutation test")
 }
+
+// projectImage is the name of the image which will be build and loaded
+// with the code source changes to be tested.
+const projectImage = "emqx/emqx-operator:0.0.1"
 
 type mutationKind int
 
 const (
-	mutateScaleCores mutationKind = iota
-	mutateScaleReplicants
+	scaleCores mutationKind = iota
+	scaleReplicants
 )
 
 func (k mutationKind) String() string {
 	switch k {
-	case mutateScaleCores:
+	case scaleCores:
 		return "scale-cores"
-	case mutateScaleReplicants:
+	case scaleReplicants:
 		return "scale-replicants"
 	}
 	return "unknown"
@@ -96,24 +94,22 @@ type clusterState struct {
 // Each entry is one concrete (kind, value) pair; to add a new mutation type,
 // just append more entries to this slice.
 var mutationChoices = []mutation{
-	{mutateScaleCores, 2},
-	{mutateScaleCores, 3},
-	{mutateScaleCores, 4},
-	{mutateScaleCores, 5},
-	{mutateScaleReplicants, 1},
-	{mutateScaleReplicants, 2},
-	{mutateScaleReplicants, 3},
-	{mutateScaleReplicants, 4},
-	{mutateScaleReplicants, 5},
+	{scaleCores, 2},
+	{scaleCores, 3},
+	{scaleCores, 4},
+	{scaleCores, 5},
+	{scaleReplicants, 1},
+	{scaleReplicants, 2},
+	{scaleReplicants, 3},
+	{scaleReplicants, 4},
+	{scaleReplicants, 5},
 }
 
-// planMutations draws `steps` mutations uniformly at random from
+// planStress draws `steps` mutations uniformly at random from
 // `mutationChoices`. An identical consecutive mutation (same kind and
 // same value as the one just emitted) is resampled, so the plan never
-// contains a truly no-op patch back-to-back; non-adjacent duplicates are
-// kept as-is because they still exercise the reconciler against a
-// different intermediate state.
-func planMutations(seed int64, steps int) []mutation {
+// contains a truly no-op patch back-to-back.
+func planStress(seed int64, steps int) []mutation {
 	rnd := rand.New(rand.NewSource(seed))
 	out := make([]mutation, 0, steps)
 	for len(out) < steps {
@@ -132,9 +128,9 @@ func finalState(plan []mutation, initial clusterState) clusterState {
 	s := initial
 	for _, m := range plan {
 		switch m.kind {
-		case mutateScaleCores:
+		case scaleCores:
 			s.cores = m.value
-		case mutateScaleReplicants:
+		case scaleReplicants:
 			s.replicants = m.value
 		}
 	}
@@ -144,12 +140,12 @@ func finalState(plan []mutation, initial clusterState) clusterState {
 // mutationPatch returns the JSON merge-patch that applies `m` to the CR.
 func mutationPatch(m mutation) string {
 	switch m.kind {
-	case mutateScaleCores:
+	case scaleCores:
 		return fmt.Sprintf(
 			`{"spec":{"coreTemplate":{"spec":{"replicas":%d}}}}`,
 			m.value,
 		)
-	case mutateScaleReplicants:
+	case scaleReplicants:
 		return fmt.Sprintf(
 			`{"spec":{"replicantTemplate":{"spec":{"replicas":%d}}}}`,
 			m.value,
@@ -158,85 +154,92 @@ func mutationPatch(m mutation) string {
 	panic(fmt.Sprintf("unknown mutation kind: %v", m.kind))
 }
 
-//nolint:errcheck
-var _ = Describe("EMQX Cluster / Mutation Testing", Label("emqx", "mutation"), Ordered, func() {
+func TestStress(t *testing.T) {
+	RegisterFailHandler(Fail)
+	// Set the default timeout and interval for async assertions
+	SetDefaultEventuallyTimeout(time.Minute * 5)
+	SetDefaultEventuallyPollingInterval(time.Second * 3)
+	// Run tests
+	RunSpecs(t, "Stress")
+}
 
-	const emqxCRBasic = "test/e2e/files/resources/emqx.yaml"
+var _ = BeforeSuite(func() {
+	By("generate manifests")
+	Expect(Run("make", "manifests")).To(Succeed())
 
+	By("build emqx-operator docker image")
+	Expect(Run("make", "docker-build-coverage",
+		fmt.Sprintf("OPERATOR_IMAGE=%s", projectImage),
+	)).To(Succeed())
+
+	By("load emqx-operator docker image into kind cluster")
+	Expect(LoadImageToKindClusterWithName(projectImage)).To(Succeed())
+})
+
+var _ = Describe("EMQX Cluster / Stress Testing", Label("emqx", "stress"), Ordered, func() {
+
+	const emqxCRBase = "test/e2e/files/resources/emqx.yaml"
+
+	// The plan is captured up-front so the test reports can show the exact
+	// sequence that was exercised, which is crucial for reproducing failures
+	// discovered by a given seed.
+	plan := planStress(GinkgoRandomSeed(), stressSteps)
 	initial := clusterState{cores: 2, replicants: 2}
 
 	BeforeAll(func() {
-		By("create manager namespace")
-		Expect(Kubectl("create", "ns", namespace)).To(Succeed())
+		if len(plan) == 0 {
+			Fail("planned stress sequence is empty")
+		} else {
+			By(fmt.Sprintf(
+				"planned stress sequence (steps=%d, interval=%s):",
+				stressSteps, stepInterval,
+			))
+			for i, m := range plan {
+				By(fmt.Sprintf("  [%d] %s=%d", i+1, m.kind, m.value))
+			}
+		}
 
-		By("install CRDs")
-		Expect(Run("make", "install")).To(Succeed())
-
-		By("deploy emqx-operator")
+		By("deploy EMQX Operator")
 		Expect(Run("make", "deploy",
 			fmt.Sprintf("OPERATOR_IMAGE=%s", projectImage),
 			fmt.Sprintf("KUSTOMIZATION_FILE_PATH=%s", "test/e2e/files/manager"),
 		)).To(Succeed())
 		Expect(Kubectl("wait", "deployment", "emqx-operator-controller-manager",
 			"--for", "condition=Available",
-			"--namespace", namespace,
+			"--namespace", Namespace,
 			"--timeout", "1m",
 		)).To(Succeed(), "Timed out waiting for emqx-operator deployment")
 	})
 
 	AfterAll(func() {
-		By("undeploy emqx-operator")
+		By("undeploy EMQX Operator")
 		_ = Run("make", "undeploy")
-
-		By("uninstall CRDs")
-		_ = Run("make", "uninstall")
-
-		By("delete manager namespace")
-		_ = Kubectl("delete", "ns", namespace)
 	})
 
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
-			DumpDiagnosticReport(namespace, "emqx-mutation", CurrentSpecReport().StartTime)
+			DumpDiagnosticReport(Namespace, "emqx-mutation", CurrentSpecReport().StartTime)
 		}
 	})
 
-	// The plan is captured up-front so the test reports can show the exact
-	// sequence that was exercised, which is crucial for reproducing failures
-	// discovered by a given seed.
-	plan := planMutations(mutationSeed, mutationSteps)
-
 	It("deploy cluster", func() {
-		By(fmt.Sprintf(
-			"planned mutation sequence (seed=%d, steps=%d, interval=%s, image=%s):",
-			mutationSeed, mutationSteps, mutationInterval, mutationImage,
-		))
-		for i, m := range plan {
-			By(fmt.Sprintf("  [%d] %s=%d", i+1, m.kind, m.value))
-		}
-
 		By("create EMQX cluster")
-		emqxCR := PatchDocument(
-			FromYAMLFile(emqxCRBasic),
-			withImage(mutationImage),
-			withCores(initial.cores),
-			withReplicants(initial.replicants),
-			withConfig(configDS()),
-		)
+		emqxCR := SpecFromYAMLFile(emqxCRBase).
+			WithImage(emqxImage).
+			WithCores(initial.cores).
+			WithReplicants(initial.replicants).
+			WithConfig(ConfigDS()).
+			ToJSONDocument()
 		Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 		By("wait for EMQX cluster to be ready")
-		Eventually(checkEMQXReady).Should(Succeed())
-		Eventually(checkEMQXStatus).WithArguments(initial.cores).Should(Succeed())
-		Eventually(checkReplicantStatus).WithArguments(initial.replicants).Should(Succeed())
-		Eventually(checkDSReplicationStatus).WithArguments(initial.cores).Should(Succeed())
-		Eventually(checkDSReplicationHealthy).Should(Succeed())
+		Eventually(EMQXReady).Should(Succeed())
+		Eventually(CoresStable).WithArguments(initial.cores).Should(Succeed())
+		Eventually(ReplicantsStable).WithArguments(initial.replicants).Should(Succeed())
+		Eventually(DSReplicationStable).WithArguments(initial.cores).Should(Succeed())
+		Eventually(DSReplicationHealthy).Should(Succeed())
 	})
 
 	It("apply mutation sequence", func() {
-		if len(plan) == 0 {
-			Skip("mutation plan is empty")
-		}
-
 		// MQTTX holds ~25 long-lived MQTT connections against the cluster
 		// service. That load is what turns a plain core scale-down into a
 		// real node evacuation (the operator drains connections from the
@@ -264,7 +267,7 @@ var _ = Describe("EMQX Cluster / Mutation Testing", Label("emqx", "mutation"), O
 			// still in-flight. A fixed delay gives the controller a chance to
 			// observe each change but keeps the queue pressured.
 			if i < len(plan)-1 {
-				time.Sleep(mutationInterval)
+				time.Sleep(stepInterval)
 			}
 		}
 
@@ -274,20 +277,11 @@ var _ = Describe("EMQX Cluster / Mutation Testing", Label("emqx", "mutation"), O
 			"wait for EMQX cluster to settle at final state (cores=%d, replicants=%d)",
 			final.cores, final.replicants,
 		))
-		Eventually(checkEMQXReady).
-			WithArguments(sequenceStartedAt).
-			Should(Succeed())
-		Eventually(checkEMQXStatus).
-			WithArguments(final.cores).
-			Should(Succeed())
-		Eventually(checkReplicantStatus).
-			WithArguments(final.replicants).
-			Should(Succeed())
-		Eventually(checkDSReplicationHealthy).
-			Should(Succeed())
-		Eventually(checkDSReplicationStatus).
-			WithArguments(final.cores).
-			Should(Succeed())
+		Eventually(EMQXReady).WithArguments(sequenceStartedAt).Should(Succeed())
+		Eventually(CoresStable).WithArguments(final.cores).Should(Succeed())
+		Eventually(ReplicantsStable).WithArguments(final.replicants).Should(Succeed())
+		Eventually(DSReplicationStable).WithArguments(final.cores).Should(Succeed())
+		Eventually(DSReplicationHealthy).Should(Succeed())
 
 		By("verify all node evacuations have completed")
 		Eventually(KubectlOut).
@@ -298,6 +292,5 @@ var _ = Describe("EMQX Cluster / Mutation Testing", Label("emqx", "mutation"), O
 
 	It("delete cluster", func() {
 		Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
-		Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")
 	})
 })

--- a/test/e2e/upgrade/emqx_upgrade_test.go
+++ b/test/e2e/upgrade/emqx_upgrade_test.go
@@ -1,18 +1,17 @@
-package e2e
+package upgrade
 
 import (
 	"flag"
 	"fmt"
+	"testing"
+	"time"
 
+	. "github.com/emqx/emqx-operator/test/e2e"
 	. "github.com/emqx/emqx-operator/test/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-// Number of core and replicant replicas:
-var coreReplicas int = 2
-var replicantReplicas int = 2
 
 // Initial EMQX image:
 var emqxImageInitial string
@@ -25,21 +24,48 @@ func init() {
 	flag.StringVar(&emqxImageUpgrade, "emqx-image-upgrade", "", "EMQX image to upgrade to")
 }
 
-//nolint:errcheck
-var _ = Describe("EMQX Upgrade Test", Ordered, func() {
+const (
+	// projectImage is the name of the image which will be build and loaded
+	// with the code source changes to be tested.
+	projectImage = "emqx/emqx-operator:0.0.1"
+
+	// namespace where the project is deployed in
+	namespace = Namespace
+)
+
+func TestUpgrade(t *testing.T) {
+	RegisterFailHandler(Fail)
+	// Set the default timeout and interval for async assertions
+	SetDefaultEventuallyTimeout(time.Minute * 5)
+	SetDefaultEventuallyPollingInterval(time.Second * 3)
+	// Run tests
+	RunSpecs(t, "Upgrade")
+}
+
+var _ = BeforeSuite(func() {
+	By("generate manifests")
+	Expect(Run("make", "manifests")).To(Succeed())
+
+	By("build emqx-operator docker image")
+	Expect(Run("make", "docker-build-coverage",
+		fmt.Sprintf("OPERATOR_IMAGE=%s", projectImage),
+	)).To(Succeed())
+
+	By("load emqx-operator docker image into kind cluster")
+	Expect(LoadImageToKindClusterWithName(projectImage)).To(Succeed())
+})
+
+var _ = Describe("EMQX Upgrade", Ordered, func() {
+	// Number of core and replicant replicas:
+	var coreReplicas int = 2
+	var replicantReplicas int = 2
 
 	const emqxCRBasic = "test/e2e/files/resources/emqx.yaml"
 
 	BeforeAll(func() {
 		if emqxImageInitial == "" || emqxImageUpgrade == "" {
-			Skip("Both `-emqx-image-initial` and `-emqx-image-upgrade` should be set")
+			Fail("Both `-emqx-image-initial` and `-emqx-image-upgrade` should be set")
 		}
-
-		By("create manager namespace")
-		Expect(Kubectl("create", "ns", namespace)).To(Succeed())
-
-		By("install CRDs")
-		Expect(Run("make", "install")).To(Succeed())
 
 		By("deploy emqx-operator")
 		Expect(Run("make", "deploy",
@@ -66,26 +92,25 @@ var _ = Describe("EMQX Upgrade Test", Ordered, func() {
 
 	It("deploy cluster", func() {
 		By("create EMQX cluster")
-		emqxCR := PatchDocument(
-			FromYAMLFile(emqxCRBasic),
-			withImage(emqxImageInitial),
-			withCores(coreReplicas),
-			withReplicants(replicantReplicas),
-			withConfig(configDS()),
-		)
+		emqxCR := SpecFromYAMLFile(emqxCRBasic).
+			WithImage(emqxImageInitial).
+			WithCores(coreReplicas).
+			WithReplicants(replicantReplicas).
+			WithConfig(ConfigDS()).
+			ToJSONDocument()
 		Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
 		By("wait for EMQX cluster to be ready")
-		Eventually(checkEMQXReady).Should(Succeed())
-		Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-		Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
-		Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
-		Eventually(checkDSReplicationHealthy).Should(Succeed())
+		Eventually(EMQXReady).Should(Succeed())
+		Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+		Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+		Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
+		Eventually(DSReplicationHealthy).Should(Succeed())
 	})
 
 	It("upgrade EMQX version", func() {
 		By("create client workload")
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
-		defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml")
+		defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml") // nolint:errcheck
 		Expect(Kubectl("wait", "pod",
 			"--selector=app=mqttx",
 			"--for=condition=Ready",
@@ -100,11 +125,11 @@ var _ = Describe("EMQX Upgrade Test", Ordered, func() {
 			To(Succeed())
 
 		By("wait for EMQX cluster to be ready again")
-		Eventually(checkEMQXReady).WithArguments(changingTime).Should(Succeed())
-		Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
-		Eventually(checkReplicantStatus).WithArguments(replicantReplicas).Should(Succeed())
-		Eventually(checkDSReplicationStatus).WithArguments(coreReplicas).Should(Succeed())
-		Eventually(checkDSReplicationHealthy).Should(Succeed())
+		Eventually(EMQXReady).WithArguments(changingTime).Should(Succeed())
+		Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+		Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+		Eventually(DSReplicationStable).WithArguments(coreReplicas).Should(Succeed())
+		Eventually(DSReplicationHealthy).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -159,7 +158,7 @@ func InstallMetricsServer() error {
 	)
 }
 
-func UnnstallMetricsServer() {
+func UnistallMetricsServer() {
 	err := Kubectl("delete", "-f", metricsServerYAML)
 	if err != nil {
 		warnError(err)
@@ -211,20 +210,6 @@ func LoadImageToKindClusterWithName(name string) error {
 	return Run("kind", "load", "docker-image", name, "--name", cluster)
 }
 
-// GetNonEmptyLines converts given command output string into individual objects
-// according to line breakers, and ignores the empty elements in it.
-func GetNonEmptyLines(output string) []string {
-	var res []string
-	elements := strings.Split(output, "\n")
-	for _, element := range elements {
-		if element != "" {
-			res = append(res, element)
-		}
-	}
-
-	return res
-}
-
 // GetProjectDir will return the directory where the project is.
 // It walks up from the current working directory until it finds a go.mod file.
 func GetProjectDir() (string, error) {
@@ -244,53 +229,4 @@ func GetProjectDir() (string, error) {
 		}
 		dir = parent
 	}
-}
-
-// UncommentCode searches for target in the file and remove the comment prefix
-// of the target content. The target content may span multiple lines.
-func UncommentCode(filename, target, prefix string) error {
-	// false positive
-	// nolint:gosec
-	content, err := os.ReadFile(filename)
-	if err != nil {
-		return err
-	}
-	strContent := string(content)
-
-	idx := strings.Index(strContent, target)
-	if idx < 0 {
-		return fmt.Errorf("unable to find the code %s to be uncomment", target)
-	}
-
-	out := new(bytes.Buffer)
-	_, err = out.Write(content[:idx])
-	if err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(bytes.NewBufferString(target))
-	if !scanner.Scan() {
-		return nil
-	}
-	for {
-		_, err := out.WriteString(strings.TrimPrefix(scanner.Text(), prefix))
-		if err != nil {
-			return err
-		}
-		// Avoid writing a newline in case the previous line was the last in target.
-		if !scanner.Scan() {
-			break
-		}
-		if _, err := out.WriteString("\n"); err != nil {
-			return err
-		}
-	}
-
-	_, err = out.Write(content[idx+len(target):])
-	if err != nil {
-		return err
-	}
-	// false positive
-	// nolint:gosec
-	return os.WriteFile(filename, out.Bytes(), 0644)
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -158,7 +158,7 @@ func InstallMetricsServer() error {
 	)
 }
 
-func UnistallMetricsServer() {
+func UninstallMetricsServer() {
 	err := Kubectl("delete", "-f", metricsServerYAML)
 	if err != nil {
 		warnError(err)


### PR DESCRIPTION
## Summary

This PR focuses on a new basic stress test suite. This suite applies a short sequence of mutations to the EMQX CR under test  in a quick succession and verifies that Operator handles them smoothly. Currently, only mutations are scaling cores and replicants up and down.

Apart from that, this PR:
1. Fixes a minor issue with `migrationTargetNodes(...)` implementation.
2. Simplifies and isolates Prometheus-related test-only code to the respective test group.
3. Splits upgrade and stress test suites into their own packages.
4. Adds CI job to run stress tests, with just 2 profiles for now.