### PR TITLE
test: run reconciler cases with faulty K8s client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
 
 ##@ Tests
 
+KUBEBUILDER_ASSETS = $(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)
+
 TEST_E2E_UPGRADE_IMAGE_INITIAL ?= emqx/emqx:5.10.2
 TEST_E2E_UPGRADE_IMAGE_UPGRADE ?= emqx/emqx:6.1.0
 
@@ -88,7 +90,11 @@ TEST_E2E_STRESS_IMAGE ?= emqx/emqx:6.1.0
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $$(go list ./... | grep -v /e2e) -coverprofile ./cover.out
+	env KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -v $$(go list ./... | grep -v /e2e) -coverprofile ./cover.out
+
+.PHONY: smoke-test-controller
+smoke-test-controller: manifests generate fmt vet envtest ## Run smoke tests.
+	env KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test -v ./internal/controller -ginkgo.v -ginkgo.label-filter "smoke" -coverprofile ./cover.out
 
 # Prometheus is installed by default; skip with:
 # - TEST_E2E_SKIP_PROMETHEUS_INSTALL=true

--- a/internal/controller/add_bootstrap_resource_suite_test.go
+++ b/internal/controller/add_bootstrap_resource_suite_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Reconciler addBootstrap", Ordered, func() {
 	})
 
 	It("should create bootstrap secrets", func() {
-		a := &addBootstrap{emqxReconciler}
-		result := a.reconcile(newReconcileRound(), instance)
-		Expect(result.err).NotTo(HaveOccurred())
+		a := &addBootstrap{emqxReconciler.withTransientErrors(1)}
+		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
+			Should(BeSuccessfulReconcile())
 
 		cookieSecret := &corev1.Secret{}
 		Expect(k8sClient.Get(ctx, instance.NodeCookieNamespacedName(), cookieSecret)).

--- a/internal/controller/add_bootstrap_resource_suite_test.go
+++ b/internal/controller/add_bootstrap_resource_suite_test.go
@@ -3,25 +3,22 @@ package controller
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Reconciler addBootstrap", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler addBootstrap", Ordered, func() {
 	var instance *crd.EMQX = &crd.EMQX{}
 	var ns *corev1.Namespace = &corev1.Namespace{}
 
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-add-emqx-bootstrap-test",
-				Labels: map[string]string{
-					"test": "e2e",
-				},
+				GenerateName: "controller-add-emqx-bootstrap-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
@@ -37,20 +34,12 @@ var _ = Describe("Reconciler addBootstrap", Ordered, func() {
 	})
 
 	AfterEach(func() {
-		bootstrapSecret := &corev1.Secret{}
-		err := k8sClient.Get(ctx, client.ObjectKey{
-			Namespace: ns.Name,
-			Name:      instance.BootstrapAPIKeyNamespacedName().Name,
-		}, bootstrapSecret)
-		if err == nil {
-			Expect(k8sClient.Delete(ctx, bootstrapSecret)).Should(Succeed())
-		} else if !errors.IsNotFound(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(k8sClient.DeleteAllOf(ctx, &corev1.Secret{}, client.InNamespace(ns.Name))).
+			Should(Succeed())
 	})
 
-	It("should create bootstrap secrets", func() {
-		a := &addBootstrap{emqxReconciler.withTransientErrors(1)}
+	It("creates bootstrap secrets", func() {
+		a := &addBootstrap{emqxReconciler()}
 		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
 			Should(BeSuccessfulReconcile())
 

--- a/internal/controller/add_core_set_suite_test.go
+++ b/internal/controller/add_core_set_suite_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Reconciler addCoreSet", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler addCoreSet", Ordered, func() {
 	var ns *corev1.Namespace
 	var instance *crd.EMQX
 	var a *addCoreSet
@@ -22,10 +22,8 @@ var _ = Describe("Reconciler addCoreSet", Ordered, func() {
 		// Create namespace:
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-add-emqx-core-test",
-				Labels: map[string]string{
-					"test": "e2e",
-				},
+				GenerateName: "controller-add-emqx-core-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
@@ -37,7 +35,7 @@ var _ = Describe("Reconciler addCoreSet", Ordered, func() {
 
 	BeforeEach(func() {
 		// Instantiate reconciler:
-		a = &addCoreSet{emqxReconciler.withTransientErrors(1)}
+		a = &addCoreSet{emqxReconciler()}
 		round = newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 	})

--- a/internal/controller/add_core_set_suite_test.go
+++ b/internal/controller/add_core_set_suite_test.go
@@ -37,14 +37,14 @@ var _ = Describe("Reconciler addCoreSet", Ordered, func() {
 
 	BeforeEach(func() {
 		// Instantiate reconciler:
-		a = &addCoreSet{emqxReconciler}
+		a = &addCoreSet{emqxReconciler.withTransientErrors(1)}
 		round = newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 	})
 
 	It("should create statefulSet", func() {
-		result := a.reconcile(round, instance)
-		Expect(result.err).ToNot(HaveOccurred())
+		Eventually(a.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(coreSets(instance)).To(ConsistOf(
 			HaveField("Spec.Template.Spec.Containers", ConsistOf(
 				HaveField("Image", Equal(instance.Spec.Image)))),
@@ -53,8 +53,8 @@ var _ = Describe("Reconciler addCoreSet", Ordered, func() {
 
 	It("change image updates existing statefulSet in place", func() {
 		instance.Spec.Image = "emqx/emqx"
-		result := a.reconcile(round, instance)
-		Expect(result.err).ToNot(HaveOccurred())
+		Eventually(a.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(actualObject(instance)).To(And(
 			HaveCondition(crd.Ready, HaveField("Status", Equal(metav1.ConditionFalse))),
 			HaveCondition(crd.CoreNodesProgressing, HaveField("Status", Equal(metav1.ConditionTrue))),

--- a/internal/controller/add_headless_service_suite_test.go
+++ b/internal/controller/add_headless_service_suite_test.go
@@ -41,8 +41,6 @@ var _ = Describe("Reconciler addHeadlessService", Ordered, func() {
 
 	It("generate headless svc", func() {
 		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
-			WithTimeout(timeout).
-			WithPolling(interval).
 			Should(BeSuccessfulReconcile())
 		Eventually(func() *corev1.Service {
 			svc := &corev1.Service{}

--- a/internal/controller/add_headless_service_suite_test.go
+++ b/internal/controller/add_headless_service_suite_test.go
@@ -9,23 +9,26 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Reconciler addHeadlessService", Ordered, func() {
-	var a *addHeadlessService
+var _ = DescribeClientFaultMatrix("Reconciler addHeadlessService", Ordered, func() {
 	var instance *crd.EMQX = &crd.EMQX{}
 	var ns *corev1.Namespace = &corev1.Namespace{}
 
-	BeforeEach(func() {
-		a = &addHeadlessService{emqxReconciler.withTransientErrors(1)}
-
+	BeforeAll(func() {
+		// Create namespace:
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-v2beta1-add-svc-test",
-				Labels: map[string]string{
-					"test": "e2e",
-				},
+				GenerateName: "controller-add-service-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+	})
 
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	BeforeEach(func() {
 		instance = emqx.DeepCopy()
 		instance.Namespace = ns.Name
 		instance.Spec.CoreTemplate = crd.EMQXCoreTemplate{
@@ -35,11 +38,8 @@ var _ = Describe("Reconciler addHeadlessService", Ordered, func() {
 		}
 	})
 
-	It("create namespace", func() {
-		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
-	})
-
-	It("generate headless svc", func() {
+	It("generates headless service", func() {
+		a := addHeadlessService{emqxReconciler()}
 		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
 			Should(BeSuccessfulReconcile())
 		Eventually(func() *corev1.Service {

--- a/internal/controller/add_headless_service_suite_test.go
+++ b/internal/controller/add_headless_service_suite_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Reconciler addHeadlessService", Ordered, func() {
 	var ns *corev1.Namespace = &corev1.Namespace{}
 
 	BeforeEach(func() {
-		a = &addHeadlessService{emqxReconciler}
+		a = &addHeadlessService{emqxReconciler.withTransientErrors(1)}
 
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -43,7 +43,7 @@ var _ = Describe("Reconciler addHeadlessService", Ordered, func() {
 		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
 			WithTimeout(timeout).
 			WithPolling(interval).
-			Should(Equal(subResult{}))
+			Should(BeSuccessfulReconcile())
 		Eventually(func() *corev1.Service {
 			svc := &corev1.Service{}
 			_ = k8sClient.Get(ctx, client.ObjectKey{Namespace: ns.Name, Name: "emqx-headless"}, svc)

--- a/internal/controller/add_replicant_set_suite_test.go
+++ b/internal/controller/add_replicant_set_suite_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler addReplicantSet", Ordered, func() {
 	var ns *corev1.Namespace = &corev1.Namespace{}
 	var instance *crd.EMQX = &crd.EMQX{}
 	var coreSet *appsv1.StatefulSet
@@ -26,10 +26,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-add-emqx-repl-test",
-				Labels: map[string]string{
-					"test": "e2e",
-				},
+				GenerateName: "controller-add-emqx-repl-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
@@ -116,7 +114,7 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 		Expect(k8sClient.Status().Update(ctx, corePod0)).To(Succeed())
 		Expect(k8sClient.Status().Update(ctx, corePod1)).To(Succeed())
 		// Instantiate reconciler and reconcile round:
-		a = &addReplicantSet{emqxReconciler.withTransientErrors(1)}
+		a = &addReplicantSet{emqxReconciler()}
 		round = newReconcileRound()
 		round.state, _ = loadReconcileState(ctx, k8sClient, instance)
 	})

--- a/internal/controller/add_replicant_set_suite_test.go
+++ b/internal/controller/add_replicant_set_suite_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 		Expect(k8sClient.Status().Update(ctx, corePod0)).To(Succeed())
 		Expect(k8sClient.Status().Update(ctx, corePod1)).To(Succeed())
 		// Instantiate reconciler and reconcile round:
-		a = &addReplicantSet{emqxReconciler}
+		a = &addReplicantSet{emqxReconciler.withTransientErrors(1)}
 		round = newReconcileRound()
 		round.state, _ = loadReconcileState(ctx, k8sClient, instance)
 	})
@@ -133,8 +133,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			// Clear replicant template:
 			instance.Spec.ReplicantTemplate = nil
 			// Reconciliation step should do nothing and succeed:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(replicantSets(instance)).To(BeEmpty())
 		})
 	})
@@ -154,16 +154,16 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			Expect(k8sClient.Status().Update(ctx, coreSet)).To(Succeed())
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			// Reconciliation step should succeed but not create any RS:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(replicantSets(instance)).To(BeEmpty())
 		})
 	})
 
 	When("core nodes are ready", func() {
 		It("should create replicaSet", func() {
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(replicantSets(instance)).To(ConsistOf(
 				HaveField("Spec.Template.Spec.Containers", ConsistOf(
 					HaveField("Image", Equal(instance.Spec.Image)),
@@ -181,8 +181,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			// Start with 3 replicas:
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(3))
 			// Run the reconcile to create replicantSet:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(replicantSets(instance)).To(ConsistOf(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(3))),
 			))
@@ -193,8 +193,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			// Reconciliation step should succeed:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			// Status conditions should reset:
 			Expect(actualObject(instance)).To(And(
 				HaveCondition(crd.Ready, HaveField("Status", Equal(metav1.ConditionFalse))),
@@ -216,8 +216,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			// Start with 1 replicas:
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(1))
 			// Run the reconcile to create replicantSet:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(replicantSets(instance)).To(ConsistOf(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(1))),
 			))
@@ -228,8 +228,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(4))
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			// Reconciliation step should succeed:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			// Status conditions should reset:
 			Expect(actualObject(instance)).To(And(
 				HaveCondition(crd.Ready, HaveField("Status", Equal(metav1.ConditionFalse))),
@@ -251,8 +251,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			// Start with 1 replicas:
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(1))
 			// Run the reconcile to create replicantSet:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(replicantSets(instance)).To(ConsistOf(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(1))),
 			))
@@ -264,8 +264,8 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			Expect(k8sClient.Update(ctx, instance)).To(Succeed())
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			// Reconciliation step should succeed:
-			result := a.reconcile(round, instance)
-			Expect(result.err).ToNot(HaveOccurred())
+			Eventually(a.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			// There should be two replicaSets soon:
 			Expect(replicantSets(instance)).To(ConsistOf(
 				HaveField("Spec.Template.Spec.Containers", ConsistOf(HaveField("Image", Equal(emqx.Spec.Image)))),

--- a/internal/controller/add_service_suite_test.go
+++ b/internal/controller/add_service_suite_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 				Labels: map[string]string{"test": "label"},
 			},
 		}
-		a = &addService{emqxReconciler}
+		a = &addService{emqxReconciler.withTransientErrors(1)}
 		round = newReconcileRoundWithRequester(mockConfigsRequester(validConfig))
 	})
 
@@ -86,7 +86,7 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 
 	It("creates Dashboard and Listeners Services from EMQX config", func() {
 		Eventually(a.reconcile).WithArguments(round, instance).
-			Should(Equal(subResult{}))
+			Should(BeSuccessfulReconcile())
 
 		dashboard := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, instance.DashboardServiceNamespacedName(), dashboard)).To(Succeed())
@@ -121,7 +121,7 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 		}
 
 		Eventually(a.reconcile).WithArguments(round, instance).
-			Should(Equal(subResult{}))
+			Should(BeSuccessfulReconcile())
 
 		listeners := &corev1.Service{}
 		Expect(k8sClient.Get(ctx, instance.ListenersServiceNamespacedName(), listeners)).To(Succeed())
@@ -135,7 +135,8 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 		}
 
 		r := newReconcileRoundWithRequester(mockConfigsRequester(validConfig))
-		Expect(a.reconcile(r, instance)).To(Equal(subResult{}))
+		Eventually(a.reconcile).WithArguments(r, instance).
+			Should(BeSuccessfulReconcile())
 
 		err := k8sClient.Get(ctx, instance.DashboardServiceNamespacedName(), &corev1.Service{})
 		Expect(k8sErrors.IsNotFound(err)).To(BeTrue())

--- a/internal/controller/add_service_suite_test.go
+++ b/internal/controller/add_service_suite_test.go
@@ -18,32 +18,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func mockConfigsRequester(configBody string) req.RequesterInterface {
-	return req.NewMockRequester(
+var _ = DescribeClientFaultMatrix("Reconciler addService", Ordered, func() {
+	var instance *crd.EMQX
+	var ns *corev1.Namespace
+
+	validConfig := config.WithDefaults("")
+	validConfigRequester := req.NewMockRequester(
 		func(method string, u url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
 			if method == "GET" && strings.Contains(u.Path, "api/v5/configs") {
-				return &http.Response{StatusCode: http.StatusOK}, []byte(configBody), nil
+				return &http.Response{StatusCode: http.StatusOK}, []byte(validConfig), nil
 			}
 			return &http.Response{StatusCode: http.StatusNotImplemented}, nil, nil
 		},
 	)
-}
-
-var _ = Describe("Reconciler addService", Ordered, func() {
-	var a *addService
-	var instance *crd.EMQX
-	var ns *corev1.Namespace
-	var round *reconcileRound
-
-	validConfig := config.WithDefaults("")
 
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-add-service-test",
-				Labels: map[string]string{
-					"test": "e2e",
-				},
+				GenerateName: "controller-add-service-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
@@ -57,16 +50,11 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 				Labels: map[string]string{"test": "label"},
 			},
 		}
-		a = &addService{emqxReconciler.withTransientErrors(1)}
-		round = newReconcileRoundWithRequester(mockConfigsRequester(validConfig))
 	})
 
 	AfterEach(func() {
-		var serviceList corev1.ServiceList
-		Expect(k8sClient.List(ctx, &serviceList, client.InNamespace(ns.Name))).To(Succeed())
-		for _, service := range serviceList.Items {
-			_ = k8sClient.Delete(ctx, &service)
-		}
+		Expect(k8sClient.DeleteAllOf(ctx, &corev1.Service{}, client.InNamespace(ns.Name))).
+			To(Succeed())
 	})
 
 	AfterAll(func() {
@@ -74,17 +62,15 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 	})
 
 	It("postpones when there is no usable API requester yet", func() {
-		r := &reconcileRound{
-			ctx:       ctx,
-			log:       logger,
-			conf:      emqxConf,
-			requester: &apiRequesterUnavailable{},
-			state:     &reconcileState{},
-		}
+		r := newReconcileRound()
+		r.requester = &apiRequesterUnavailable{}
+		a := &addService{emqxReconciler()}
 		Expect(a.reconcile(r, instance)).To(Equal(subResult{needRequeue: true}))
 	})
 
 	It("creates Dashboard and Listeners Services from EMQX config", func() {
+		a := &addService{emqxReconciler()}
+		round := newReconcileRoundWithRequester(validConfigRequester)
 		Eventually(a.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 
@@ -103,6 +89,8 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 				Replicas: ptr.To(int32(2)),
 			},
 		}
+
+		round := newReconcileRoundWithRequester(validConfigRequester)
 		round.state.replicantSets = []*appsv1.ReplicaSet{
 			{
 				ObjectMeta: metav1.ObjectMeta{
@@ -120,6 +108,7 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 			},
 		}
 
+		a := &addService{emqxReconciler()}
 		Eventually(a.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 
@@ -129,13 +118,13 @@ var _ = Describe("Reconciler addService", Ordered, func() {
 	})
 
 	It("does not create the Dashboard Service when the template is disabled", func() {
-		disabled := false
 		instance.Spec.DashboardServiceTemplate = &crd.ServiceTemplate{
-			Enabled: &disabled,
+			Enabled: ptr.To(false),
 		}
 
-		r := newReconcileRoundWithRequester(mockConfigsRequester(validConfig))
-		Eventually(a.reconcile).WithArguments(r, instance).
+		a := &addService{emqxReconciler()}
+		round := newReconcileRoundWithRequester(validConfigRequester)
+		Eventually(a.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 
 		err := k8sClient.Get(ctx, instance.DashboardServiceNamespacedName(), &corev1.Service{})

--- a/internal/controller/cleanup_outdated_suite_test.go
+++ b/internal/controller/cleanup_outdated_suite_test.go
@@ -14,20 +14,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Reconciler cleanupOutdatedSets", Ordered, func() {
-	var s *cleanupOutdatedSets
-
-	var instance *crd.EMQX = &crd.EMQX{}
-	var ns *corev1.Namespace = &corev1.Namespace{}
-	var round *reconcileRound
+var _ = DescribeClientFaultMatrix("Reconciler cleanupOutdatedSets", Ordered, func() {
+	var instance *crd.EMQX
+	var ns *corev1.Namespace
 
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-cleanup-outdated-test",
-				Labels: map[string]string{
-					"test": "e2e",
-				},
+				GenerateName: "controller-cleanup-outdated-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
@@ -50,8 +45,6 @@ var _ = Describe("Reconciler cleanupOutdatedSets", Ordered, func() {
 				},
 			},
 		}
-		s = &cleanupOutdatedSets{emqxReconciler.withTransientErrors(1)}
-		round = newReconcileRound()
 	})
 
 	It("should delete outdated replicant sets", func() {
@@ -93,10 +86,12 @@ var _ = Describe("Reconciler cleanupOutdatedSets", Ordered, func() {
 			Expect(k8sClient.Create(ctx, rs.DeepCopy())).Should(Succeed())
 			rs.Status.Replicas = 0
 			rs.Status.ObservedGeneration = 1
-			Expect(k8sClient.Status().Patch(ctx, rs.DeepCopy(), client.Merge)).Should(Succeed())
-			round.state.replicantSets = append(round.state.replicantSets, rs)
+			Expect(k8sClient.Status().Update(ctx, rs)).Should(Succeed())
 		}
 
+		s := &cleanupOutdatedSets{emqxReconciler()}
+		round := newReconcileRound()
+		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 

--- a/internal/controller/cleanup_outdated_suite_test.go
+++ b/internal/controller/cleanup_outdated_suite_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Reconciler cleanupOutdatedSets", Ordered, func() {
 				},
 			},
 		}
-		s = &cleanupOutdatedSets{emqxReconciler}
+		s = &cleanupOutdatedSets{emqxReconciler.withTransientErrors(1)}
 		round = newReconcileRound()
 	})
 
@@ -97,7 +97,8 @@ var _ = Describe("Reconciler cleanupOutdatedSets", Ordered, func() {
 			round.state.replicantSets = append(round.state.replicantSets, rs)
 		}
 
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 
 		Eventually(func() *appsv1.ReplicaSetList {
 			list := &appsv1.ReplicaSetList{}

--- a/internal/controller/cleanup_outdated_suite_test.go
+++ b/internal/controller/cleanup_outdated_suite_test.go
@@ -108,8 +108,6 @@ var _ = Describe("Reconciler cleanupOutdatedSets", Ordered, func() {
 			)
 			return list
 		}).
-			WithTimeout(timeout).
-			WithPolling(interval).
 			Should(HaveField("Items", HaveLen(int(instance.Spec.RevisionHistoryLimit))))
 	})
 })

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -108,7 +108,7 @@ func NewEMQXReconciler(mgr manager.Manager) *EMQXReconciler {
 	restConfig := mgr.GetConfig()
 	_ = kubernetes.NewForConfigOrDie(restConfig)
 	return &EMQXReconciler{
-		Handler:       handler.NewHandler(mgr),
+		Handler:       handler.NewHandler(mgr.GetClient()),
 		RESTConfig:    restConfig,
 		Scheme:        mgr.GetScheme(),
 		EventRecorder: mgr.GetEventRecorderFor("emqx-controller"),

--- a/internal/controller/suite_faulty_client_test.go
+++ b/internal/controller/suite_faulty_client_test.go
@@ -2,11 +2,11 @@ package controller
 
 import (
 	"context"
-	"errors"
 	"math/rand"
 	"reflect"
 	"sync"
 
+	emperror "emperror.dev/errors"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -82,8 +82,9 @@ func (f *faultEmitter) err() error {
 	}
 	f.remainingEvents--
 	if faultRandomFloat64() < f.probability {
-		logger.Error(errors.New("injected k8s client error"), "injecting error")
-		return errors.New("injected k8s client error")
+		err := emperror.WithStackDepth(emperror.NewPlain("injected k8s client error"), 3)
+		logger.Info("injecting fault", "error", err)
+		return err
 	}
 	return nil
 }

--- a/internal/controller/suite_faulty_client_test.go
+++ b/internal/controller/suite_faulty_client_test.go
@@ -3,20 +3,31 @@ package controller
 import (
 	"context"
 	"errors"
+	"math/rand"
 	"reflect"
 	"sync"
 
+	ginkgo "github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-type transientErrorClient struct {
-	mu        sync.Mutex
-	remaining int
+type faultEmitter struct {
+	mu              sync.Mutex
+	remainingEvents int
+	probability     float64
+	rng             *rand.Rand
 }
 
-func newTransientErrorClient(base client.WithWatch, numErrors int) client.Client {
-	fault := &transientErrorClient{remaining: numErrors}
+func newFaultyClient(
+	base client.WithWatch,
+	numEvents int,
+	faultProbability float64,
+) client.Client {
+	fault := newFaultEmitter(numEvents, faultProbability)
+	if fault == nil {
+		return base
+	}
 	return interceptor.NewClient(base, interceptor.Funcs{
 		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if err := fault.err(); err != nil {
@@ -43,26 +54,35 @@ func newTransientErrorClient(base client.WithWatch, numErrors int) client.Client
 			}
 			return c.Update(ctx, obj, opts...)
 		},
-		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-			if err := fault.err(); err != nil {
-				restoreObject(ctx, c, obj)
-				return err
-			}
-			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
-		},
 	})
 }
 
-func (f *transientErrorClient) err() error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.remaining == 0 {
+func newFaultEmitter(numEvents int, faultProbability float64) *faultEmitter {
+	if numEvents <= 0 {
 		return nil
 	}
-	f.remaining--
-	err := errors.New("injected k8s client error")
-	// logger.WithCallDepth(3).Error(err, "injected error", "remaining", f.remaining)
-	return err
+	if faultProbability <= 0 {
+		return nil
+	}
+	return &faultEmitter{
+		remainingEvents: numEvents,
+		probability:     faultProbability,
+		rng:             rand.New(rand.NewSource(ginkgo.GinkgoRandomSeed())),
+	}
+}
+
+func (f *faultEmitter) err() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.remainingEvents == 0 {
+		return nil
+	}
+	f.remainingEvents--
+	if f.rng.Float64() < f.probability {
+		logger.Error(errors.New("injected k8s client error"), "injecting error")
+		return errors.New("injected k8s client error")
+	}
+	return nil
 }
 
 func restoreObject(ctx context.Context, c client.Client, obj client.Object) {

--- a/internal/controller/suite_faulty_client_test.go
+++ b/internal/controller/suite_faulty_client_test.go
@@ -16,8 +16,12 @@ type faultEmitter struct {
 	mu              sync.Mutex
 	remainingEvents int
 	probability     float64
-	rng             *rand.Rand
 }
+
+var (
+	faultRandomMu sync.Mutex
+	faultRandom   *rand.Rand
+)
 
 func newFaultyClient(
 	base client.WithWatch,
@@ -67,7 +71,6 @@ func newFaultEmitter(numEvents int, faultProbability float64) *faultEmitter {
 	return &faultEmitter{
 		remainingEvents: numEvents,
 		probability:     faultProbability,
-		rng:             rand.New(rand.NewSource(ginkgo.GinkgoRandomSeed())),
 	}
 }
 
@@ -78,11 +81,20 @@ func (f *faultEmitter) err() error {
 		return nil
 	}
 	f.remainingEvents--
-	if f.rng.Float64() < f.probability {
+	if faultRandomFloat64() < f.probability {
 		logger.Error(errors.New("injected k8s client error"), "injecting error")
 		return errors.New("injected k8s client error")
 	}
 	return nil
+}
+
+func faultRandomFloat64() float64 {
+	faultRandomMu.Lock()
+	defer faultRandomMu.Unlock()
+	if faultRandom == nil {
+		faultRandom = rand.New(rand.NewSource(ginkgo.GinkgoRandomSeed()))
+	}
+	return faultRandom.Float64()
 }
 
 func restoreObject(ctx context.Context, c client.Client, obj client.Object) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -31,24 +31,26 @@ import (
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	"go.uber.org/zap/zapcore"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	controllerlog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	config "github.com/emqx/emqx-operator/internal/controller/config"
+	"github.com/emqx/emqx-operator/internal/handler"
 	req "github.com/emqx/emqx-operator/internal/requester"
 	// +kubebuilder:scaffold:imports
 )
@@ -56,14 +58,12 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var k8sManager ctrl.Manager
+var restConfig *rest.Config
+var k8sClient client.WithWatch
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 var logger logr.Logger
-var timeout, interval time.Duration
 
 var emqxReconciler *EMQXReconciler
 var emqxConf *config.EMQX
@@ -89,24 +89,20 @@ var emqx *crd.EMQX = &crd.EMQX{
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
+	gomega.SetDefaultEventuallyTimeout(time.Second * 10)
+	gomega.SetDefaultEventuallyPollingInterval(time.Second)
 	RunSpecs(t, "Controller Suite", ginkgotypes.ReporterConfig{
 		Verbose: true,
 	})
 }
 
 var _ = BeforeSuite(func() {
-	timeout = time.Second * 10
-	interval = time.Second
-
-	gomega.SetDefaultEventuallyTimeout(timeout)
-	gomega.SetDefaultEventuallyPollingInterval(interval)
-
 	logger = zap.New(
 		zap.WriteTo(GinkgoWriter),
 		zap.UseDevMode(true),
 		zap.Level(zapcore.DebugLevel),
 	)
-	logf.SetLogger(logger)
+	controllerlog.SetLogger(logger)
 
 	ctx, cancel = context.WithCancel(context.TODO())
 
@@ -125,35 +121,26 @@ var _ = BeforeSuite(func() {
 	}
 
 	var err error
-	// cfg is defined in this file globally.
-	cfg, err = testEnv.Start()
+	restConfig, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
+	Expect(restConfig).NotTo(BeNil())
 
 	err = crd.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	k8sClient, err = client.NewWithWatch(restConfig, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-	})
-	Expect(err).ToNot(HaveOccurred())
+	emqxReconciler = &EMQXReconciler{
+		Handler:       handler.NewHandler(k8sClient),
+		RESTConfig:    restConfig,
+		Scheme:        scheme.Scheme,
+		EventRecorder: &eventLogger{logger},
+	}
 
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
-		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
-	}()
-
-	emqxReconciler = NewEMQXReconciler(k8sManager)
 	emqxConf, err = config.EMQXConfigWithDefaults(emqx.Spec.Config.Data)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(emqxConf).ToNot(BeNil())
@@ -261,6 +248,13 @@ func newReconcileRoundWithRequester(requester req.RequesterInterface) *reconcile
 	}
 }
 
+// withTransientErrors attaches a transiently failing k8s client to the reconciler.
+func (r *EMQXReconciler) withTransientErrors(numErrors int) *EMQXReconciler {
+	r.Client = newTransientErrorClient(k8sClient, numErrors)
+	return r
+}
+
+// apiRequesterOverride always provides the given fixed API requester.
 type apiRequesterOverride struct {
 	requester req.RequesterInterface
 }
@@ -273,8 +267,8 @@ func (b *apiRequesterOverride) forPod(_ *corev1.Pod) req.RequesterInterface {
 	return b.requester
 }
 
-type apiRequesterUnavailable struct {
-}
+// apiRequesterUnavailable simulates apiRequester for completely unavailable cluser.
+type apiRequesterUnavailable struct{}
 
 func (b *apiRequesterUnavailable) forOldestCore(_ *reconcileState, _ ...reconcileStatePodFilter) req.RequesterInterface {
 	return nil
@@ -282,4 +276,46 @@ func (b *apiRequesterUnavailable) forOldestCore(_ *reconcileState, _ ...reconcil
 
 func (b *apiRequesterUnavailable) forPod(_ *corev1.Pod) req.RequesterInterface {
 	return nil
+}
+
+// eventLogger is an EventRecorder that simply redirects events into the specified logger instance.
+type eventLogger struct {
+	logger logr.Logger
+}
+
+func (el *eventLogger) writeEvent(object apiruntime.Object, annotations map[string]string, eventtype, reason, message string) {
+	kvs := []any{
+		"type", eventtype,
+		"reason", reason,
+		"message", message,
+	}
+	gvk, err := apiutil.GVKForObject(object, scheme.Scheme)
+	if err == nil {
+		kvs = append(kvs, "gv", gvk.GroupVersion())
+	}
+	if annotations != nil {
+		kvs = append(kvs, "annotations", annotations)
+	}
+	el.logger.Info("controller-event", kvs...)
+}
+
+func (el *eventLogger) Event(object apiruntime.Object, eventtype, reason, message string) {
+	el.writeEvent(object, nil, eventtype, reason, message)
+}
+
+func (el *eventLogger) Eventf(object apiruntime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	el.writeEvent(object, nil, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func (el *eventLogger) AnnotatedEventf(object apiruntime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	el.writeEvent(object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
+}
+
+func BeSuccessfulReconcile() gomegatypes.GomegaMatcher {
+	return WithTransform(
+		func(in subResult) error {
+			return in.err
+		},
+		Succeed(),
+	)
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -18,17 +18,18 @@ package controller
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
-	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	"go.uber.org/zap/zapcore"
@@ -39,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -57,14 +57,12 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var restConfig *rest.Config
 var k8sClient client.WithWatch
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
 var logger logr.Logger
 
-var emqxReconciler *EMQXReconciler
 var emqxConf *config.EMQX
 var emqx *crd.EMQX = &crd.EMQX{
 	ObjectMeta: metav1.ObjectMeta{
@@ -86,13 +84,53 @@ var emqx *crd.EMQX = &crd.EMQX{
 	},
 }
 
+const (
+	clientFaultModeNone   = "none"
+	clientFaultModeFixed  = "fixed"
+	clientFaultModeRandom = "random"
+)
+
+var (
+	clientFaultMode         string
+	clientFaultRandomEvents = flag.Int(
+		"client-fault-events",
+		10,
+		"number of fault events evaluated when random client faults are simulated",
+	)
+	clientFaultRandomProbability = flag.Float64(
+		"client-fault-probability",
+		0.25,
+		"probability that each random event emits a client fault",
+	)
+)
+
+var baseReconciler *EMQXReconciler
+
+func emqxReconciler() *EMQXReconciler {
+	switch clientFaultMode {
+	case clientFaultModeFixed:
+		r := *baseReconciler
+		r.Handler = handler.NewHandler(newFaultyClient(k8sClient, 1, 1))
+		return &r
+	case clientFaultModeRandom:
+		r := *baseReconciler
+		r.Handler = handler.NewHandler(newFaultyClient(
+			k8sClient,
+			*clientFaultRandomEvents,
+			*clientFaultRandomProbability,
+		))
+		return &r
+	default:
+		r := *baseReconciler
+		return &r
+	}
+}
+
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(time.Second * 10)
 	SetDefaultEventuallyPollingInterval(time.Second)
-	RunSpecs(t, "Controller Suite", ginkgotypes.ReporterConfig{
-		Verbose: true,
-	})
+	RunSpecs(t, "Controller Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -119,8 +157,7 @@ var _ = BeforeSuite(func() {
 			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
-	var err error
-	restConfig, err = testEnv.Start()
+	restConfig, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(restConfig).NotTo(BeNil())
 
@@ -133,16 +170,16 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	emqxReconciler = &EMQXReconciler{
+	emqxConf, err = config.EMQXConfigWithDefaults(emqx.Spec.Config.Data)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(emqxConf).ToNot(BeNil())
+
+	baseReconciler = &EMQXReconciler{
 		Handler:       handler.NewHandler(k8sClient),
 		RESTConfig:    restConfig,
 		Scheme:        scheme.Scheme,
 		EventRecorder: &eventLogger{logger},
 	}
-
-	emqxConf, err = config.EMQXConfigWithDefaults(emqx.Spec.Config.Data)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(emqxConf).ToNot(BeNil())
 })
 
 var _ = AfterSuite(func() {
@@ -247,12 +284,6 @@ func newReconcileRoundWithRequester(requester req.RequesterInterface) *reconcile
 	}
 }
 
-// withTransientErrors attaches a transiently failing k8s client to the reconciler.
-func (r *EMQXReconciler) withTransientErrors(numErrors int) *EMQXReconciler {
-	r.Client = newTransientErrorClient(k8sClient, numErrors)
-	return r
-}
-
 // apiRequesterOverride always provides the given fixed API requester.
 type apiRequesterOverride struct {
 	requester req.RequesterInterface
@@ -309,6 +340,40 @@ func (el *eventLogger) Eventf(object apiruntime.Object, eventtype, reason, messa
 func (el *eventLogger) AnnotatedEventf(object apiruntime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 	el.writeEvent(object, annotations, eventtype, reason, fmt.Sprintf(messageFmt, args...))
 }
+
+// Ginkgo helpers
+
+func DescribeClientFaultMatrix(text string, args ...interface{}) bool {
+	var testf func() = nil
+	var nodeArgs []interface{}
+
+	nodeArgs = append(nodeArgs, Offset(1))
+	for _, arg := range args {
+		if reflect.TypeOf(arg).Kind() == reflect.Func {
+			testf = arg.(func())
+		} else {
+			nodeArgs = append(nodeArgs, arg)
+		}
+	}
+
+	return Describe(text, Ordered, func() {
+		var contextArgs []interface{}
+
+		contextArgs = append(nodeArgs, Label("smoke"), func() {
+			BeforeAll(func() { clientFaultMode = clientFaultModeNone })
+			testf()
+		})
+		Context("client", contextArgs...)
+
+		contextArgs = append(nodeArgs, func() {
+			BeforeAll(func() { clientFaultMode = clientFaultModeRandom })
+			testf()
+		})
+		Context("faulty client", contextArgs...)
+	})
+}
+
+// Gomega helpers
 
 func BeSuccessfulReconcile() gomegatypes.GomegaMatcher {
 	return WithTransform(

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
-	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	"go.uber.org/zap/zapcore"
@@ -89,8 +88,8 @@ var emqx *crd.EMQX = &crd.EMQX{
 
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
-	gomega.SetDefaultEventuallyTimeout(time.Second * 10)
-	gomega.SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyTimeout(time.Second * 10)
+	SetDefaultEventuallyPollingInterval(time.Second)
 	RunSpecs(t, "Controller Suite", ginkgotypes.ReporterConfig{
 		Verbose: true,
 	})

--- a/internal/controller/suite_transient_error_client_test.go
+++ b/internal/controller/suite_transient_error_client_test.go
@@ -1,0 +1,77 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+type transientErrorClient struct {
+	mu        sync.Mutex
+	remaining int
+}
+
+func newTransientErrorClient(base client.WithWatch, numErrors int) client.Client {
+	fault := &transientErrorClient{remaining: numErrors}
+	return interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if err := fault.err(); err != nil {
+				return err
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if err := fault.err(); err != nil {
+				return err
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if err := fault.err(); err != nil {
+				return err
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if err := fault.err(); err != nil {
+				restoreObject(ctx, c, obj)
+				return err
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if err := fault.err(); err != nil {
+				restoreObject(ctx, c, obj)
+				return err
+			}
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	})
+}
+
+func (f *transientErrorClient) err() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.remaining == 0 {
+		return nil
+	}
+	f.remaining--
+	err := errors.New("injected k8s client error")
+	// logger.WithCallDepth(3).Error(err, "injected error", "remaining", f.remaining)
+	return err
+}
+
+func restoreObject(ctx context.Context, c client.Client, obj client.Object) {
+	stored, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return
+	}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), stored); err != nil {
+		return
+	}
+	reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(stored).Elem())
+}

--- a/internal/controller/sync_cluster_membership_suite_test.go
+++ b/internal/controller/sync_cluster_membership_suite_test.go
@@ -181,9 +181,10 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: "", Status: "stopped"},
 			{Name: emqxNodeName(coreSet.Name + "-10"), PodName: "", Status: "stopped"},
 		}
-		s := &syncClusterMembership{emqxReconciler}
+		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(ConsistOf(
 			emqxNodeName(coreSet.Name+"-1"),
 			emqxNodeName(coreSet.Name+"-10"),
@@ -195,9 +196,10 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "stopped"},
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: coreSet.Name + "-1", Status: "stopped"},
 		}
-		s := &syncClusterMembership{emqxReconciler}
+		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
 	})
 
@@ -206,9 +208,10 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running"},
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: "", Status: "running"},
 		}
-		s := &syncClusterMembership{emqxReconciler}
+		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
 	})
 
@@ -220,9 +223,10 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: "emqx@10.0.0.1", PodName: replicantPod.Name, Status: "stopped", Role: "replicant"},
 			{Name: "emqx@10.0.0.11", PodName: "", Status: "stopped", Role: "replicant"},
 		}
-		s := &syncClusterMembership{emqxReconciler}
+		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(ConsistOf("emqx@10.0.0.11"))
 	})
 
@@ -234,9 +238,10 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 		instance.Status.ReplicantNodes = []crd.EMQXNode{
 			{Name: "emqx@10.0.0.1", PodName: replicantPod.Name, Status: "stopped", Role: "replicant"},
 		}
-		s := &syncClusterMembership{emqxReconciler}
+		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
 	})
 
@@ -247,9 +252,10 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 		instance.Status.ReplicantNodes = []crd.EMQXNode{
 			{Name: "emqx@10.0.0.99", PodName: "", Status: "running", Role: "replicant"},
 		}
-		s := &syncClusterMembership{emqxReconciler}
+		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(s.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
 	})
 })

--- a/internal/controller/sync_cluster_membership_suite_test.go
+++ b/internal/controller/sync_cluster_membership_suite_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, func() {
 	var ns *corev1.Namespace
 	var instance *crd.EMQX
 	var round *reconcileRound
@@ -35,8 +35,8 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "controller-sync-cluster-test",
-				Labels: map[string]string{"test": "e2e"},
+				GenerateName: "controller-sync-cluster-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
@@ -181,7 +181,7 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: "", Status: "stopped"},
 			{Name: emqxNodeName(coreSet.Name + "-10"), PodName: "", Status: "stopped"},
 		}
-		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
+		s := &syncClusterMembership{emqxReconciler()}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
@@ -196,7 +196,7 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "stopped"},
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: coreSet.Name + "-1", Status: "stopped"},
 		}
-		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
+		s := &syncClusterMembership{emqxReconciler()}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
@@ -208,7 +208,7 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running"},
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: "", Status: "running"},
 		}
-		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
+		s := &syncClusterMembership{emqxReconciler()}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
@@ -223,7 +223,7 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 			{Name: "emqx@10.0.0.1", PodName: replicantPod.Name, Status: "stopped", Role: "replicant"},
 			{Name: "emqx@10.0.0.11", PodName: "", Status: "stopped", Role: "replicant"},
 		}
-		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
+		s := &syncClusterMembership{emqxReconciler()}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
@@ -238,7 +238,7 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 		instance.Status.ReplicantNodes = []crd.EMQXNode{
 			{Name: "emqx@10.0.0.1", PodName: replicantPod.Name, Status: "stopped", Role: "replicant"},
 		}
-		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
+		s := &syncClusterMembership{emqxReconciler()}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
@@ -252,7 +252,7 @@ var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
 		instance.Status.ReplicantNodes = []crd.EMQXNode{
 			{Name: "emqx@10.0.0.99", PodName: "", Status: "running", Role: "replicant"},
 		}
-		s := &syncClusterMembership{emqxReconciler.withTransientErrors(1)}
+		s := &syncClusterMembership{emqxReconciler()}
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())

--- a/internal/controller/sync_core_set_suite_test.go
+++ b/internal/controller/sync_core_set_suite_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Reconciler syncCoreSet", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 	var ns *corev1.Namespace = &corev1.Namespace{}
 	var instance *crd.EMQX
 
@@ -28,8 +28,8 @@ var _ = Describe("Reconciler syncCoreSet", Ordered, func() {
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   "controller-sync-core-set-test",
-				Labels: map[string]string{"test": "e2e"},
+				GenerateName: "controller-sync-core-set-test",
+				Labels:       map[string]string{"test": "e2e"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
@@ -201,7 +201,7 @@ var _ = Describe("Reconciler syncCoreSet", Ordered, func() {
 		})
 
 		It("should allow rolling update with multiple old cores", func() {
-			s := &syncCoreSet{emqxReconciler.withTransientErrors(1)}
+			s := &syncCoreSet{emqxReconciler()}
 			Eventually(s.rollingUpdate).WithArguments(round, instance).
 				Should(BeSuccessfulReconcile())
 			_, err := actualObject(pod1)
@@ -213,7 +213,7 @@ var _ = Describe("Reconciler syncCoreSet", Ordered, func() {
 			pod1.Labels[appsv1.ControllerRevisionHashLabelKey] = coreSet.Status.UpdateRevision
 			Expect(k8sClient.Update(ctx, pod1)).Should(Succeed())
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			s := &syncCoreSet{emqxReconciler.withTransientErrors(1)}
+			s := &syncCoreSet{emqxReconciler()}
 			Eventually(s.rollingUpdate).WithArguments(round, instance).
 				Should(BeSuccessfulReconcile())
 			Expect(actualObject(pod0)).To(

--- a/internal/controller/sync_core_set_suite_test.go
+++ b/internal/controller/sync_core_set_suite_test.go
@@ -201,9 +201,9 @@ var _ = Describe("Reconciler syncCoreSet", Ordered, func() {
 		})
 
 		It("should allow rolling update with multiple old cores", func() {
-			s := &syncCoreSet{emqxReconciler}
-			result := s.rollingUpdate(round, instance)
-			Expect(result).To(Equal(subResult{}))
+			s := &syncCoreSet{emqxReconciler.withTransientErrors(1)}
+			Eventually(s.rollingUpdate).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			_, err := actualObject(pod1)
 			Expect(k8sErrors.IsNotFound(err)).To(BeTrue(), "highest-ordinal outdated pod should be deleted first")
 		})
@@ -213,9 +213,9 @@ var _ = Describe("Reconciler syncCoreSet", Ordered, func() {
 			pod1.Labels[appsv1.ControllerRevisionHashLabelKey] = coreSet.Status.UpdateRevision
 			Expect(k8sClient.Update(ctx, pod1)).Should(Succeed())
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			s := &syncCoreSet{emqxReconciler}
-			result := s.rollingUpdate(round, instance)
-			Expect(result).To(Equal(subResult{}))
+			s := &syncCoreSet{emqxReconciler.withTransientErrors(1)}
+			Eventually(s.rollingUpdate).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(actualObject(pod0)).To(
 				Not(BeNil()),
 				"sole remaining outdated core must stay up while replicant ReplicaSet migrates",

--- a/internal/controller/sync_replicant_sets_suite_test.go
+++ b/internal/controller/sync_replicant_sets_suite_test.go
@@ -172,7 +172,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			s := &syncReplicantSets{emqxReconciler}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			// Pod should be annotated with deletion cost:
 			Expect(actualObject(currentReplicants[0])).To(
 				HaveField("Annotations", HaveKey("controller.kubernetes.io/pod-deletion-cost")),
@@ -188,7 +189,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			s := &syncReplicantSets{emqxReconciler}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			for _, p := range currentReplicants {
 				Expect(actualObject(p)).To(
 					HaveField("Annotations", HaveKey("controller.kubernetes.io/pod-deletion-cost")),
@@ -207,7 +209,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			s := &syncReplicantSets{emqxReconciler}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			for _, p := range currentReplicants {
 				Expect(actualObject(p)).To(Not(
 					HaveField("Annotations", HaveKey("controller.kubernetes.io/pod-deletion-cost")),
@@ -225,7 +228,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 
 			// Phase 2: numAllowedReplicas = min(3 + 2 - 3, 3) = 2
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(actualObject(update)).To(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(2))),
 			)
@@ -243,7 +247,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			// Phase 2: numAllowedReplicas = min(3 + 2 - 2, 3) = 2
 			round = newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(actualObject(update)).To(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(3))),
 			)
@@ -261,7 +266,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			// Phase 3: numAllowedReplicas = min(3 + 2 - 1, 3) = still 3
 			round = newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(actualObject(update)).To(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(3))),
 			)
@@ -369,7 +375,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			s := &syncReplicantSets{emqxReconciler}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 			Expect(actualObject(rs)).To(
 				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(5))),
 			)
@@ -383,7 +390,8 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			s := &syncReplicantSets{emqxReconciler}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 
 			numAnnotated := 0
 			for _, p := range replicants {
@@ -406,10 +414,11 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			rs.Status.AvailableReplicas = 0
 			Expect(k8sClient.Status().Update(ctx, rs)).Should(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 
 			numAnnotated := 0
 			for _, p := range replicants {
@@ -429,10 +438,11 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 
 		It("is a no-op at desired replica count", func() {
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(3))
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 
 			// No pods annotated.
 			for _, p := range replicants {
@@ -483,10 +493,11 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			_ = util.AttachPodAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
 			Expect(k8sClient.Update(ctx, replicants[0])).Should(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 
 			// Stale annotations must be gone.
 			Expect(actualObject(replicants[0])).To(And(
@@ -528,8 +539,9 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			))
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler}
-			Expect(s.reconcile(round, instance)).To(Equal(subResult{}))
+			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
 
 			// Stale annotations must be gone.
 			Expect(actualObject(replicants[0])).To(And(
@@ -733,7 +745,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 		update.Status.AvailableReplicas = 0
 		Expect(k8sClient.Status().Update(ctx, update)).Should(Succeed())
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		s := &syncReplicantSets{emqxReconciler}
+		s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
 		Expect(admissions).Should(BeEmpty())
 	})
@@ -754,7 +766,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 		}
 		round := newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		s := &syncReplicantSets{emqxReconciler}
+		s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
 		// Pod should still be admitted (as admissionWait) despite zero budget,
 		// because it has the scaling-down annotation from a previous iteration.
@@ -783,7 +795,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 		}
 		round := newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		s := &syncReplicantSets{emqxReconciler}
+		s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
 		Expect(admissions).Should(HaveLen(1))
 		Expect(admissions[0].Admission).Should(And(

--- a/internal/controller/sync_replicant_sets_suite_test.go
+++ b/internal/controller/sync_replicant_sets_suite_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func() {
 	var ns *corev1.Namespace = &corev1.Namespace{}
 	var instance *crd.EMQX
 
@@ -41,7 +41,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-sync-replicant-sets-suite-test",
+				GenerateName: "controller-sync-replicant-sets-suite-test",
 				Labels: map[string]string{
 					"test": "e2e",
 				},
@@ -169,7 +169,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 		})
 
 		It("should scale down current replicant set and annotate pod", func() {
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -186,7 +186,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 
 		It("drains up to maxUnavailable old pods in one reconcile", func() {
 			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{MaxUnavailable: ptr.To(intstr.FromInt(3))}
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -206,7 +206,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			Expect(actualObject(current)).To(Not(BeNil()))
 			current.Status.AvailableReplicas = 0
 			Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -223,7 +223,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 
 		It("surges the update RS gradually with maxSurge", func() {
 			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{MaxSurge: ptr.To(intstr.FromInt(2))}
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 
@@ -372,7 +372,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 
 		It("scales up replicant set when desired > current", func() {
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(5))
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -387,7 +387,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{MaxUnavailable: ptr.To(intstr.FromInt(2))}
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
 
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -414,7 +414,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			rs.Status.AvailableReplicas = 0
 			Expect(k8sClient.Status().Update(ctx, rs)).Should(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -438,7 +438,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 
 		It("is a no-op at desired replica count", func() {
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(3))
-			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -462,7 +462,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			for i := range instance.Status.ReplicantNodes {
 				instance.Status.ReplicantNodes[i].Sessions = 100
 			}
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 
@@ -493,7 +493,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			_ = util.AttachPodAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
 			Expect(k8sClient.Update(ctx, replicants[0])).Should(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			Eventually(s.reconcile).WithArguments(round, instance).
@@ -539,7 +539,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			))
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+			s := &syncReplicantSets{emqxReconciler()}
 			Eventually(s.reconcile).WithArguments(round, instance).
 				Should(BeSuccessfulReconcile())
 
@@ -573,7 +573,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			))
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 
-			s := &syncReplicantSets{emqxReconciler}
+			s := &syncReplicantSets{emqxReconciler()}
 			result := s.reconcile(round, instance)
 			Expect(result.err).To(HaveOccurred())
 
@@ -587,7 +587,7 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 	})
 })
 
-var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func() {
 	var ns *corev1.Namespace = &corev1.Namespace{}
 	var instance *crd.EMQX
 
@@ -604,7 +604,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "controller-sync-replicant-sets-admission-test",
+				GenerateName: "controller-sync-replicant-sets-admission-test",
 				Labels: map[string]string{
 					"test": "e2e",
 				},
@@ -745,7 +745,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 		update.Status.AvailableReplicas = 0
 		Expect(k8sClient.Status().Update(ctx, update)).Should(Succeed())
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+		s := &syncReplicantSets{emqxReconciler()}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
 		Expect(admissions).Should(BeEmpty())
 	})
@@ -766,7 +766,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 		}
 		round := newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+		s := &syncReplicantSets{emqxReconciler()}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
 		// Pod should still be admitted (as admissionWait) despite zero budget,
 		// because it has the scaling-down annotation from a previous iteration.
@@ -795,7 +795,7 @@ var _ = Describe("Reconciler syncReplicantSets admission", Ordered, func() {
 		}
 		round := newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		s := &syncReplicantSets{emqxReconciler.withTransientErrors(1)}
+		s := &syncReplicantSets{emqxReconciler()}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
 		Expect(admissions).Should(HaveLen(1))
 		Expect(admissions[0].Admission).Should(And(

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 const (
@@ -43,10 +42,10 @@ func newPatcher() *Patcher {
 	return patcher
 }
 
-func NewHandler(mgr manager.Manager) *Handler {
+func NewHandler(client client.Client) *Handler {
 	return &Handler{
 		Patcher: newPatcher(),
-		Client:  mgr.GetClient(),
+		Client:  client,
 	}
 }
 

--- a/test/e2e/stress/emqx_stress_test.go
+++ b/test/e2e/stress/emqx_stress_test.go
@@ -40,7 +40,6 @@ import (
 // across different seeds / sequence lengths without recompilation.
 var (
 	stressSteps  int
-	randomSeed   int64
 	stepInterval time.Duration
 	emqxImage    string
 )
@@ -48,8 +47,6 @@ var (
 func init() {
 	flag.IntVar(&stressSteps, "stress-steps", 8,
 		"Number of individual mutations to apply in sequence")
-	flag.Int64Var(&randomSeed, "random-seed", 0,
-		"Seed for the pseudo-random mutation sequence. Defaults to the Ginkgo random seed when unset.")
 	flag.DurationVar(&stepInterval, "step-interval", 5*time.Second,
 		"Delay between individual changes. Tight intervals are deliberate: "+
 			"they stack changes on the reconciler while previous rollouts are "+
@@ -183,16 +180,10 @@ var _ = Describe("EMQX Cluster / Stress Testing", Label("emqx", "stress"), Order
 
 	const emqxCRBase = "test/e2e/files/resources/emqx.yaml"
 
-	seed := GinkgoRandomSeed()
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "random-seed" {
-			seed = randomSeed
-		}
-	})
-
 	// The plan is captured up-front so the test reports can show the exact
 	// sequence that was exercised, which is crucial for reproducing failures
 	// discovered by a given seed.
+	seed := GinkgoRandomSeed()
 	plan := planStress(seed, stressSteps)
 	initial := clusterState{cores: 2, replicants: 2}
 


### PR DESCRIPTION
## Summary

This PR aims to improve test coverage through client fault injection: controller test suite now runs each test context 2 times: with a regular testenv k8s client and with a faulty one, with random fault injection pattern (25% probability, at most 10 consecutive faults).