### PR TITLE
fix: handle scaling replicants down to zero replicas

### DIFF
--- a/api/v2/const.go
+++ b/api/v2/const.go
@@ -29,7 +29,7 @@ const (
 	// labels
 	LabelInstance        string = "apps.emqx.io/instance"   // my-emqx
 	LabelManagedBy       string = "apps.emqx.io/managed-by" // emqx-operator
-	LabelDBRole          string = "apps.emqx.io/db-role"    // core, replicant
+	LabelMriaRole        string = "apps.emqx.io/db-role"    // core, replicant
 	LabelPodTemplateHash string = "apps.emqx.io/pod-template-hash"
 )
 

--- a/api/v2/const.go
+++ b/api/v2/const.go
@@ -21,6 +21,11 @@ import corev1 "k8s.io/api/core/v1"
 const DefaultContainerName string = "emqx"
 
 const (
+	RoleCore      string = "core"
+	RoleReplicant string = "replicant"
+)
+
+const (
 	// labels
 	LabelInstance        string = "apps.emqx.io/instance"   // my-emqx
 	LabelManagedBy       string = "apps.emqx.io/managed-by" // emqx-operator

--- a/api/v2/emqx_types_spec.go
+++ b/api/v2/emqx_types_spec.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 // EMQXSpec defines the desired state of EMQX.
@@ -313,7 +314,7 @@ type ServiceTemplate struct {
 }
 
 func (spec *EMQXSpec) HasReplicants() bool {
-	return spec.ReplicantTemplate != nil && spec.ReplicantTemplate.Spec.Replicas != nil && *spec.ReplicantTemplate.Spec.Replicas > 0
+	return spec.ReplicantTemplate != nil && ptr.Deref(spec.ReplicantTemplate.Spec.Replicas, 1) > 0
 }
 
 func (s *ServiceTemplate) IsEnabled() bool {

--- a/api/v2/labels.go
+++ b/api/v2/labels.go
@@ -36,9 +36,9 @@ func (instance *EMQX) DefaultLabelsWith(extraLabels ...map[string]string) map[st
 }
 
 func CoreLabels() map[string]string {
-	return map[string]string{LabelDBRole: RoleCore}
+	return map[string]string{LabelMriaRole: RoleCore}
 }
 
 func ReplicantLabels() map[string]string {
-	return map[string]string{LabelDBRole: RoleReplicant}
+	return map[string]string{LabelMriaRole: RoleReplicant}
 }

--- a/api/v2/labels.go
+++ b/api/v2/labels.go
@@ -36,9 +36,9 @@ func (instance *EMQX) DefaultLabelsWith(extraLabels ...map[string]string) map[st
 }
 
 func CoreLabels() map[string]string {
-	return map[string]string{LabelDBRole: "core"}
+	return map[string]string{LabelDBRole: RoleCore}
 }
 
 func ReplicantLabels() map[string]string {
-	return map[string]string{LabelDBRole: "replicant"}
+	return map[string]string{LabelDBRole: RoleReplicant}
 }

--- a/internal/controller/add_core_set_test.go
+++ b/internal/controller/add_core_set_test.go
@@ -51,7 +51,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		assert.Equal(t, "core-label-value", got.Labels["core-label-key"])
 		assert.Equal(t, "emqx", got.Labels[crdv2.LabelInstance])
 		assert.Equal(t, "emqx-operator", got.Labels[crdv2.LabelManagedBy])
-		assert.Equal(t, "core", got.Labels[crdv2.LabelDBRole])
+		assert.Equal(t, "core", got.Labels[crdv2.LabelMriaRole])
 		assert.Equal(t, "emqx-core-"+got.Labels[crdv2.LabelPodTemplateHash], got.Name)
 		assert.Equal(t, emqx.Namespace, got.Namespace)
 	})
@@ -64,7 +64,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crdv2.LabelInstance:        "emqx",
 			crdv2.LabelManagedBy:       "emqx-operator",
-			crdv2.LabelDBRole:          "core",
+			crdv2.LabelMriaRole:        "core",
 			crdv2.LabelPodTemplateHash: got.Labels[crdv2.LabelPodTemplateHash],
 			"core-label-key":           "core-label-value",
 		}, got.Spec.Template.Labels)
