### PR TITLE
fix: add separate reconciler to force-leave dead nodes

### DIFF
--- a/internal/controller/add_core_set.go
+++ b/internal/controller/add_core_set.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"reflect"
 	"slices"
 
@@ -132,21 +131,6 @@ func newStatefulSet(instance *crdv2.EMQX, conf *config.EMQX) *appsv1.StatefulSet
 }
 
 func generateStatefulSet(instance *crdv2.EMQX) *appsv1.StatefulSet {
-	// Add a PreStop hook to leave the cluster when the pod is asked to stop.
-	// This is especially important when DS Raft is enabled, otherwise there will be a
-	// lot of leftover records in the DS cluster metadata.
-	lifecycle := instance.Spec.CoreTemplate.Spec.Lifecycle
-	if lifecycle == nil {
-		lifecycle = &corev1.Lifecycle{}
-	} else {
-		lifecycle = lifecycle.DeepCopy()
-	}
-	lifecycle.PreStop = &corev1.LifecycleHandler{
-		Exec: &corev1.ExecAction{
-			Command: []string{"/bin/sh", "-c", "emqx ctl cluster leave"},
-		},
-	}
-
 	cookie := resources.Cookie(instance)
 	bootstrapAPIKeys := resources.BootstrapAPIKey(instance)
 	config := resources.EMQXConfig(instance)
@@ -216,7 +200,7 @@ func generateStatefulSet(instance *crdv2.EMQX) *appsv1.StatefulSet {
 								},
 								{
 									Name:  "EMQX_CLUSTER__DNS__NAME",
-									Value: fmt.Sprintf("%s.%s.svc.%s", instance.HeadlessServiceNamespacedName().Name, instance.Namespace, instance.Spec.ClusterDomain),
+									Value: clusterDNSName(instance),
 								},
 								{
 									Name:  "EMQX_HOST",
@@ -239,7 +223,7 @@ func generateStatefulSet(instance *crdv2.EMQX) *appsv1.StatefulSet {
 							LivenessProbe:   instance.Spec.CoreTemplate.Spec.LivenessProbe,
 							ReadinessProbe:  instance.Spec.CoreTemplate.Spec.ReadinessProbe,
 							StartupProbe:    instance.Spec.CoreTemplate.Spec.StartupProbe,
-							Lifecycle:       lifecycle,
+							Lifecycle:       instance.Spec.CoreTemplate.Spec.Lifecycle,
 							VolumeMounts: slices.Concat(
 								[]corev1.VolumeMount{
 									{

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"fmt"
 	"slices"
 
 	emperror "emperror.dev/errors"
@@ -136,9 +135,11 @@ func newReplicaSet(instance *crdv2.EMQX, conf *config.EMQX) *appsv1.ReplicaSet {
 }
 
 func generateReplicaSet(instance *crdv2.EMQX) *appsv1.ReplicaSet {
-	// Add a PreStop hook to leave the cluster when the pod is asked to stop.
-	// This is especially important when DS Raft is enabled, otherwise there will be a
-	// lot of leftover records in the DS cluster metadata.
+	cookie := resources.Cookie(instance)
+	config := resources.EMQXConfig(instance)
+
+	// Replicants should leave the cluster while still alive. Once stopped, EMQX
+	// normally no longer sees them as cluster nodes to force-leave.
 	lifecycle := instance.Spec.ReplicantTemplate.Spec.Lifecycle
 	if lifecycle == nil {
 		lifecycle = &corev1.Lifecycle{}
@@ -150,9 +151,6 @@ func generateReplicaSet(instance *crdv2.EMQX) *appsv1.ReplicaSet {
 			Command: []string{"/bin/sh", "-c", "emqx ctl cluster leave"},
 		},
 	}
-
-	cookie := resources.Cookie(instance)
-	config := resources.EMQXConfig(instance)
 
 	return &appsv1.ReplicaSet{
 		TypeMeta: metav1.TypeMeta{
@@ -209,7 +207,7 @@ func generateReplicaSet(instance *crdv2.EMQX) *appsv1.ReplicaSet {
 								},
 								{
 									Name:  "EMQX_CLUSTER__DNS__NAME",
-									Value: fmt.Sprintf("%s.%s.svc.%s", instance.HeadlessServiceNamespacedName().Name, instance.Namespace, instance.Spec.ClusterDomain),
+									Value: clusterDNSName(instance),
 								},
 								{
 									Name: "EMQX_HOST",

--- a/internal/controller/ds_update_replica_sets.go
+++ b/internal/controller/ds_update_replica_sets.go
@@ -3,11 +3,10 @@ package controller
 import (
 	"reflect"
 	"sort"
-	"strconv"
-	"strings"
 
 	emperror "emperror.dev/errors"
 	crdv2 "github.com/emqx/emqx-operator/api/v2"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
 	"github.com/emqx/emqx-operator/internal/emqx/api"
 )
 
@@ -53,7 +52,7 @@ func (u *dsUpdateReplicaSets) reconcile(r *reconcileRound, instance *crdv2.EMQX)
 			if site == nil {
 				return subResult{err: emperror.Errorf("no site for node %s", node.Name)}
 			}
-			if getPodIndex(node.PodName) < desiredReplicas {
+			if util.PodOrdinal(node.PodName) < desiredReplicas {
 				targetSites = append(targetSites, site.ID)
 			}
 		}
@@ -79,17 +78,4 @@ func (u *dsUpdateReplicaSets) reconcile(r *reconcileRound, instance *crdv2.EMQX)
 	}
 
 	return subResult{}
-}
-
-func getPodIndex(podName string) int32 {
-	parts := strings.Split(podName, "-")
-	if len(parts) < 2 {
-		return -1
-	}
-	indexPart := parts[len(parts)-1]
-	index, err := strconv.Atoi(indexPart)
-	if err != nil {
-		return -1
-	}
-	return int32(index)
 }

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -138,6 +138,7 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		&dsReflectPodCondition{r},
 		&syncReplicantSets{r},
 		&syncCoreSets{r},
+		&syncClusterMembership{r},
 		&cleanupOutdatedSets{r},
 		&dsCleanupSites{r},
 	} {

--- a/internal/controller/sync_cluster_membership.go
+++ b/internal/controller/sync_cluster_membership.go
@@ -64,11 +64,6 @@ func (*syncClusterMembership) keepCoreNode(r *reconcileRound, instance *crdv2.EM
 			podName = parsed.podName
 		}
 	}
-	// Determine pod ordinal, be conservative if pod has no ordinal:
-	ordinal := util.PodOrdinal(podName)
-	if ordinal < 0 {
-		return true
-	}
 	// Find out correspoding core set:
 	var owningCoreSet *appsv1.StatefulSet
 	for _, coreSet := range r.state.coreSets {
@@ -78,10 +73,11 @@ func (*syncClusterMembership) keepCoreNode(r *reconcileRound, instance *crdv2.EM
 			}
 		}
 	}
-	// Be conservative if no correspoding core set:
+	// Force-leave if no correspoding core set:
 	if owningCoreSet == nil {
-		return true
+		return false
 	}
 	// Keep node if it is in the range of desired number of replicas:
+	ordinal := util.PodOrdinal(podName)
 	return ordinal < ptr.Deref(owningCoreSet.Spec.Replicas, 1)
 }

--- a/internal/controller/sync_cluster_membership.go
+++ b/internal/controller/sync_cluster_membership.go
@@ -1,0 +1,87 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	crdv2 "github.com/emqx/emqx-operator/api/v2"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
+	api "github.com/emqx/emqx-operator/internal/emqx/api"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// Responsibilities:
+// - Removes EMQX cores from the cluster that should no longer be a member, because of scale-down.
+type syncClusterMembership struct {
+	*EMQXReconciler
+}
+
+func (s *syncClusterMembership) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
+	req := r.oldestCoreRequester()
+	if req == nil {
+		return subResult{}
+	}
+
+	staleNodes := []*crdv2.EMQXNode{}
+	for _, node := range instance.Status.CoreNodes {
+		if node.Status != api.NodeStatusStopped {
+			continue
+		}
+		if pod := r.state.podWithName(node.PodName); pod != nil {
+			continue
+		}
+		if s.keepCoreNode(r, instance, &node) {
+			continue
+		}
+		staleNodes = append(staleNodes, &node)
+	}
+
+	for _, staleNode := range staleNodes {
+		err := api.ForceLeave(req, staleNode.Name)
+		if err == nil {
+			s.EventRecorder.Event(
+				instance,
+				corev1.EventTypeNormal,
+				"NodeForceLeave",
+				fmt.Sprintf("Stale %s node %s force-left the cluster", staleNode.Role, staleNode.Name),
+			)
+		} else {
+			return subResult{err: err}
+		}
+	}
+
+	return subResult{}
+}
+
+func (*syncClusterMembership) keepCoreNode(r *reconcileRound, instance *crdv2.EMQX, node *crdv2.EMQXNode) bool {
+	// Determine pod name, either from node status or node name itself:
+	podName := node.PodName
+	if podName == "" {
+		parsed := parseNodeName(node.Name, instance)
+		if parsed != nil {
+			podName = parsed.podName
+		}
+	}
+	// Determine pod ordinal, be conservative if pod has no ordinal:
+	ordinal := util.PodOrdinal(podName)
+	if ordinal < 0 {
+		return true
+	}
+	// Find out correspoding core set:
+	var owningCoreSet *appsv1.StatefulSet
+	for _, coreSet := range r.state.coreSets {
+		if strings.HasPrefix(podName, coreSet.Name+"-") {
+			if owningCoreSet == nil || len(coreSet.Name) > len(owningCoreSet.Name) {
+				owningCoreSet = coreSet
+			}
+		}
+	}
+	// Be conservative if no correspoding core set:
+	if owningCoreSet == nil {
+		return true
+	}
+	// Keep node if it is in the range of desired number of replicas:
+	return ordinal < ptr.Deref(owningCoreSet.Spec.Replicas, 1)
+}

--- a/internal/controller/sync_cluster_membership_suite_test.go
+++ b/internal/controller/sync_cluster_membership_suite_test.go
@@ -1,0 +1,259 @@
+package controller
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	crdv2 "github.com/emqx/emqx-operator/api/v2"
+	req "github.com/emqx/emqx-operator/internal/requester"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Reconciler syncClusterMembership", Ordered, func() {
+	var ns *corev1.Namespace
+	var instance *crdv2.EMQX
+	var round *reconcileRound
+	var coreSetUpdate, coreSetCurrent *appsv1.StatefulSet
+	var replicantSet *appsv1.ReplicaSet
+	var corePod0, corePod1 *corev1.Pod
+	var replicantPod *corev1.Pod
+	var forceLeftNodes []string
+
+	emqxNodeName := func(podName string) string {
+		return constructNodeName(podName, instance)
+	}
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "controller-sync-cluster-test-",
+				Labels:       map[string]string{"test": "e2e"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	mkCorePod := func(sts *appsv1.StatefulSet, ordinal int) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      sts.Name + "-" + strconv.Itoa(ordinal),
+				Namespace: sts.Namespace,
+				Labels:    sts.Spec.Template.Labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "StatefulSet",
+						Name:       sts.Name,
+						UID:        sts.UID,
+						Controller: ptr.To(true),
+					},
+				},
+			},
+			Spec: sts.Spec.Template.Spec,
+		}
+	}
+
+	BeforeEach(func() {
+		instance = emqx.DeepCopy()
+		instance.Namespace = ns.Name
+		instance.Spec.ClusterDomain = "local"
+		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(1))
+		instance.Spec.ReplicantTemplate = &crdv2.EMQXReplicantTemplate{}
+		instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(1))
+		instance.Status.CoreNodesStatus.CurrentRevision = currentRevision
+		instance.Status.CoreNodesStatus.UpdateRevision = updateRevision
+		instance.Status.ReplicantNodesStatus.CurrentRevision = updateRevision
+		instance.Status.ReplicantNodesStatus.UpdateRevision = updateRevision
+
+		coreLabels := instance.DefaultLabelsWith(
+			crdv2.CoreLabels(),
+			map[string]string{crdv2.LabelPodTemplateHash: updateRevision},
+		)
+		coreLabelsCurrent := instance.DefaultLabelsWith(
+			crdv2.CoreLabels(),
+			map[string]string{crdv2.LabelPodTemplateHash: currentRevision},
+		)
+		coreSetUpdate = &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.Name + "-core-" + updateRevision,
+				Namespace: ns.Name,
+				Labels:    coreLabels,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: instance.HeadlessServiceNamespacedName().Name,
+				Replicas:    ptr.To(int32(1)),
+				Selector:    &metav1.LabelSelector{MatchLabels: coreLabels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: coreLabels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "emqx", Image: "emqx"}}},
+				},
+			},
+		}
+		coreSetCurrent = &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.Name + "-core-" + currentRevision,
+				Namespace: ns.Name,
+				Labels:    coreLabelsCurrent,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: instance.HeadlessServiceNamespacedName().Name,
+				Replicas:    ptr.To(int32(0)),
+				Selector:    &metav1.LabelSelector{MatchLabels: coreLabelsCurrent},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: coreLabelsCurrent},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "emqx", Image: "emqx"}}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, coreSetUpdate)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, coreSetCurrent)).Should(Succeed())
+
+		corePod0 = mkCorePod(coreSetUpdate, 0)
+		Expect(k8sClient.Create(ctx, corePod0)).Should(Succeed())
+		corePod1 = mkCorePod(coreSetUpdate, 1)
+		Expect(k8sClient.Create(ctx, corePod1)).Should(Succeed())
+
+		replicantLabels := instance.DefaultLabelsWith(
+			crdv2.ReplicantLabels(),
+			map[string]string{crdv2.LabelPodTemplateHash: updateRevision},
+		)
+		replicantSet = &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.Name + "-replicant-" + updateRevision,
+				Namespace: ns.Name,
+				Labels:    replicantLabels,
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: ptr.To(int32(1)),
+				Selector: &metav1.LabelSelector{MatchLabels: replicantLabels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: replicantLabels},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "emqx", Image: "emqx"}}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, replicantSet)).Should(Succeed())
+		replicantPod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      replicantSet.Name + "-xyz",
+				Namespace: ns.Name,
+				Labels:    replicantLabels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "apps/v1",
+						Kind:       "ReplicaSet",
+						Name:       replicantSet.Name,
+						UID:        replicantSet.UID,
+						Controller: ptr.To(true),
+					},
+				},
+			},
+			Spec: replicantSet.Spec.Template.Spec,
+		}
+		Expect(k8sClient.Create(ctx, replicantPod)).Should(Succeed())
+
+		forceLeftNodes = nil
+		mockRequester := req.NewMockRequester(
+			func(method string, u url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
+				if method == "DELETE" && strings.Contains(u.Path, "force_leave") {
+					parts := strings.Split(u.Path, "/")
+					forceLeftNodes = append(forceLeftNodes, parts[len(parts)-2])
+					return &http.Response{StatusCode: 204}, nil, nil
+				}
+				return &http.Response{StatusCode: 501}, nil, nil
+			},
+		)
+		round = newReconcileRoundWithRequester(mockRequester)
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(ns.Name))).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &appsv1.ReplicaSet{}, client.InNamespace(ns.Name))).Should(Succeed())
+		Expect(k8sClient.DeleteAllOf(ctx, &appsv1.StatefulSet{}, client.InNamespace(ns.Name))).Should(Succeed())
+	})
+
+	It("force-leaves scaled-down core nodes whose pods are gone", func() {
+		instance.Status.CoreNodes = []crdv2.EMQXNode{
+			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running", Role: "core"},
+			{Name: emqxNodeName(corePod1.Name), PodName: corePod1.Name, Status: "stopped", Role: "core"},
+			{Name: emqxNodeName(coreSetUpdate.Name + "-10"), PodName: "", Status: "stopped", Role: "core"},
+			{Name: emqxNodeName(coreSetUpdate.Name + "-11"), PodName: "", Status: "stopped", Role: "core"},
+		}
+		s := &syncClusterMembership{emqxReconciler}
+		round.state = loadReconcileState(ctx, k8sClient, instance)
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Expect(forceLeftNodes).To(ConsistOf(
+			emqxNodeName(coreSetUpdate.Name+"-10"),
+			emqxNodeName(coreSetUpdate.Name+"-11"),
+		))
+	})
+
+	It("does NOT force-leave stopped core node whose pod still exists", func() {
+		instance.Status.CoreNodes = []crdv2.EMQXNode{
+			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "stopped", Role: "core"},
+			{Name: emqxNodeName(corePod1.Name), PodName: corePod1.Name, Status: "stopped", Role: "core"},
+		}
+		s := &syncClusterMembership{emqxReconciler}
+		round.state = loadReconcileState(ctx, k8sClient, instance)
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Expect(forceLeftNodes).To(BeEmpty())
+	})
+
+	It("does NOT force-leave stopped core node whose ordinal is still desired", func() {
+		Expect(k8sClient.Delete(ctx, corePod0)).Should(Succeed())
+		instance.Status.CoreNodes = []crdv2.EMQXNode{
+			{Name: emqxNodeName(corePod0.Name), PodName: "", Status: "stopped", Role: "core"},
+		}
+		s := &syncClusterMembership{emqxReconciler}
+		round.state = loadReconcileState(ctx, k8sClient, instance)
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Expect(forceLeftNodes).To(BeEmpty())
+	})
+
+	It("force-leaves stopped old current core node after it is scaled to zero", func() {
+		instance.Status.CoreNodes = []crdv2.EMQXNode{
+			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running", Role: "core"},
+			{Name: emqxNodeName(corePod1.Name), PodName: corePod1.Name, Status: "stopped", Role: "core"},
+			{Name: emqxNodeName(coreSetCurrent.Name + "-0"), PodName: "", Status: "stopped", Role: "core"},
+		}
+		s := &syncClusterMembership{emqxReconciler}
+		round.state = loadReconcileState(ctx, k8sClient, instance)
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Expect(forceLeftNodes).To(ConsistOf(emqxNodeName(coreSetCurrent.Name + "-0")))
+	})
+
+	It("force-leaves core nodes belonging to removed coreSet", func() {
+		instance.Status.CoreNodes = []crdv2.EMQXNode{
+			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running", Role: "core"},
+			{Name: emqxNodeName(corePod1.Name), PodName: corePod1.Name, Status: "stopped", Role: "core"},
+			{Name: emqxNodeName("emqx-core-ancient-0"), PodName: "", Status: "stopped", Role: "core"},
+		}
+		s := &syncClusterMembership{emqxReconciler}
+		round.state = loadReconcileState(ctx, k8sClient, instance)
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Expect(forceLeftNodes).To(ConsistOf(emqxNodeName("emqx-core-ancient-0")))
+	})
+
+	It("does NOT force-leave running core nodes without pods", func() {
+		instance.Status.CoreNodes = []crdv2.EMQXNode{
+			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running", Role: "core"},
+			{Name: emqxNodeName(corePod1.Name), PodName: "", Status: "running", Role: "core"},
+		}
+		s := &syncClusterMembership{emqxReconciler}
+		round.state = loadReconcileState(ctx, k8sClient, instance)
+		Expect(s.reconcile(round, instance)).Should(Equal(subResult{}))
+		Expect(forceLeftNodes).To(BeEmpty())
+	})
+})

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -8,6 +8,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"slices"
+	"strings"
 	"time"
 
 	emperror "emperror.dev/errors"
