### PR TITLE
fix(manager): limit event source to single namespace if configured

### DIFF
--- a/api/v2/groupversion_info.go
+++ b/api/v2/groupversion_info.go
@@ -28,6 +28,9 @@ var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "apps.emqx.io", Version: "v2"}
 
+	// Fully-qualified kind of EMQX CRs.
+	EMQXResourceKind = "emqxes." + GroupVersion.Group
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/api/v2beta1/groupversion_info.go
+++ b/api/v2beta1/groupversion_info.go
@@ -28,6 +28,9 @@ var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "apps.emqx.io", Version: "v2beta1"}
 
+	// Fully-qualified kind of EMQX Rebalance CRs.
+	RebalanceResourceKind = "rebalances." + GroupVersion.Group
+
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,21 +17,30 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"os"
 	"strings"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -48,14 +57,6 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
-
-func init() {
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-
-	utilruntime.Must(crdv2.AddToScheme(scheme))
-	utilruntime.Must(crdv2beta1.AddToScheme(scheme))
-	// +kubebuilder:scaffold:scheme
-}
 
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
@@ -140,6 +141,14 @@ func main() {
 		// this setup is not recommended for production.
 	}
 
+	utilruntime.Must(clientscheme.AddToScheme(scheme))
+	utilruntime.Must(apiext.AddToScheme(scheme))
+	utilruntime.Must(crdv2.AddToScheme(scheme))
+	utilruntime.Must(crdv2beta1.AddToScheme(scheme))
+	// +kubebuilder:scaffold:scheme
+
+	singleNamespace = strings.TrimSpace(singleNamespace)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -164,42 +173,80 @@ func main() {
 		},
 	})
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		bailOut(err, "unable to instantiate controller manager")
+	}
+
+	// EMQX CRDs need to be fully registered on API server for controllers to start.
+	// As resources might be applied in unspecified order, wait for CRDs registration (at most a minute).
+	directClient, err := client.New(mgr.GetConfig(), client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	})
+	if err != nil {
+		bailOut(err, "unable to create k8s client")
+	}
+	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			ns := "default"
+			if singleNamespace != "" {
+				ns = singleNamespace
+			}
+			errUnregistered := &meta.NoKindMatchError{}
+			for name, o := range map[string]client.Object{
+				crdv2.EMQXResourceKind:           &crdv2.EMQX{},
+				crdv2beta1.RebalanceResourceKind: &crdv2beta1.Rebalance{},
+			} {
+				// To keep manager RBAC slimmer, try to get randomly named CR of respective kind:
+				crdName := types.NamespacedName{Name: "foobar", Namespace: ns}
+				err := directClient.Get(ctx, crdName, o)
+				if err == nil || apierrors.IsNotFound(err) {
+					continue
+				}
+				if errors.As(err, &errUnregistered) {
+					setupLog.Info("CRD not found, retrying with a backoff...", "crd", name)
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		},
+	)
+	if err != nil {
+		bailOut(err, "unable to retrieve CRDs")
 	}
 
 	if err = controller.NewEMQXReconciler(mgr).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EMQX")
-		os.Exit(1)
+		bailOut(err, "unable to create controller", "controller", "EMQX")
 	}
 
 	if err = controller.NewRebalanceReconciler(mgr).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Rebalance")
-		os.Exit(1)
+		bailOut(err, "unable to create controller", "controller", "Rebalance")
 	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		bailOut(err, "unable to set up health check")
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		bailOut(err, "unable to set up ready check")
 	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
+		bailOut(err, "unable to start controller manager")
 	}