@@ -72,7 +72,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crdv2.LabelInstance:        "emqx",
 			crdv2.LabelManagedBy:       "emqx-operator",
-			crdv2.LabelDBRole:          "core",
+			crdv2.LabelMriaRole:        "core",
 			crdv2.LabelPodTemplateHash: got.Labels[crdv2.LabelPodTemplateHash],
 			"core-label-key":           "core-label-value",
 		}, got.Spec.Selector.MatchLabels)
@@ -168,7 +168,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 					Name:      "emqx-core-data",
 					Namespace: "emqx",
 					Labels: map[string]string{
-						crdv2.LabelDBRole:    "core",
+						crdv2.LabelMriaRole:  "core",
 						crdv2.LabelInstance:  "emqx",
 						crdv2.LabelManagedBy: "emqx-operator",
 						"core-label-key":     "core-label-value",

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -27,7 +27,7 @@ type addReplicantSet struct {
 
 func (a *addReplicantSet) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
 	// Cluster w/o replicants, skip this step.
-	if instance.Spec.ReplicantTemplate == nil {
+	if !instance.Spec.HasReplicants() {
 		return subResult{}
 	}
 

--- a/internal/controller/add_replicant_set_suite_test.go
+++ b/internal/controller/add_replicant_set_suite_test.go
@@ -176,7 +176,7 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 			)
 		})
 
-		It("should update replicaSet", func() {
+		It("should do nothing", func() {
 			// Set replicas count to 0:
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
 			// Reconciliation step should succeed:
@@ -185,10 +185,10 @@ var _ = Describe("Reconciler addReplicantSet", Ordered, func() {
 				WithTimeout(timeout).
 				WithPolling(interval).
 				Should(Equal(subResult{}))
-			// ReplicaSet should be updated in place:
+			// ReplicaSet scaling is handled by syncReplicantSets:
 			Eventually(replicantSets).WithArguments(instance).
 				Should(ConsistOf(
-					HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+					HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(3))),
 				))
 		})
 

--- a/internal/controller/add_replicant_set_test.go
+++ b/internal/controller/add_replicant_set_test.go
@@ -54,7 +54,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		assert.Equal(t, "repl-label-value", got.Labels["repl-label-key"])
 		assert.Equal(t, "emqx", got.Labels[crdv2.LabelInstance])
 		assert.Equal(t, "emqx-operator", got.Labels[crdv2.LabelManagedBy])
-		assert.Equal(t, "replicant", got.Labels[crdv2.LabelDBRole])
+		assert.Equal(t, "replicant", got.Labels[crdv2.LabelMriaRole])
 		assert.Equal(t, "emqx-replicant-"+got.Labels[crdv2.LabelPodTemplateHash], got.Name)
 		assert.Equal(t, emqx.Namespace, got.Namespace)
 	})
@@ -68,7 +68,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crdv2.LabelInstance:        "emqx",
 			crdv2.LabelManagedBy:       "emqx-operator",
-			crdv2.LabelDBRole:          "replicant",
+			crdv2.LabelMriaRole:        "replicant",
 			crdv2.LabelPodTemplateHash: got.Labels[crdv2.LabelPodTemplateHash],
 			"repl-label-key":           "repl-label-value",
 		}, got.Spec.Template.Labels)
@@ -76,7 +76,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crdv2.LabelInstance:        "emqx",
 			crdv2.LabelManagedBy:       "emqx-operator",
-			crdv2.LabelDBRole:          "replicant",
+			crdv2.LabelMriaRole:        "replicant",
 			crdv2.LabelPodTemplateHash: got.Labels[crdv2.LabelPodTemplateHash],
 			"repl-label-key":           "repl-label-value",
 		}, got.Spec.Selector.MatchLabels)

--- a/internal/controller/add_service_test.go
+++ b/internal/controller/add_service_test.go
@@ -81,7 +81,7 @@ func TestGenerateDashboardService(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			crdv2.LabelInstance:  "emqx",
 			crdv2.LabelManagedBy: "emqx-operator",
-			crdv2.LabelDBRole:    "core",
+			crdv2.LabelMriaRole:  "core",
 		}, got.Spec.Selector)
 	})
 
@@ -209,7 +209,7 @@ func TestGenerateListenersService(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			crdv2.LabelInstance:  "emqx",
 			crdv2.LabelManagedBy: "emqx-operator",
-			crdv2.LabelDBRole:    "core",
+			crdv2.LabelMriaRole:  "core",
 		}, got.Spec.Selector)
 	})
 
