### PR TITLE
config/emqx: skip non-object listener entries in GetListenersServicePorts

### DIFF
--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -268,6 +268,9 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 			continue
 		}
 		for name, lc := range listener.(hocon.Object) {
+			if lc == nil || lc.Type() != hocon.ObjectType {
+				continue
+			}
 			lconf := lc.(hocon.Object)
 			// Compatible with "enable" and "enabled"
 			// the default value of them both is true


### PR DESCRIPTION
Closes #1182. Removed/disabled default listeners can come back as scalars from /api/v5/configs; the bare `lc.(hocon.Object)` then crashes every reconcile.