+}
+
+func bailOut(err error, msg string, keysAndValues ...any) {
+	setupLog.Error(err, msg, keysAndValues...)
+	os.Exit(1)
 }
 
 // defaultNamespacesForCache maps controller-runtime's cache to one namespace when
 // --single-namespace is set, so list/watch requests stay namespaced (cluster Role is not required).
 func defaultNamespacesForCache(singleNamespace string) map[string]cache.Config {
-	if ns := strings.TrimSpace(singleNamespace); ns != "" {
-		return map[string]cache.Config{ns: {}}
+	if singleNamespace != "" {
+		return map[string]cache.Config{singleNamespace: {}}
 	}
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"strings"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -75,6 +76,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var singleNamespace string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -86,6 +88,9 @@ func main() {
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&singleNamespace, "single-namespace", "",
+		"If set, restrict the client cache to this namespace only. Leave unset to watch all namespaces. "+
+			"Set to the respective namespace if manager is running with namespace-scoped RBAC roles.")
 	opts := zap.Options{
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
@@ -155,7 +160,7 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 
 		Cache: cache.Options{
-			DefaultNamespaces: getWatchNamespace(),
+			DefaultNamespaces: defaultNamespacesForCache(singleNamespace),
 		},
 	})
 	if err != nil {
@@ -190,15 +195,11 @@ func main() {
 	}
 }
 
-// getWatchNamespace returns the Namespace the operator should be watching for changes
-func getWatchNamespace() map[string]cache.Config {
-	var watchNamespaceEnvVar = "WATCH_NAMESPACE"
-
-	ns, found := os.LookupEnv(watchNamespaceEnvVar)
-	if found {
-		return map[string]cache.Config{
-			ns: {},
-		}
+// defaultNamespacesForCache maps controller-runtime's cache to one namespace when
+// --single-namespace is set, so list/watch requests stay namespaced (cluster Role is not required).
+func defaultNamespacesForCache(singleNamespace string) map[string]cache.Config {
+	if ns := strings.TrimSpace(singleNamespace); ns != "" {
+		return map[string]cache.Config{ns: {}}
 	}
 	return nil
 }

--- a/deploy/charts/emqx-operator/templates/controller-manager.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager.yaml
@@ -35,6 +35,9 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --zap-devel={{ .Values.development }}
+        {{- if .Values.singleNamespace }}
+        - --single-namespace={{ .Release.Namespace }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: manager

--- a/deploy/charts/emqx-operator/values.yaml
+++ b/deploy/charts/emqx-operator/values.yaml
@@ -5,8 +5,8 @@
 # If true, CRDs will not be installed.
 skipCRDs: false
 
-# If true, the operator will watch only the namespace where it is deployed.
-# If false, the operator will watch all namespaces.
+# If true, the operator watches only the namespace where it is deployed.
+# If false, the operator watches all namespaces.
 singleNamespace: false
 
 # Development configures the logger to use a Zap development config

--- a/test/e2e-helm/helm_install_test.go
+++ b/test/e2e-helm/helm_install_test.go
@@ -104,6 +104,15 @@ var _ = Describe("Helm Install", Ordered, func() {
 			"--namespace", namespace,
 			"--timeout", "1m",
 		)).To(Succeed())
+
+		By("verify operator logs do not show errors")
+		Consistently(KubectlOut, "20s", "5s").
+			WithArguments("logs", "-n", namespace,
+				"deployment/emqx-operator-controller-manager", "--tail=50",
+			).ShouldNot(Or(
+			ContainSubstring("ERROR"),
+			ContainSubstring("Error"),
+		))
 	})
 
 	It("should install cleanly / pre-upgrade check disabled", func() {
@@ -122,5 +131,48 @@ var _ = Describe("Helm Install", Ordered, func() {
 		By("verify CRDs are installed")
 		Expect(crdExists("emqxes.apps.emqx.io")).To(BeTrue())
 		Expect(crdExists("rebalances.apps.emqx.io")).To(BeTrue())
+
+		By("verify operator logs do not show errors")
+		Consistently(KubectlOut, "20s", "5s").
+			WithArguments("logs", "-n", namespace,
+				"deployment/emqx-operator-controller-manager", "--tail=50",
+			).ShouldNot(Or(
+			ContainSubstring("ERROR"),
+			ContainSubstring("Error"),
+		))
+	})
+
+	It("should install cleanly / single namespace", func() {
+		By("install 2.3.x chart with singleNamespace=true")
+		Expect(helmInstall(namespace,
+			"--set", "singleNamespace=true",
+			"--set", "upgrade.preUpgradeCheck=false",
+		)).To(Succeed())
+
+		By("verify operator deployment is available")
+		Expect(Kubectl("wait", "deployment",
+			"emqx-operator-controller-manager",
+			"--for", "condition=Available",
+			"--namespace", namespace,
+			"--timeout", "1m",
+		)).To(Succeed())
+
+		By("verify CRDs are installed")
+		Expect(crdExists("emqxes.apps.emqx.io")).To(BeTrue())
+		Expect(crdExists("rebalances.apps.emqx.io")).To(BeTrue())
+
+		By("verify no ClusterRoles exists for the manager")
+		Expect(Kubectl("get", "role", "emqx-operator-manager-role",
+			"-n", namespace)).To(Succeed())
+		Expect(resourceExists("clusterrole", "emqx-operator-manager-role")).To(BeFalse())
+
+		By("verify operator logs do not show errors")
+		Consistently(KubectlOut, "30s", "5s").
+			WithArguments("logs", "-n", namespace,
+				"deployment/emqx-operator-controller-manager", "--tail=50",
+			).ShouldNot(Or(
+			ContainSubstring("ERROR"),
+			ContainSubstring("Error"),
+		))
 	})
 })


### PR DESCRIPTION
## Summary

Fixes #1193.

This PR addresses broken "single namespace" deployment mode configurable through a Helm Chart value, by correctly limiting the scope of event source in runtime. Without this, API server does not authorize requests due to namespace-scoped RBAC roles in this deployment mode.