@@ -235,7 +235,7 @@ func TestGenerateListenersService(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			crdv2.LabelInstance:  "emqx",
 			crdv2.LabelManagedBy: "emqx-operator",
-			crdv2.LabelDBRole:    "replicant",
+			crdv2.LabelMriaRole:  "replicant",
 		}, got.Spec.Selector)
 	})
 

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -7,6 +7,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	k8s "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -86,6 +87,20 @@ func (r *reconcileState) updateReplicantSet(instance *crdv2.EMQX) *appsv1.Replic
 		}
 	}
 	return nil
+}
+
+func (r *reconcileState) hasReplicants() bool {
+	for _, rs := range r.replicantSets {
+		if rs.Status.Replicas > 0 || ptr.Deref(rs.Spec.Replicas, 1) > 0 {
+			return true
+		}
+	}
+	for _, pod := range r.pods {
+		if pod.Labels[crdv2.LabelDBRole] == "replicant" {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *reconcileState) partOfCurrentSet(pod *corev1.Pod, instance *crdv2.EMQX) bool {

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -96,7 +96,7 @@ func (r *reconcileState) hasReplicants() bool {
 		}
 	}
 	for _, pod := range r.pods {
-		if pod.Labels[crdv2.LabelDBRole] == "replicant" {
+		if pod.Labels[crdv2.LabelDBRole] == crdv2.RoleReplicant {
 			return true
 		}
 	}

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -29,7 +29,7 @@ func (r *reconcileState) podWithName(name string) *corev1.Pod {
 func (r *reconcileState) podsWithRole(role string) []*corev1.Pod {
 	var list []*corev1.Pod
 	for _, pod := range r.pods {
-		if pod.Labels[crdv2.LabelDBRole] == role {
+		if pod.Labels[crdv2.LabelMriaRole] == role {
 			list = append(list, pod)
 		}
 	}
@@ -96,7 +96,7 @@ func (r *reconcileState) hasReplicants() bool {
 		}
 	}
 	for _, pod := range r.pods {
-		if pod.Labels[crdv2.LabelDBRole] == crdv2.RoleReplicant {
+		if pod.Labels[crdv2.LabelMriaRole] == crdv2.RoleReplicant {
 			return true
 		}
 	}

--- a/internal/controller/sync_core_sets.go
+++ b/internal/controller/sync_core_sets.go
@@ -30,7 +30,7 @@ func (s *syncCoreSets) reconcile(r *reconcileRound, instance *crdv2.EMQX) subRes
 	if updateSts.UID != currentSts.UID {
 		return s.migrateSet(r, instance, currentSts)
 	}
-	return s.scaleDownSet(r, instance, currentSts)
+	return s.scaleSet(r, instance, currentSts)
 }
 
 // Orchestrates gradual scale down of the old statefulSet, by migrating workloads to the new statefulSet.
@@ -58,7 +58,7 @@ func (s *syncCoreSets) migrateSet(
 }
 
 // Scale up or down the existing statefulSet.
-func (s *syncCoreSets) scaleDownSet(
+func (s *syncCoreSets) scaleSet(
 	r *reconcileRound,
 	instance *crdv2.EMQX,
 	current *appsv1.StatefulSet,

--- a/internal/controller/sync_pods_suite_test.go
+++ b/internal/controller/sync_pods_suite_test.go
@@ -576,4 +576,16 @@ var _ = Describe("Reconciler syncReplicantSets", Ordered, func() {
 			HaveField("Pod", Not(BeNil())),
 		))
 	})
+
+	It("scales replicant sets down to zero when replicants are disabled", func() {
+		instance.Spec.ReplicantTemplate = &crdv2.EMQXReplicantTemplate{}
+		instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
+		instance.Status.ReplicantNodesStatus = crdv2.EMQXNodesStatus{}
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Eventually(actualize).WithArguments(current).
+			WithTimeout(timeout).WithPolling(interval).
+			Should(
+				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+			)
+	})
 })

--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
 type syncReplicantSets struct {
@@ -22,6 +23,10 @@ type scaleDownReplicant struct {
 }
 
 func (s *syncReplicantSets) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
+	if !instance.Spec.HasReplicants() {
+		return s.scaleReplicantSetsDownToZero(r)
+	}
+
 	updateRs := r.state.updateReplicantSet(instance)
 	currentRs := r.state.currentReplicantSet(instance)
 	if updateRs == nil || currentRs == nil {
@@ -29,6 +34,23 @@ func (s *syncReplicantSets) reconcile(r *reconcileRound, instance *crdv2.EMQX) s
 	}
 	if updateRs.UID != currentRs.UID {
 		return s.migrateSet(r, instance, currentRs)
+	}
+	return subResult{}
+}
+
+func (s *syncReplicantSets) scaleReplicantSetsDownToZero(r *reconcileRound) subResult {
+	for _, rs := range r.state.replicantSets {
+		if ptr.Deref(rs.Spec.Replicas, 1) == 0 {
+			continue
+		}
+		r.log.Info("scaling down replicantSet",
+			"replicaSet", klog.KObj(rs),
+			"reason", "replicant replicas set to zero",
+		)
+		rs.Spec.Replicas = ptr.To(int32(0))
+		if err := s.Client.Update(r.ctx, rs); err != nil {
+			return subResult{err: emperror.Wrap(err, "failed to scale down replicantSet")}
+		}
 	}
 	return subResult{}
 }

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -20,7 +20,7 @@ type updateStatus struct {
 
 func (u *updateStatus) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
 	status := u.inheritStatus(instance)
-	hasReplicants := instance.Spec.HasReplicants()
+	hasReplicants := instance.Spec.HasReplicants() || r.state.hasReplicants()
 
 	currentCoreSet, updateCoreSet := switchCoreSet(r, instance)
 	var currentReplicantSet, updateReplicantSet *appsv1.ReplicaSet

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -362,15 +362,15 @@ func (u *updateStatus) updateEMQXNodesStatus(
 		}
 		list := &status.CoreNodes
 		host := extractHostname(n.Node)
-		if node.Role == "replicant" {
+		if node.Role == crdv2.RoleReplicant {
 			list = &status.ReplicantNodes
 		}
 		for _, pod := range r.state.pods {
-			if node.Role == "core" && strings.HasPrefix(host, pod.Name) {
+			if node.Role == crdv2.RoleCore && strings.HasPrefix(host, pod.Name) {
 				node.PodName = pod.Name
 				break
 			}
-			if node.Role == "replicant" && host == pod.Status.PodIP {
+			if node.Role == crdv2.RoleReplicant && host == pod.Status.PodIP {
 				node.PodName = pod.Name
 				break
 			}

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -19,30 +19,32 @@ type updateStatus struct {
 }
 
 func (u *updateStatus) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
-	status := &instance.Status
-
-	status.CoreNodesStatus.Replicas = ptr.Deref(instance.Spec.CoreTemplate.Spec.Replicas, 1)
-	if instance.Spec.ReplicantTemplate != nil {
-		status.ReplicantNodesStatus.Replicas = ptr.Deref(instance.Spec.ReplicantTemplate.Spec.Replicas, 1)
-	}
+	status := u.inheritStatus(instance)
+	hasReplicants := instance.Spec.HasReplicants()
 
 	currentCoreSet, updateCoreSet := switchCoreSet(r, instance)
-	currentReplicantSet, updateReplicantSet := switchReplicantSet(r, instance)
+	var currentReplicantSet, updateReplicantSet *appsv1.ReplicaSet
+	if hasReplicants {
+		currentReplicantSet, updateReplicantSet = switchReplicantSet(r, instance)
+	}
 
-	status.CoreNodesStatus.ReadyReplicas = 0
 	if currentCoreSet != nil {
+		status.CoreNodesStatus.CurrentRevision = currentCoreSet.Labels[crdv2.LabelPodTemplateHash]
 		status.CoreNodesStatus.CurrentReplicas = currentCoreSet.Status.Replicas
 	}
 	if updateCoreSet != nil {
+		status.CoreNodesStatus.UpdateRevision = updateCoreSet.Labels[crdv2.LabelPodTemplateHash]
 		status.CoreNodesStatus.UpdateReplicas = updateCoreSet.Status.Replicas
 	}
-
-	status.ReplicantNodesStatus.ReadyReplicas = 0
-	if currentReplicantSet != nil {
-		status.ReplicantNodesStatus.CurrentReplicas = currentReplicantSet.Status.Replicas
-	}
-	if updateReplicantSet != nil {
-		status.ReplicantNodesStatus.UpdateReplicas = updateReplicantSet.Status.Replicas
+	if hasReplicants {
+		if currentReplicantSet != nil {
+			status.ReplicantNodesStatus.CurrentRevision = currentReplicantSet.Labels[crdv2.LabelPodTemplateHash]
+			status.ReplicantNodesStatus.CurrentReplicas = currentReplicantSet.Status.Replicas
+		}
+		if updateReplicantSet != nil {
+			status.ReplicantNodesStatus.UpdateRevision = updateReplicantSet.Labels[crdv2.LabelPodTemplateHash]
+			status.ReplicantNodesStatus.UpdateReplicas = updateReplicantSet.Status.Replicas
+		}
 	}
 
 	req := r.oldestCoreRequester()
@@ -53,23 +55,23 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crdv2.EMQX) subRes
 		if err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to get node status")}
 		}
-		u.updateEMQXNodesStatus(r, instance, nodes)
+		u.updateEMQXNodesStatus(r, &status, nodes)
 	}
 	for _, node := range status.CoreNodes {
 		if node.Status == "running" {
 			status.CoreNodesStatus.ReadyReplicas++
 		}
 	}
-	for _, node := range status.ReplicantNodes {
-		if node.Status == "running" {
-			status.ReplicantNodesStatus.ReadyReplicas++
+	if hasReplicants {
+		for _, node := range status.ReplicantNodes {
+			if node.Status == "running" {
+				status.ReplicantNodesStatus.ReadyReplicas++
+			}
 		}
 	}
-
 	if req != nil {
 		clusterEvacuationsStatus, err := api.ClusterEvacuationStatus(req)
 		if err == nil {
-			status.NodeEvacuationsStatus = []crdv2.NodeEvacuationStatus{}
 			for _, ns := range clusterEvacuationsStatus {
 				status.NodeEvacuationsStatus = append(status.NodeEvacuationsStatus, crdv2.NodeEvacuationStatus{
 					NodeName:               ns.Node,
@@ -132,12 +134,47 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crdv2.EMQX) subRes
 	}
 
 	// update status condition
+	instance.Status = status
 	u.updateStatusCondition(r, instance)
 
 	if err := u.Client.Status().Update(r.ctx, instance); err != nil {
 		return subResult{err: emperror.Wrap(err, "failed to update status")}
 	}
 	return subResult{}
+}
+
+// inheritStatus builds a minimal EMQXStatus with information that has to be
+// preserved across reconcile rounds.
+func (u *updateStatus) inheritStatus(instance *crdv2.EMQX) crdv2.EMQXStatus {
+	status := crdv2.EMQXStatus{
+		Conditions: u.inheritConditions(instance),
+		CoreNodesStatus: crdv2.EMQXNodesStatus{
+			Replicas:       ptr.Deref(instance.Spec.CoreTemplate.Spec.Replicas, 1),
+			CollisionCount: instance.Status.CoreNodesStatus.CollisionCount,
+		},
+	}
+	if instance.Spec.HasReplicants() {
+		status.ReplicantNodesStatus = crdv2.EMQXNodesStatus{
+			Replicas:       ptr.Deref(instance.Spec.ReplicantTemplate.Spec.Replicas, 1),
+			CollisionCount: instance.Status.ReplicantNodesStatus.CollisionCount,
+		}
+	}
+	return status
+}
+
+func (*updateStatus) inheritConditions(instance *crdv2.EMQX) []metav1.Condition {
+	hasReplicants := instance.Spec.HasReplicants()
+	if hasReplicants {
+		return instance.Status.Conditions
+	}
+	next := make([]metav1.Condition, 0, len(instance.Status.Conditions))
+	for _, condition := range instance.Status.Conditions {
+		if condition.Type == crdv2.ReplicantNodesProgressing || condition.Type == crdv2.ReplicantNodesReady {
+			continue
+		}
+		next = append(next, condition)
+	}
+	return next
 }
 
 func (u *updateStatus) updateStatusCondition(r *reconcileRound, instance *crdv2.EMQX) {
@@ -238,10 +275,6 @@ func (u *updateStatus) resetConditions(
 	instance *crdv2.EMQX,
 	reason string,
 ) {
-	if !instance.Spec.HasReplicants() {
-		instance.Status.RemoveCondition(crdv2.ReplicantNodesProgressing)
-		instance.Status.RemoveCondition(crdv2.ReplicantNodesReady)
-	}
 	instance.Status.ResetConditions(reason)
 	u.updateStatusCondition(r, instance)
 }
@@ -276,9 +309,6 @@ func switchCoreSet(
 			current = update
 		}
 	}
-	if current != nil {
-		instance.Status.CoreNodesStatus.CurrentRevision = current.Labels[crdv2.LabelPodTemplateHash]
-	}
 	return current, update
 }
 
@@ -303,16 +333,14 @@ func switchReplicantSet(
 			current = update
 		}
 	}
-	if current != nil {
-		instance.Status.ReplicantNodesStatus.CurrentRevision = current.Labels[crdv2.LabelPodTemplateHash]
-	}
 	return current, update
 }
 
-func (u *updateStatus) updateEMQXNodesStatus(r *reconcileRound, instance *crdv2.EMQX, nodes []api.EMQXNode) {
-	status := &instance.Status
-	status.CoreNodes = []crdv2.EMQXNode{}
-	status.ReplicantNodes = []crdv2.EMQXNode{}
+func (u *updateStatus) updateEMQXNodesStatus(
+	r *reconcileRound,
+	status *crdv2.EMQXStatus,
+	nodes []api.EMQXNode,
+) {
 	slices.SortFunc(nodes, func(a, b api.EMQXNode) int {
 		// Use seconds granularity to avoid jitter in ordering
 		asec := a.Uptime / 1000

--- a/test/e2e/emqx.go
+++ b/test/e2e/emqx.go
@@ -17,7 +17,7 @@ var (
 	emqxReplicantLabels = labels.Set(map[string]string{
 		crdv2.LabelInstance:  "emqx",
 		crdv2.LabelManagedBy: "emqx-operator",
-		crdv2.LabelDBRole:    "replicant",
+		crdv2.LabelMriaRole:  crdv2.RoleReplicant,
 	})
 )
 

--- a/test/e2e/emqx.go
+++ b/test/e2e/emqx.go
@@ -6,6 +6,19 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	emqxLabels = labels.Set(map[string]string{
+		crdv2.LabelInstance:  "emqx",
+		crdv2.LabelManagedBy: "emqx-operator",
+	})
+	emqxReplicantLabels = labels.Set(map[string]string{
+		crdv2.LabelInstance:  "emqx",
+		crdv2.LabelManagedBy: "emqx-operator",
+		crdv2.LabelDBRole:    "replicant",
+	})
 )
 
 func checkEMQXReady(g Gomega, afterTime ...metav1.Time) {
@@ -28,7 +41,7 @@ func checkEMQXStatus(g Gomega, coreReplicas int) {
 	var podList corev1.PodList
 	var status crdv2.EMQXNodesStatus
 	g.Expect(KubectlOut("get", "pod",
-		"--selector", "apps.emqx.io/instance=emqx,apps.emqx.io/managed-by=emqx-operator",
+		"--selector", emqxLabels.String(),
 		"-o", "json",
 	)).To(UnmarshalInto(&podList), "Failed to list EMQX pods")
 	g.Expect(podList.Items).To(
@@ -59,6 +72,12 @@ func checkNoReplicants(g Gomega) {
 		To(Equal("{}"), "EMQX cluster status has replicant nodes status")
 	g.Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.replicantNodes}")).
 		To(BeEmpty(), "EMQX cluster status lists replicant nodes")
+	g.Expect(KubectlOut("get", "pods",
+		"--selector", emqxReplicantLabels.String(),
+		"-o", "json",
+	)).To(BeUnmarshalledAs(&corev1.PodList{},
+		HaveField("Items", BeEmpty()),
+	))
 }
 
 func checkReplicantStatus(g Gomega, replicantReplicas int) {

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -467,7 +467,7 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			By("fetch existing replicant ReplicaSets")
 			var rsBefore appsv1.ReplicaSetList
 			Expect(KubectlOut("get", "replicaset",
-				"--selector", crdv2.LabelInstance+"=emqx,"+crdv2.LabelDBRole+"=replicant",
+				"--selector", crdv2.LabelInstance+"=emqx,"+crdv2.LabelMriaRole+"=replicant",
 				"-o", "json",
 			)).To(UnmarshalInto(&rsBefore), "Failed to list replicant ReplicaSets")
 			Expect(rsBefore.Items).NotTo(BeEmpty(), "No replicant ReplicaSets were present before scaling down")
@@ -538,13 +538,13 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			)).To(UnmarshalInto(&pods), "Failed to list EMQX pods")
 			Expect(pods.Items).To(HaveLen(4), "EMQX cluster does not have 4 pods")
 			for _, pod := range pods.Items {
-				if pod.Labels[crdv2.LabelDBRole] == "core" {
+				if pod.Labels[crdv2.LabelMriaRole] == crdv2.RoleCore {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crdv2.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionTrue)),
 					)))
 				}
-				if pod.Labels[crdv2.LabelDBRole] == "replicant" {
+				if pod.Labels[crdv2.LabelMriaRole] == crdv2.RoleReplicant {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crdv2.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionFalse)),
@@ -686,13 +686,13 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			)).To(UnmarshalInto(&pods), "Failed to list EMQX pods")
 			Expect(pods.Items).To(HaveLen(4))
 			for _, pod := range pods.Items {
-				if pod.Labels[crdv2.LabelDBRole] == "core" {
+				if pod.Labels[crdv2.LabelMriaRole] == crdv2.RoleCore {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crdv2.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionTrue)),
 					)))
 				}
-				if pod.Labels[crdv2.LabelDBRole] == "replicant" {
+				if pod.Labels[crdv2.LabelMriaRole] == crdv2.RoleReplicant {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crdv2.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionFalse)),

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -457,6 +457,50 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			Expect(out).To(Equal("0"))
 		})
 
+		It("scale replicants down to zero", func() {
+			By("fetch current replicant nodes")
+			var replicantNodes []crdv2.EMQXNode
+			Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.replicantNodes}")).
+				To(UnmarshalInto(&replicantNodes), "Failed to get EMQX replicant nodes")
+			Expect(replicantNodes).NotTo(BeEmpty(), "No replicant nodes were present before scaling down")
+
+			By("fetch existing replicant ReplicaSets")
+			var rsBefore appsv1.ReplicaSetList
+			Expect(KubectlOut("get", "replicaset",
+				"--selector", crdv2.LabelInstance+"=emqx,"+crdv2.LabelDBRole+"=replicant",
+				"-o", "json",
+			)).To(UnmarshalInto(&rsBefore), "Failed to list replicant ReplicaSets")
+			Expect(rsBefore.Items).NotTo(BeEmpty(), "No replicant ReplicaSets were present before scaling down")
+
+			By("scale replicants to zero and constrain revision history")
+			const revisionHistoryLimit = 1
+			replicantReplicas = 0
+			Expect(Kubectl("patch", "emqx", "emqx",
+				"--type", "json",
+				"--patch", `[
+						{"op": "replace", "path": "/spec/replicantTemplate/spec/replicas", "value": 0},
+						{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": `+fmt.Sprint(revisionHistoryLimit)+`}
+					]`,
+			)).To(Succeed(), "Failed to scale replicants down to 0")
+
+			By("wait for EMQX to stabilize without replicants")
+			Eventually(checkEMQXReady).Should(Succeed())
+			Eventually(checkEMQXStatus).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(checkNoReplicants).Should(Succeed())
+
+			By("verify replicant ReplicaSets are retained according to revisionHistoryLimit")
+			Eventually(KubectlOut).WithArguments("get", "replicaset",
+				"--selector", emqxReplicantLabels.String(),
+				"-o", "json",
+			).Should(BeUnmarshalledAs(&appsv1.ReplicaSetList{}, HaveField("Items", And(
+				HaveLen(revisionHistoryLimit),
+				HaveEach(And(
+					HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+					HaveField("Status.Replicas", BeEquivalentTo(0)),
+				)),
+			))))
+		})
+
 		It("delete cluster", func() {
 			Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
 			Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")


### PR DESCRIPTION
## Summary

This PR addresses a degraded operation of Operator when replicants replicas is changed to zero from a positive value. Without this fix, Operator enters an inconsistent state, evident from constant stream of debug-level logs mentioning `switching update -> current replicantSet`.
