### PR TITLE
fix(api): provide empty `spec` default to inject field defaults

### DIFF
--- a/api/v2/emqx_types_spec.go
+++ b/api/v2/emqx_types_spec.go
@@ -159,6 +159,7 @@ type EMQXCoreTemplate struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Specification of the desired state of a core node.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+	// +kubebuilder:default={}
 	Spec EMQXCoreTemplateSpec `json:"spec,omitempty"`
 }
 

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -154,6 +154,7 @@ spec:
                         type: string
                     type: object
                   spec:
+                    default: {}
                     description: |-
                       Specification of the desired state of a core node.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -34,6 +34,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -156,6 +157,54 @@ var _ = AfterSuite(func() {
 	_ = testEnv.Stop()
 	// err := testEnv.Stop()
 	// Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("CRD Defaults", Ordered, func() {
+	var ns *corev1.Namespace
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "api-defaults-test-ns",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
+
+	It("defaults coreTemplate.spec when spec is missing", func() {
+		instance := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": crdv2.GroupVersion.String(),
+				"kind":       "EMQX",
+				"metadata": map[string]interface{}{
+					"name":      "emqx",
+					"namespace": ns.Name,
+				},
+				"spec": map[string]interface{}{
+					"image": "emqx",
+					"coreTemplate": map[string]interface{}{
+						"metadata": map[string]interface{}{},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+		actual := &crdv2.EMQX{}
+		Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "emqx"}, actual)).To(Succeed())
+		Expect(actual.Spec.CoreTemplate.Spec).To(HaveField("Replicas", And(
+			Not(BeNil()),
+			HaveValue(BeEquivalentTo(2)),
+		)))
+		Expect(actual.Spec.CoreTemplate.Spec).To(HaveField("PodSecurityContext", And(
+			Not(BeNil()),
+			HaveValue(HaveField("RunAsUser", HaveValue(BeEquivalentTo(1000)))),
+		)))
+	})
 })
 
 func newReconcileRound() *reconcileRound {

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 type updateStatus struct {
@@ -20,9 +21,9 @@ type updateStatus struct {
 func (u *updateStatus) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
 	status := &instance.Status
 
-	status.CoreNodesStatus.Replicas = *instance.Spec.CoreTemplate.Spec.Replicas
+	status.CoreNodesStatus.Replicas = ptr.Deref(instance.Spec.CoreTemplate.Spec.Replicas, 1)
 	if instance.Spec.ReplicantTemplate != nil {
-		status.ReplicantNodesStatus.Replicas = *instance.Spec.ReplicantTemplate.Spec.Replicas
+		status.ReplicantNodesStatus.Replicas = ptr.Deref(instance.Spec.ReplicantTemplate.Spec.Replicas, 1)
 	}
 
 	currentCoreSet, updateCoreSet := switchCoreSet(r, instance)


### PR DESCRIPTION
## Summary

Fixes #1098.

This PR tunes CRD schema to make CR instances properly inherit field defaults, working around API Server convention to not fill inner field defaults for unset fields, namely `spec` in this case.

Tested manually with the following manifest:
```
apiVersion: apps.emqx.io/v2
kind: EMQX
metadata:
  name: emqx
  namespace: default
spec:
  image: emqx/emqx:5.10
  config:
    data: "license.key = evaluation"
  coreTemplate:
    metadata:
      labels:
        app: emqx
```