@@ -157,4 +158,37 @@ func deepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 		SpewKeys:       true,
 	}
 	_, _ = printer.Fprintf(hasher, "%#v", objectToWrite)
+}
+
+type nodeName struct {
+	name     string
+	hostName string
+	podName  string
+}
+
+func parseNodeName(s string, instance *crdv2.EMQX) *nodeName {
+	var parsed nodeName
+	nameParts := strings.Split(s, "@")
+	if len(nameParts) != 2 {
+		return nil
+	}
+	parsed.name = nameParts[0]
+	parsed.hostName = nameParts[1]
+	hostParts := strings.Split(nameParts[1], instance.HeadlessServiceNamespacedName().Name)
+	if len(hostParts) > 1 {
+		parsed.podName = strings.TrimRight(hostParts[0], ".")
+	}
+	return &parsed
+}
+
+func constructNodeName(podName string, instance *crdv2.EMQX) string {
+	return fmt.Sprintf("emqx@%s.%s", podName, clusterDNSName(instance))
+}
+
+func clusterDNSName(instance *crdv2.EMQX) string {
+	return fmt.Sprintf("%s.%s.svc.%s",
+		instance.HeadlessServiceNamespacedName().Name,
+		instance.Namespace,
+		instance.Spec.ClusterDomain,
+	)
 }

--- a/internal/controller/util/pod.go
+++ b/internal/controller/util/pod.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,4 +46,16 @@ func UpdatePodCondition(
 	})
 	patch := client.RawPatch(types.StrategicMergePatchType, patchBytes)
 	return k8sClient.Status().Patch(ctx, pod, patch)
+}
+
+func PodOrdinal(podName string) int32 {
+	parts := strings.Split(podName, "-")
+	if len(parts) < 2 {
+		return -1
+	}
+	index, err := strconv.ParseInt(parts[len(parts)-1], 10, 32)
+	if err != nil {
+		return -1
+	}
+	return int32(index)
 }

--- a/internal/emqx/api/api.go
+++ b/internal/emqx/api/api.go
@@ -52,6 +52,10 @@ func post(req req.RequesterInterface, path string, body []byte) ([]byte, error) 
 	return request(req, "POST", path, body, nil)
 }
 
+func delete(req req.RequesterInterface, path string) ([]byte, error) {
+	return request(req, "DELETE", path, nil, nil)
+}
+
 func request(req req.RequesterInterface, method string, path string, body []byte, header http.Header) ([]byte, error) {
 	if req == nil {
 		return nil, emperror.New("no requester")

--- a/internal/emqx/api/nodes.go
+++ b/internal/emqx/api/nodes.go
@@ -8,6 +8,9 @@ import (
 	req "github.com/emqx/emqx-operator/internal/requester"
 )
 
+// EMQX node status values reported by the API.
+const NodeStatusStopped = "stopped"
+
 type EMQXNode struct {
 	// EMQX node name, example: emqx@127.0.0.1
 	Node string `json:"node,omitempty"`
@@ -32,7 +35,7 @@ func NodeInfo(req req.RequesterInterface, nodeName string) (*EMQXNode, error) {
 	if emperror.Is(err, ErrorNotFound) {
 		return &EMQXNode{
 			Node:       nodeName,
-			NodeStatus: "stopped",
+			NodeStatus: NodeStatusStopped,
 		}, nil
 	}
 	if err != nil {
@@ -44,6 +47,17 @@ func NodeInfo(req req.RequesterInterface, nodeName string) (*EMQXNode, error) {
 		return nil, emperror.Wrap(err, "unexpected node info format")
 	}
 	return nodeInfo, nil
+}
+
+// ForceLeave removes a node from the EMQX cluster.
+// DELETE /api/v5/cluster/{node}/force_leave
+func ForceLeave(req req.RequesterInterface, nodeName string) error {
+	path := fmt.Sprintf("api/v5/cluster/%s/force_leave", nodeName)
+	_, err := delete(req, path)
+	if emperror.Is(err, ErrorNotFound) {
+		return nil
+	}
+	return err
 }
 
 func Nodes(req req.RequesterInterface) ([]EMQXNode, error) {

--- a/test/e2e/emqx.go
+++ b/test/e2e/emqx.go
@@ -65,6 +65,7 @@ func checkEMQXStatus(g Gomega, coreReplicas int) {
 		"EMQX status does not have expected number of core nodes",
 	)
 	checkNodesStatusRevision(g, status, "core", coreReplicas)
+	checkNoStoppedNodes(g, "coreNodes", "core")
 }
 
 func checkNoReplicants(g Gomega) {
@@ -94,6 +95,19 @@ func checkReplicantStatus(g Gomega, replicantReplicas int) {
 		"EMQX status does not have expected number of replicant nodes",
 	)
 	checkNodesStatusRevision(g, status, "replicant", replicantReplicas)
+	checkNoStoppedNodes(g, "replicantNodes", "replicant")
+}
+
+func checkNoStoppedNodes(g Gomega, statusField, role string) {
+	var nodes []crdv2.EMQXNode
+	g.Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status."+statusField+"}")).
+		To(UnmarshalInto(&nodes), "Failed to get EMQX %s nodes", role)
+	g.Expect(nodes).To(
+		HaveEach(Not(HaveField("Status", Equal("stopped")))),
+		"EMQX %s nodes status lists stopped nodes: %+v",
+		role,
+		nodes,
+	)
 }
 
 func checkNodesStatusRevision(g Gomega, status crdv2.EMQXNodesStatus, role string, replicas int) {


### PR DESCRIPTION
## Summary

This PR moves responsibility of keeping cluster membership consistent with managed resources from `PrepStop` hooks to a separate reconciler, primarily to make sure that membership consistency does not depend on hook completions with all their limitations: e.g. strict time limit.
