### PR TITLE
fix(config): employ emqx-flavoured HOCON parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 # Copy the go source
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
+COPY hocon/ hocon/
 COPY internal/ internal/
 
 # Build

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/rory-z/go-hocon v1.2.15-1
 	github.com/sethvargo/go-password v0.3.1
 	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
-github.com/rory-z/go-hocon v1.2.15-1 h1:YGBuIMOlXVemPf2s75b4OgzKqWFpZs9KZ0HsUgO+ZSQ=
-github.com/rory-z/go-hocon v1.2.15-1/go.mod h1:sjuu2Bh9o83jB28wEFXFajI+fRLc66LY7l+ueEbpKLQ=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-password v0.3.1 h1:WqrLTjo7X6AcVYfC6R7GtSyuUQR9hGyAj/f1PYQZCJU=
 github.com/sethvargo/go-password v0.3.1/go.mod h1:rXofC1zT54N7R8K/h1WDUdkf9BOx5OptoxrMBcrXzvs=

--- a/hocon/parser.go
+++ b/hocon/parser.go
@@ -109,16 +109,16 @@ type Object map[string]Value
 
 func (o Object) Type() Type { return ObjectType }
 
-func (o Object) Lookup(path string) Value {
+func (o Object) Lookup(path string) (Value, bool) {
 	p := asPath(path)
 	if len(p) == 0 {
-		return nil
+		return o, true
 	}
 	result, v := o.lookup(p)
 	if result != valueFound {
-		return nil
+		return nil, false
 	}
-	return v
+	return v, true
 }
 
 func (o Object) DeepCopy() Object {

--- a/hocon/parser_test.go
+++ b/hocon/parser_test.go
@@ -131,11 +131,25 @@ func TestObjectLookup(t *testing.T) {
 		"scalar": String("value"),
 	}
 
-	g.Expect(root.Lookup("a.b")).To(Equal(Int(42)))
-	g.Expect(root.Lookup("a.c")).To(BeNil())
-	g.Expect(root.Lookup("missing")).To(BeNil())
-	g.Expect(root.Lookup("scalar.child")).To(BeNil())
-	g.Expect(root.Lookup("")).To(BeNil())
+	v, ok := root.Lookup("a.b")
+	g.Expect(v).To(Equal(Int(42)))
+	g.Expect(ok).To(BeTrue())
+
+	v, ok = root.Lookup("a.c")
+	g.Expect(v).To(BeNil())
+	g.Expect(ok).To(BeTrue())
+
+	v, ok = root.Lookup("missing")
+	g.Expect(v).To(BeNil())
+	g.Expect(ok).To(BeFalse())
+
+	v, ok = root.Lookup("scalar.child")
+	g.Expect(v).To(BeNil())
+	g.Expect(ok).To(BeFalse())
+
+	v, ok = root.Lookup("")
+	g.Expect(v).To(Equal(root))
+	g.Expect(ok).To(BeTrue())
 }
 
 func TestSelfref(t *testing.T) {

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -17,13 +17,14 @@ limitations under the License.
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/rory-z/go-hocon"
+	"github.com/emqx/emqx-operator/hocon"
 	corev1 "k8s.io/api/core/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -37,7 +38,7 @@ dashboard.listeners.http.bind = 18083
 `
 
 type EMQX struct {
-	*hocon.Config
+	Config hocon.Object
 }
 
 func WithDefaults(config string) string {
@@ -58,82 +59,34 @@ func EMQXConfig(config string) (*EMQX, error) {
 }
 
 func (c *EMQX) LoadEMQXConf(config string) error {
-	hoconConfig, err := hocon.ParseString(config)
+	doc, err := hocon.ParseDocument(config)
 	if err != nil {
 		return err
 	}
-	c.Config = hoconConfig
+	root, err := doc.Evaluate()
+	if err != nil {
+		return err
+	}
+	c.Config = root
 	return nil
 }
 
 func (c *EMQX) Copy() *EMQX {
-	root := hocon.Object{}
 	return &EMQX{
-		// Should deep-copy `c.config`.
-		root.ToConfig().WithFallback(c.Config),
+		Config: c.Config.DeepCopy(),
 	}
 }
 
 func (c *EMQX) Print() string {
-	return printObject(c.GetRoot().(hocon.Object), true)
-}
-
-func printValue(v hocon.Value) string {
-	switch v.Type() {
-	case hocon.ObjectType:
-		return printObject(v.(hocon.Object), false)
-	case hocon.ArrayType:
-		return printArray(v.(hocon.Array))
-	default:
-		return v.String()
+	if len(c.Config) == 0 {
+		return ""
 	}
-}
-
-func printObject(o hocon.Object, root bool) string {
-	builder := strings.Builder{}
-	n := len(o)
-	if !root {
-		builder.WriteString("{")
-	}
-	keys := make([]string, 0, n)
-	for k := range o {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for i, key := range keys {
-		value := o[key]
-		builder.WriteString(key)
-		if value.Type() != hocon.ObjectType {
-			builder.WriteString(" = ")
-		} else {
-			builder.WriteString(" ")
-		}
-		builder.WriteString(printValue(value))
-		if i < n-1 {
-			builder.WriteString(", ")
-		}
-	}
-	if !root {
-		builder.WriteString("}")
-	}
-	return builder.String()
-}
-
-func printArray(a hocon.Array) string {
-	var builder strings.Builder
-	builder.WriteString("[")
-	for i, value := range a {
-		if i > 0 {
-			builder.WriteString(", ")
-		}
-		builder.WriteString(printValue(value))
-	}
-	builder.WriteString("]")
-	return builder.String()
+	out, _ := json.Marshal(c.Config)
+	return string(out)
 }
 
 func (c *EMQX) StripReadOnlyConfig() []string {
-	root := c.GetRoot().(hocon.Object)
+	root := c.Config
 	stripped := []string{}
 	for _, key := range []string{
 		// Explicitly considered read-only:
@@ -166,7 +119,7 @@ func (c *EMQX) StripReadOnlyConfig() []string {
 }
 
 func (c *EMQX) Strip(path string) bool {
-	object := c.GetRoot().(hocon.Object)
+	object := c.Config
 	keys := strings.Split(path, ".")
 	l := len(keys)
 	if l > 0 {
@@ -196,22 +149,31 @@ func stripRecursive(object hocon.Object, keys []string, i int, l int) bool {
 }
 
 func (c *EMQX) GetNodeCookie() string {
-	return toString(byDefault(c.Get("node.cookie"), ""))
+	return toString(byDefault(c.Get("node.cookie"), hocon.String("")))
+}
+
+func (c *EMQX) Get(path string) hocon.Value {
+	return c.Config.Lookup(path)
+}
+
+func (c *EMQX) GetString(path string) (string, bool) {
+	v := c.Config.Lookup(path)
+	if v == nil {
+		return "", true
+	}
+	s := toString(v)
+	return s, s != ""
 }
 
 func (c *EMQX) GetDashboardPortMap() map[string]int {
 	portMap := make(map[string]int)
 	portMap["dashboard"] = 18083 // default port
 
-	httpBind := byDefault(c.Get("dashboard.listeners.http.bind"), "")
-	dashboardPort := toString(httpBind)
-	if dashboardPort != "" {
-		if !strings.Contains(dashboardPort, ":") {
-			// example: ":18083"
-			dashboardPort = fmt.Sprintf(":%s", dashboardPort)
-		}
-		_, strPort, _ := net.SplitHostPort(dashboardPort)
-		if port, _ := strconv.Atoi(strPort); port != 0 {
+	httpBind := toString(c.Get("dashboard.listeners.http.bind"))
+	httpsBind := toString(c.Get("dashboard.listeners.https.bind"))
+	if httpBind != "" {
+		port := extractPortNumber(httpBind)
+		if port > 0 {
 			portMap["dashboard"] = port
 		} else {
 			// port = 0 means disable dashboard
@@ -219,21 +181,10 @@ func (c *EMQX) GetDashboardPortMap() map[string]int {
 			delete(portMap, "dashboard")
 		}
 	}
-
-	httpsBind := byDefault(c.Get("dashboard.listeners.https.bind"), "")
-	dashboardHttpsPort := toString(httpsBind)
-	if dashboardHttpsPort != "" {
-		if !strings.Contains(dashboardHttpsPort, ":") {
-			// example: ":18084"
-			dashboardHttpsPort = fmt.Sprintf(":%s", dashboardHttpsPort)
-		}
-		_, strPort, _ := net.SplitHostPort(dashboardHttpsPort)
-		if port, _ := strconv.Atoi(strPort); port != 0 {
+	if httpsBind != "" {
+		port := extractPortNumber(httpsBind)
+		if port > 0 {
 			portMap["dashboard-https"] = port
-		} else {
-			// port = 0 means disable dashboard
-			// delete default port
-			delete(portMap, "dashboard-https")
 		}
 	}
 
@@ -264,81 +215,65 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 	portList := []corev1.ServicePort{}
 
 	// May be empty
-	for t, listener := range c.GetObject("listeners") {
-		if listener.Type() != hocon.ObjectType {
-			continue
-		}
-		for name, lc := range listener.(hocon.Object) {
-			lconf := lc.(hocon.Object)
-			// Compatible with "enable" and "enabled"
-			// the default value of them both is true
-			enabled := byDefault(lconf["enable"], byDefault(lconf["enabled"], true))
-			if isFalse(enabled) {
-				continue
-			}
-			bind := toString(byDefault(lconf["bind"], ":0"))
-			if !strings.Contains(bind, ":") {
-				// example: ":1883"
-				bind = fmt.Sprintf(":%s", bind)
-			}
-			_, strPort, _ := net.SplitHostPort(bind)
-			intStrValue := intstr.Parse(strPort)
-
-			protocol := corev1.ProtocolTCP
-			if t == "quic" {
-				protocol = corev1.ProtocolUDP
-			}
-
-			portList = append(portList, corev1.ServicePort{
-				Name:       fmt.Sprintf("%s-%s", t, name),
-				Protocol:   protocol,
-				Port:       int32(intStrValue.IntValue()),
-				TargetPort: intStrValue,
-			})
-		}
-	}
-
-	// Get gateway.lwm2m.listeners.udp.default.bind
-	for proto, gc := range c.GetObject("gateway") {
-		gateway := gc.(hocon.Object)
-		// Compatible with "enable" and "enabled"
-		// the default value of them both is true
-		enabled := byDefault(gateway["enable"], byDefault(gateway["enabled"], true))
-		if isFalse(enabled) {
-			continue
-		}
-		listeners := gateway["listeners"].(hocon.Object)
-		for t, listener := range listeners {
+	listeners := c.Get("listeners")
+	if listeners != nil && listeners.Type() == hocon.ObjectType {
+		for t, listener := range listeners.(hocon.Object) {
 			if listener.Type() != hocon.ObjectType {
 				continue
 			}
 			for name, lc := range listener.(hocon.Object) {
-				lconf := lc.(hocon.Object)
-				// Compatible with "enable" and "enabled"
-				// the default value of them both is true
-				enabled := byDefault(lconf["enable"], byDefault(lconf["enabled"], true))
-				if isFalse(enabled) {
+				lconf, ok := lc.(hocon.Object)
+				if !ok || !isEnabled(lconf) {
 					continue
 				}
-				bind := toString(byDefault(lconf["bind"], ":0"))
-				if !strings.Contains(bind, ":") {
-					// example: ":1883"
-					bind = fmt.Sprintf(":%s", bind)
-				}
-				_, strPort, _ := net.SplitHostPort(bind)
-				intStrValue := intstr.Parse(strPort)
-
+				bind := toString(byDefault(lconf["bind"], hocon.String(":0")))
+				port := extractPortNumber(bind)
 				protocol := corev1.ProtocolTCP
-				if t == "udp" || t == "dtls" {
+				if t == "quic" {
 					protocol = corev1.ProtocolUDP
 				}
-
 				portList = append(portList, corev1.ServicePort{
-					Name:       fmt.Sprintf("%s-%s-%s", proto, t, name),
+					Name:       fmt.Sprintf("%s-%s", t, name),
 					Protocol:   protocol,
-					Port:       int32(intStrValue.IntValue()),
-					TargetPort: intStrValue,
+					Port:       int32(port),
+					TargetPort: intstr.FromInt(port),
 				})
+			}
+		}
+	}
+
+	gateways := c.Get("gateway")
+	if gateways != nil && gateways.Type() == hocon.ObjectType {
+		for proto, gc := range gateways.(hocon.Object) {
+			gateway, ok := gc.(hocon.Object)
+			if !ok || !isEnabled(gateway) {
+				continue
+			}
+			listeners := gateway["listeners"].(hocon.Object)
+			for t, listener := range listeners {
+				if listener.Type() != hocon.ObjectType {
+					continue
+				}
+				for name, lc := range listener.(hocon.Object) {
+					lconf, ok := lc.(hocon.Object)
+					// Compatible with "enable" and "enabled"
+					// the default value of them both is true
+					if !ok || !isEnabled(lconf) {
+						continue
+					}
+					bind := toString(byDefault(lconf["bind"], hocon.String(":0")))
+					port := extractPortNumber(bind)
+					protocol := corev1.ProtocolTCP
+					if t == "udp" || t == "dtls" {
+						protocol = corev1.ProtocolUDP
+					}
+					portList = append(portList, corev1.ServicePort{
+						Name:       fmt.Sprintf("%s-%s-%s", proto, t, name),
+						Protocol:   protocol,
+						Port:       int32(port),
+						TargetPort: intstr.FromInt(port),
+					})
+				}
 			}
 		}
 	}
@@ -350,45 +285,51 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 	return portList
 }
 
-/* hocon.Config helper functions */
+func extractPortNumber(bind string) int {
+	if !strings.Contains(bind, ":") {
+		// example: ":1883"
+		bind = fmt.Sprintf(":%s", bind)
+	}
+	_, portString, _ := net.SplitHostPort(bind)
+	port, err := strconv.ParseInt(portString, 10, 32)
+	if err != nil {
+		return -1
+	}
+	return int(port)
+}
 
-func byDefault(v hocon.Value, def any) hocon.Value {
+/* HOCON helper functions */
+
+func isEnabled(conf hocon.Object) bool {
+	// Compatible with "enable" and "enabled", default value of both is true.
+	return isTrue(byDefault(conf["enable"], byDefault(conf["enabled"], hocon.Bool(true))))
+}
+
+func byDefault(v hocon.Value, def hocon.Value) hocon.Value {
 	if v == nil {
-		switch def := def.(type) {
-		case hocon.Value:
-			return def
-		case bool:
-			return hocon.Boolean(def)
-		case string:
-			return hocon.String(def)
-		case int:
-			return hocon.Int(def)
-		default:
-			panic(fmt.Sprintf("unsupported type: %T", def))
-		}
+		return def
 	}
 	return v
 }
 
 func isTrue(v hocon.Value) bool {
-	if v.Type() != hocon.BooleanType {
-		return false
+	if v.Type() == hocon.BooleanType {
+		return bool(v.(hocon.Bool))
 	}
-	return bool(v.(hocon.Boolean))
-}
-
-func isFalse(v hocon.Value) bool {
-	return !isTrue(v)
+	return false
 }
 
 func toString(v hocon.Value) string {
+	if v == nil {
+		return ""
+	}
 	switch v.Type() {
 	case hocon.StringType:
-		return string(v.(hocon.String))
+		return v.(hocon.StringValue).String()
 	case hocon.BooleanType:
-		return v.String()
-	case hocon.NumberType:
-		return v.String()
+		return strconv.FormatBool(bool(v.(hocon.Bool)))
+	case hocon.IntegerType:
+		return strconv.FormatInt(int64(v.(hocon.Int)), 10)
 	}
 	return ""
 }

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -157,25 +157,24 @@ func (c *EMQX) StripReadOnlyConfig() []string {
 func (c *EMQX) Strip(path string) bool {
 	object := c.Config
 	keys := strings.Split(path, ".")
-	l := len(keys)
-	if l > 0 {
-		return stripRecursive(object, keys, 0, l)
+	if len(keys) > 0 {
+		return stripRecursive(object, keys)
 	}
 	return false
 }
 
-func stripRecursive(object hocon.Object, keys []string, i int, l int) bool {
-	key := keys[i]
+func stripRecursive(object hocon.Object, keys []string) bool {
+	key := keys[0]
 	val, ok := object[key]
 	if !ok {
 		return false
 	}
-	if i == l-1 {
+	if len(keys) == 1 {
 		delete(object, key)
 		return true
 	}
 	inner, ok := val.(hocon.Object)
-	if ok && stripRecursive(inner, keys, i+1, l) {
+	if ok && stripRecursive(inner, keys[1:]) {
 		if len(inner) == 0 {
 			delete(object, key)
 		}
@@ -184,12 +183,28 @@ func stripRecursive(object hocon.Object, keys []string, i int, l int) bool {
 	return false
 }
 
-func (c *EMQX) GetNodeCookie() string {
-	return toString(byDefault(c.Get("node.cookie"), hocon.String("")))
+func (c *EMQX) Replace(path string, with hocon.Value) {
+	object := c.Config
+	keys := strings.Split(path, ".")
+	l := len(keys)
+	if l > 0 {
+		replaceRecursive(object, keys, with)
+	}
 }
 
-func (c *EMQX) Get(path string) hocon.Value {
-	return c.Config.Lookup(path)
+func replaceRecursive(object hocon.Object, keys []string, with hocon.Value) {
+	k := keys[0]
+	v, ok := object[k]
+	switch {
+	case len(keys) == 1:
+		object[k] = with
+	case ok && v.Type() == hocon.ObjectType:
+		inner, _ := v.(hocon.Object)
+		replaceRecursive(inner, keys[1:], with)
+	default:
+		object[k] = hocon.Object{}
+		replaceRecursive(object, keys, with)
+	}
 }
 
 func (c *EMQX) GetNodeCookie() string {

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -94,6 +94,33 @@ func (c *EMQX) String() string {
 	return sb.String()
 }
 
+func (c *EMQX) Get(path string) (hocon.Value, bool) {
+	return c.Config.Lookup(path)
+}
+
+func (c *EMQX) Find(path string) hocon.Value {
+	v, ok := c.Config.Lookup(path)
+	if ok {
+		return v
+	}
+	return nil
+}
+
+func AsString(v hocon.Value) (string, error) {
+	if v == nil {
+		return "", nil
+	}
+	switch v.Type() {
+	case hocon.StringType:
+		return v.(hocon.StringValue).String(), nil
+	case hocon.BooleanType:
+		return strconv.FormatBool(bool(v.(hocon.Bool))), nil
+	case hocon.IntegerType:
+		return strconv.FormatInt(int64(v.(hocon.Int)), 10), nil
+	}
+	return "", fmt.Errorf("%T has no string representation", v)
+}
+
 func (c *EMQX) StripReadOnlyConfig() []string {
 	root := c.Config
 	stripped := []string{}
@@ -165,22 +192,19 @@ func (c *EMQX) Get(path string) hocon.Value {
 	return c.Config.Lookup(path)
 }
 
-func (c *EMQX) GetString(path string) (string, bool) {
-	v := c.Config.Lookup(path)
-	if v == nil {
-		return "", true
-	}
-	s := toString(v)
-	return s, s != ""
+func (c *EMQX) GetNodeCookie() string {
+	v, _ := c.Get("node.cookie")
+	cookie, _ := AsString(v)
+	return cookie
 }
 
 func (c *EMQX) GetDashboardPortMap() map[string]int {
 	portMap := make(map[string]int)
 	portMap["dashboard"] = 18083 // default port
 
-	httpBind := toString(c.Get("dashboard.listeners.http.bind"))
-	httpsBind := toString(c.Get("dashboard.listeners.https.bind"))
-	if httpBind != "" {
+	v, ok := c.Get("dashboard.listeners.http.bind")
+	httpBind, err := AsString(v)
+	if ok && err == nil {
 		port := extractPortNumber(httpBind)
 		if port > 0 {
 			portMap["dashboard"] = port
@@ -190,7 +214,10 @@ func (c *EMQX) GetDashboardPortMap() map[string]int {
 			delete(portMap, "dashboard")
 		}
 	}
-	if httpsBind != "" {
+
+	v, ok = c.Get("dashboard.listeners.https.bind")
+	httpsBind, err := AsString(v)
+	if ok && err == nil {
 		port := extractPortNumber(httpsBind)
 		if port > 0 {
 			portMap["dashboard-https"] = port
@@ -224,8 +251,8 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 	portList := []corev1.ServicePort{}
 
 	// May be empty
-	listeners := c.Get("listeners")
-	if listeners != nil && listeners.Type() == hocon.ObjectType {
+	listeners, ok := c.Get("listeners")
+	if ok && listeners != nil && listeners.Type() == hocon.ObjectType {
 		for t, listener := range listeners.(hocon.Object) {
 			if listener.Type() != hocon.ObjectType {
 				continue
@@ -235,7 +262,10 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 				if !ok || !isEnabled(lconf) {
 					continue
 				}
-				bind := toString(byDefault(lconf["bind"], hocon.String(":0")))
+				bind, err := AsString(byDefault(lconf["bind"], hocon.String(":0")))
+				if err != nil {
+					continue
+				}
 				port := extractPortNumber(bind)
 				protocol := corev1.ProtocolTCP
 				if t == "quic" {
@@ -251,8 +281,8 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 		}
 	}
 
-	gateways := c.Get("gateway")
-	if gateways != nil && gateways.Type() == hocon.ObjectType {
+	gateways, ok := c.Get("gateway")
+	if ok && gateways != nil && gateways.Type() == hocon.ObjectType {
 		for proto, gc := range gateways.(hocon.Object) {
 			gateway, ok := gc.(hocon.Object)
 			if !ok || !isEnabled(gateway) {
@@ -270,7 +300,10 @@ func (c *EMQX) GetListenersServicePorts() []corev1.ServicePort {
 					if !ok || !isEnabled(lconf) {
 						continue
 					}
-					bind := toString(byDefault(lconf["bind"], hocon.String(":0")))
+					bind, err := AsString(byDefault(lconf["bind"], hocon.String(":0")))
+					if err != nil {
+						continue
+					}
 					port := extractPortNumber(bind)
 					protocol := corev1.ProtocolTCP
 					if t == "udp" || t == "dtls" {
@@ -311,7 +344,11 @@ func extractPortNumber(bind string) int {
 
 func isEnabled(conf hocon.Object) bool {
 	// Compatible with "enable" and "enabled", default value of both is true.
-	return isTrue(byDefault(conf["enable"], byDefault(conf["enabled"], hocon.Bool(true))))
+	enabled := byDefault(conf["enable"], byDefault(conf["enabled"], hocon.Bool(true)))
+	if enabled.Type() == hocon.BooleanType {
+		return bool(enabled.(hocon.Bool))
+	}
+	return false
 }
 
 func byDefault(v hocon.Value, def hocon.Value) hocon.Value {
@@ -319,26 +356,4 @@ func byDefault(v hocon.Value, def hocon.Value) hocon.Value {
 		return def
 	}
 	return v
-}
-
-func isTrue(v hocon.Value) bool {
-	if v.Type() == hocon.BooleanType {
-		return bool(v.(hocon.Bool))
-	}
-	return false
-}
-
-func toString(v hocon.Value) string {
-	if v == nil {
-		return ""
-	}
-	switch v.Type() {
-	case hocon.StringType:
-		return v.(hocon.StringValue).String()
-	case hocon.BooleanType:
-		return strconv.FormatBool(bool(v.(hocon.Bool)))
-	case hocon.IntegerType:
-		return strconv.FormatInt(int64(v.(hocon.Int)), 10)
-	}
-	return ""
 }

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -77,12 +77,21 @@ func (c *EMQX) Copy() *EMQX {
 	}
 }
 
-func (c *EMQX) JSON() string {
-	if len(c.Config) == 0 {
-		return ""
+func (c *EMQX) String() string {
+	var sb strings.Builder
+	roots := make([]string, 0, len(c.Config))
+	for r := range c.Config {
+		roots = append(roots, r)
 	}
-	out, _ := json.Marshal(c.Config)
-	return string(out)
+	sort.Strings(roots)
+	for _, root := range roots {
+		sb.WriteString(strconv.Quote(root))
+		sb.WriteString(" ")
+		json, _ := json.Marshal(c.Config[root])
+		sb.Write(json)
+		sb.WriteString("\n")
+	}
+	return sb.String()
 }
 
 func (c *EMQX) StripReadOnlyConfig() []string {

--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -77,7 +77,7 @@ func (c *EMQX) Copy() *EMQX {
 	}
 }
 
-func (c *EMQX) Print() string {
+func (c *EMQX) JSON() string {
 	if len(c.Config) == 0 {
 		return ""
 	}

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/emqx/emqx-operator/hocon"
+	"github.com/lithammer/dedent"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -35,7 +37,7 @@ func TestCopy(t *testing.T) {
 		got := config.Copy()
 		assert.NotSame(t, config.Config, got.Config)
 		got.StripReadOnlyConfig()
-		assert.NotEqual(t, config.JSON(), got.JSON())
+		assert.NotEqual(t, config.String(), got.String())
 	})
 }
 
@@ -317,7 +319,7 @@ func TestJSON(t *testing.T) {
 	t.Run("empty config", func(t *testing.T) {
 		config, err := EMQXConfig("")
 		assert.Nil(t, err)
-		got := config.JSON()
+		got := config.String()
 		assert.Equal(t, "", got)
 	})
 
@@ -327,25 +329,32 @@ func TestJSON(t *testing.T) {
 			cluster.core_nodes = ["emqx@node1.emqx.io", "emqx@node2.emqx.io"]
 		`)
 		assert.Nil(t, err)
-		got := config.JSON()
-		expected := `{"cluster":{"core_nodes":["emqx@node1.emqx.io","emqx@node2.emqx.io"]},"node":{"name":"emqx@127.0.0.1"}}`
-		assert.JSONEq(t, expected, got)
+		got := config.String()
+		expected := dedent.Dedent(`
+			"cluster" {"core_nodes":["emqx@node1.emqx.io","emqx@node2.emqx.io"]}
+			"node" {"name":"emqx@127.0.0.1"}
+		`)
+		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
 
 	t.Run("empty arrays", func(t *testing.T) {
 		config, err := EMQXConfig(`cluster.core_nodes = []`)
 		assert.Nil(t, err)
-		got := config.JSON()
-		expected := `{"cluster":{"core_nodes":[]}}`
-		assert.Equal(t, expected, got)
+		got := config.String()
+		expected := dedent.Dedent(`
+			"cluster" {"core_nodes":[]}
+		`)
+		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
 
 	t.Run("nested arrays", func(t *testing.T) {
 		config, err := EMQXConfig(`cluster.seed_nodes = [["emqx@node1.emqx.io"], []]`)
 		assert.Nil(t, err)
-		got := config.JSON()
-		expected := `{"cluster":{"seed_nodes":[["emqx@node1.emqx.io"],[]]}}`
-		assert.Equal(t, expected, got)
+		got := config.String()
+		expected := dedent.Dedent(`
+			"cluster" {"seed_nodes":[["emqx@node1.emqx.io"],[]]}
+		`)
+		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
 
 	t.Run("complex", func(t *testing.T) {
@@ -440,11 +449,11 @@ func TestJSON(t *testing.T) {
 			hocon.String("SELECT\n\tclientid,\n\tpayload,\n\ttopic\nFROM \"+/+/t/test\""),
 			config.Get("rule_engine.rules.test_rule.sql"),
 		)
-		confJSON := config.JSON()
-		// JSON roundtrip preserves configuration:
-		config, err = EMQXConfig(confJSON)
+		// Roundtrip preserves configuration:
+		confString = config.String()
+		config, err = EMQXConfig(confString)
 		assert.Nil(t, err)
-		assert.JSONEq(t, confJSON, config.JSON())
+		assert.Equal(t, confString, config.String())
 	})
 }
 
@@ -454,7 +463,7 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.listeners.http.bind")
 		assert.Equal(t, got, false)
-		assert.Equal(t, config.JSON(), "")
+		assert.Equal(t, config.String(), "")
 	})
 
 	t.Run("delete non-existent key", func(t *testing.T) {
@@ -464,7 +473,10 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.config.file")
 		assert.Equal(t, got, false)
-		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.JSON())
+		assert.Equal(t,
+			`"dashboard" {"listeners":{"http":{"bind":18083}}}`+"\n",
+			config.String(),
+		)
 	})
 
 	t.Run("delete whole root", func(t *testing.T) {
@@ -474,7 +486,7 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard")
 		assert.Equal(t, got, true)
-		assert.Equal(t, config.JSON(), "")
+		assert.Equal(t, config.String(), "")
 	})
 
 	t.Run("delete empty leftover objects", func(t *testing.T) {
@@ -484,6 +496,9 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.listeners.https.bind")
 		assert.Equal(t, got, true)
-		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.JSON())
+		assert.Equal(t,
+			`"dashboard" {"listeners":{"http":{"bind":18083}}}`+"\n",
+			config.String(),
+		)
 	})
 }

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -59,6 +59,16 @@ func TestNodeCookie(t *testing.T) {
 		got := config.GetNodeCookie()
 		assert.Equal(t, "COOKIE #!@#$", got)
 	})
+
+	t.Run("triple-quoted cookie", func(t *testing.T) {
+		config, err := EMQXConfig(`node.cookie = """~
+			COOKIE
+			LONGER THAN
+			NEEDED~"""`)
+		assert.Nil(t, err)
+		got := config.GetNodeCookie()
+		assert.Equal(t, "COOKIE\nLONGER THAN\nNEEDED", got)
+	})
 }
 
 func TestStripReadOnlyConfig(t *testing.T) {
@@ -89,6 +99,11 @@ func TestStripReadOnlyConfig(t *testing.T) {
 			"durable_sessions",
 		})
 	})
+
+	t.Run("wrong config", func(t *testing.T) {
+		_, err := EMQXConfig("hello world")
+		assert.Error(t, err)
+	})
 }
 
 func TestGetDashboardPortMap(t *testing.T) {
@@ -99,11 +114,6 @@ func TestGetDashboardPortMap(t *testing.T) {
 		assert.Equal(t, map[string]int{
 			"dashboard": 18083,
 		}, got)
-	})
-
-	t.Run("wrong config", func(t *testing.T) {
-		_, err := EMQXConfig("hello world")
-		assert.ErrorContains(t, err, "invalid config object")
 	})
 
 	t.Run("a single http port", func(t *testing.T) {
@@ -209,11 +219,6 @@ func TestGetDashboardServicePorts(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.GetDashboardServicePorts()
 		assert.Equal(t, expect, got)
-	})
-
-	t.Run("wrong config", func(t *testing.T) {
-		_, err := EMQXConfig("hello world")
-		assert.ErrorContains(t, err, "invalid config object")
 	})
 }
 
@@ -322,67 +327,23 @@ func TestPrint(t *testing.T) {
 		`)
 		assert.Nil(t, err)
 		got := config.Print()
-		expected := `cluster {core_nodes = ["emqx@node1.emqx.io", "emqx@node2.emqx.io"]}, node {name = "emqx@127.0.0.1"}`
-		assert.Equal(t, expected, got)
+		expected := `{"cluster":{"core_nodes":["emqx@node1.emqx.io","emqx@node2.emqx.io"]},"node":{"name":"emqx@127.0.0.1"}}`
+		assert.JSONEq(t, expected, got)
 	})
 
 	t.Run("empty arrays", func(t *testing.T) {
-		config, err := EMQXConfig(`
-			cluster.core_nodes = []
-		`)
+		config, err := EMQXConfig(`cluster.core_nodes = []`)
 		assert.Nil(t, err)
 		got := config.Print()
-		expected := `cluster {core_nodes = []}`
-		assert.Equal(t, expected, got)
-	})
-
-	t.Run("non-empty scalar arrays", func(t *testing.T) {
-		config, err := EMQXConfig(`
-			authentication.mechanisms = ["password_based", "jwt"]
-			authorization.cache_ttl = [1, 5, 10]
-		`)
-		assert.Nil(t, err)
-		got := config.Print()
-		expected := `authentication {mechanisms = ["password_based", jwt]}, authorization {cache_ttl = [1, 5, 10]}`
+		expected := `{"cluster":{"core_nodes":[]}}`
 		assert.Equal(t, expected, got)
 	})
 
 	t.Run("nested arrays", func(t *testing.T) {
-		config, err := EMQXConfig(`
-			cluster.seed_nodes = [["emqx@node1.emqx.io"], []]
-		`)
+		config, err := EMQXConfig(`cluster.seed_nodes = [["emqx@node1.emqx.io"], []]`)
 		assert.Nil(t, err)
 		got := config.Print()
-		expected := `cluster {seed_nodes = [["emqx@node1.emqx.io"], []]}`
-		assert.Equal(t, expected, got)
-	})
-
-	t.Run("array objects", func(t *testing.T) {
-		config, err := EMQXConfig(`
-			authentication = [
-				{mechanism = password_based, backend = built_in_database},
-				{mechanism = jwt}
-			]
-		`)
-		assert.Nil(t, err)
-		got := config.Print()
-		expected := `authentication = [{backend = "built_in_database", mechanism = "password_based"}, {mechanism = jwt}]`
-		assert.Equal(t, expected, got)
-	})
-
-	t.Run("complex nested structure", func(t *testing.T) {
-		config, err := EMQXConfig(`
-			durable_sessions.enable = true
-			gateway.coap.listeners.udp.default.bind = 5683
-			gateway.coap.listeners.dtls.default.bind = 5684
-			listeners.tcp.default.bind = 1883
-			listeners.ssl.default.bind = 8883
-			dashboard.listeners.http.bind = 18083
-			dashboard.listeners.https.bind = 18084
-		`)
-		assert.Nil(t, err)
-		got := config.Print()
-		expected := `dashboard {listeners {http {bind = 18083}, https {bind = 18084}}}, durable_sessions {enable = true}, gateway {coap {listeners {dtls {default {bind = 5684}}, udp {default {bind = 5683}}}}}, listeners {ssl {default {bind = 8883}}, tcp {default {bind = 1883}}}`
+		expected := `{"cluster":{"seed_nodes":[["emqx@node1.emqx.io"],[]]}}`
 		assert.Equal(t, expected, got)
 	})
 }
@@ -403,7 +364,7 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.config.file")
 		assert.Equal(t, got, false)
-		assert.Equal(t, config.Print(), `dashboard {listeners {http {bind = 18083}}}`)
+		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.Print())
 	})
 
 	t.Run("delete whole root", func(t *testing.T) {
@@ -423,6 +384,6 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.listeners.https.bind")
 		assert.Equal(t, got, true)
-		assert.Equal(t, config.Print(), `dashboard {listeners {http {bind = 18083}}}`)
+		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.Print())
 	})
 }

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -445,9 +445,10 @@ func TestJSON(t *testing.T) {
 		// Configuration parses correctly:
 		config, err := EMQXConfig(confString)
 		assert.Nil(t, err)
+		field, _ := config.Get("rule_engine.rules.test_rule.sql")
 		assert.Equal(t,
 			hocon.String("SELECT\n\tclientid,\n\tpayload,\n\ttopic\nFROM \"+/+/t/test\""),
-			config.Get("rule_engine.rules.test_rule.sql"),
+			field,
 		)
 		// Roundtrip preserves configuration:
 		confString = config.String()

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestCopy(t *testing.T) {
-	t.Run("empty config", func(t *testing.T) {
+	t.Run("copy config", func(t *testing.T) {
 		config, err := EMQXConfig(`
 		durable_sessions.enable = true
 		listeners.tcp.default.bind = 11883
@@ -34,7 +34,7 @@ func TestCopy(t *testing.T) {
 		got := config.Copy()
 		assert.NotSame(t, config.Config, got.Config)
 		got.StripReadOnlyConfig()
-		assert.NotEqual(t, config.Print(), got.Print())
+		assert.NotEqual(t, config.JSON(), got.JSON())
 	})
 }
 
@@ -312,11 +312,11 @@ func TestGetListenersServicePorts(t *testing.T) {
 	})
 }
 
-func TestPrint(t *testing.T) {
+func TestJSON(t *testing.T) {
 	t.Run("empty config", func(t *testing.T) {
 		config, err := EMQXConfig("")
 		assert.Nil(t, err)
-		got := config.Print()
+		got := config.JSON()
 		assert.Equal(t, "", got)
 	})
 
@@ -326,7 +326,7 @@ func TestPrint(t *testing.T) {
 			cluster.core_nodes = ["emqx@node1.emqx.io", "emqx@node2.emqx.io"]
 		`)
 		assert.Nil(t, err)
-		got := config.Print()
+		got := config.JSON()
 		expected := `{"cluster":{"core_nodes":["emqx@node1.emqx.io","emqx@node2.emqx.io"]},"node":{"name":"emqx@127.0.0.1"}}`
 		assert.JSONEq(t, expected, got)
 	})
@@ -334,7 +334,7 @@ func TestPrint(t *testing.T) {
 	t.Run("empty arrays", func(t *testing.T) {
 		config, err := EMQXConfig(`cluster.core_nodes = []`)
 		assert.Nil(t, err)
-		got := config.Print()
+		got := config.JSON()
 		expected := `{"cluster":{"core_nodes":[]}}`
 		assert.Equal(t, expected, got)
 	})
@@ -342,7 +342,7 @@ func TestPrint(t *testing.T) {
 	t.Run("nested arrays", func(t *testing.T) {
 		config, err := EMQXConfig(`cluster.seed_nodes = [["emqx@node1.emqx.io"], []]`)
 		assert.Nil(t, err)
-		got := config.Print()
+		got := config.JSON()
 		expected := `{"cluster":{"seed_nodes":[["emqx@node1.emqx.io"],[]]}}`
 		assert.Equal(t, expected, got)
 	})
@@ -354,7 +354,7 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.listeners.http.bind")
 		assert.Equal(t, got, false)
-		assert.Equal(t, config.Print(), "")
+		assert.Equal(t, config.JSON(), "")
 	})
 
 	t.Run("delete non-existent key", func(t *testing.T) {
@@ -364,7 +364,7 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.config.file")
 		assert.Equal(t, got, false)
-		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.Print())
+		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.JSON())
 	})
 
 	t.Run("delete whole root", func(t *testing.T) {
@@ -374,7 +374,7 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard")
 		assert.Equal(t, got, true)
-		assert.Equal(t, config.Print(), "")
+		assert.Equal(t, config.JSON(), "")
 	})
 
 	t.Run("delete empty leftover objects", func(t *testing.T) {
@@ -384,6 +384,6 @@ func TestStrip(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.Strip("dashboard.listeners.https.bind")
 		assert.Equal(t, got, true)
-		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.Print())
+		assert.JSONEq(t, `{"dashboard":{"listeners":{"http":{"bind":18083}}}}`, config.JSON())
 	})
 }

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"testing"
 
+	"github.com/emqx/emqx-operator/hocon"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -345,6 +346,105 @@ func TestJSON(t *testing.T) {
 		got := config.JSON()
 		expected := `{"cluster":{"seed_nodes":[["emqx@node1.emqx.io"],[]]}}`
 		assert.Equal(t, expected, got)
+	})
+
+	t.Run("complex", func(t *testing.T) {
+		confString := `
+			license {
+				key = "file:///emqx.license"
+			}
+			log.console.level = error
+			log.console.formatter = json
+			log.console.timestamp_format = rfc3339
+			listeners.tcp.default {
+				bind = "0.0.0.0:1883"
+				enable = true
+				enable_authn = true
+				proxy_protocol = true
+				proxy_protocol_timeout = 5s
+				max_conn_rate = "4000/s"
+				tcp_options {
+				send_timeout = 15s
+				keepalive = "7200,75,9"
+				}
+			}
+			listeners.tcp.internal {
+				bind = "0.0.0.0:1884"
+				enable = true
+				enable_authn = true
+				proxy_protocol = false
+				max_conn_rate = "1000/s"
+				tcp_options {
+				send_timeout = 15s
+				keepalive = "7200,75,9"
+				}
+			}
+			listeners.ssl.default.enable = false
+			listeners.ws.default.enable = false
+			listeners.wss.default.enable = false
+			# cluster.autoclean: how long after a node becomes unreachable before
+			# it's removed from cluster membership. EMQX's default is 24h (!).
+			cluster.autoclean = 60s
+			authorization {
+				cache {
+				enable = true
+				max_size = 32
+				ttl = 60m
+				}
+				deny_action = disconnect
+				no_match = deny
+				sources = [
+				{
+					enable = true
+					path = "data/authz/acl.conf"
+					type = file
+				}
+				]
+			}
+			rule_engine {
+				ignore_sys_message = true
+				jq_function_default_timeout = "10s"
+				rules {
+				test_rule {
+					actions = [
+					{
+						args {
+						direct_dispatch = false
+						mqtt_properties {}
+						payload = ""
+						qos = 0
+						retain = false
+						topic = "${clientid}/cmds/test"
+						user_properties = ""
+						}
+						function = republish
+					}
+					]
+					description = ""
+					enable = true
+					metadata {last_modified_at = 1779340531269}
+					sql = """~
+					SELECT
+						clientid,
+						payload,
+						topic
+					FROM "+/+/t/test"~"""
+				}
+				}
+			}
+		`
+		// Configuration parses correctly:
+		config, err := EMQXConfig(confString)
+		assert.Nil(t, err)
+		assert.Equal(t,
+			hocon.String("SELECT\n\tclientid,\n\tpayload,\n\ttopic\nFROM \"+/+/t/test\""),
+			config.Get("rule_engine.rules.test_rule.sql"),
+		)
+		confJSON := config.JSON()
+		// JSON roundtrip preserves configuration:
+		config, err = EMQXConfig(confJSON)
+		assert.Nil(t, err)
+		assert.JSONEq(t, confJSON, config.JSON())
 	})
 }
 

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -134,13 +134,13 @@ func stripNonChangeableConfig(confDesired string, confLast string) (string, []st
 	cl, _ := config.EMQXConfig(confLast)
 	if cd != nil && cl != nil {
 		for _, path := range dashboardConfigPaths {
-			vd := cd.Get(path)
-			vl := cl.Get(path)
+			vd, vdOk := cd.GetString(path)
+			vl, vlOk := cl.GetString(path)
 			// Disallow changing if following conditions are met:
 			// * Desired is configured and was configured previously (but not "0", i.e. disabled)
 			// * Desired is different from previous value
 			// Otherwise, listener is being enabled, which should be allowed.
-			if vd != nil && vl != nil && vl.String() != "0" && vd.String() != vl.String() {
+			if vdOk && vlOk && vd != "" && vl != "" && vl != "0" && vd != vl {
 				_ = cd.Strip(path)
 				stripped = append(stripped, path)
 				return cd.Print(), stripped

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -27,7 +27,7 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 	conf := confSpec
 	stripped := []string{}
 	if confLast != nil {
-		conf, stripped = stripNonChangeableConfig(confSpec, config.WithDefaults(*confLast))
+		conf, stripped = preserveNonChangeableConfig(confSpec, config.WithDefaults(*confLast))
 	}
 
 	// Make sure the config map exists
@@ -116,7 +116,7 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 	return subResult{}
 }
 
-func stripNonChangeableConfig(confDesired string, confLast string) (string, []string) {
+func preserveNonChangeableConfig(confDesired string, confLast string) (string, []string) {
 	// Operator relies on Dashboard listener to access EMQX API.
 	// Changing the dashboard listener port is too finicky to allow it, so we strip
 	// any changes to previously configured dashboard listener port, either `http` or
@@ -139,7 +139,7 @@ func stripNonChangeableConfig(confDesired string, confLast string) (string, []st
 			// * Desired is different from previous value
 			// Otherwise, listener is being enabled, which should be allowed.
 			if vdExists && vlExists && sl != "0" && sd != sl {
-				_ = cd.Strip(path)
+				cd.Replace(path, vl)
 				stripped = append(stripped, path)
 				return cd.String(), stripped
 			}

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -35,7 +35,8 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 	confWithDefaults := config.WithDefaults(conf)
 	configMap := &corev1.ConfigMap{}
 	err := s.Client.Get(r.ctx, instance.ConfigsNamespacedName(), configMap)
-	if err != nil && k8sErrors.IsNotFound(err) {
+	switch {
+	case err != nil && k8sErrors.IsNotFound(err):
 		configMap = resource.ConfigMap(confWithDefaults)
 		if err := ctrl.SetControllerReference(instance, configMap, s.Scheme); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to set controller reference for configMap")}
@@ -44,21 +45,14 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 		if err := s.Client.Create(r.ctx, configMap); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to create configMap")}
 		}
-		return subResult{}
-	}
-	if err != nil {
+	case err != nil:
 		return subResult{err: emperror.Wrap(err, "failed to get configMap")}
-	}
-
-	// If the config is different, update the config right away.
-	// Assuming the config is valid, otherwise master controller would bail out.
-	if configMap.Data[resources.BaseConfigFile] != confWithDefaults {
+	case configMap.Data[resources.BaseConfigFile] != confWithDefaults:
+		// If the config is different, update the config right away.
+		// Assuming the config is valid, otherwise master controller would bail out.
 		desired := resource.ConfigMap(confWithDefaults)
 		configMap.Labels = desired.Labels
 		configMap.Data = desired.Data
-		if err := ctrl.SetControllerReference(instance, configMap, s.Scheme); err != nil {
-			return subResult{err: emperror.Wrap(err, "failed to set controller reference for configMap")}
-		}
 		r.log.V(1).Info("updating config resource", "configMap", klog.KObj(configMap))
 		if err := s.Client.Update(r.ctx, configMap); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to update configMap")}

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -53,7 +53,9 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 	// If the config is different, update the config right away.
 	// Assuming the config is valid, otherwise master controller would bail out.
 	if configMap.Data[resources.BaseConfigFile] != confWithDefaults {
-		configMap = resource.ConfigMap(confWithDefaults)
+		desired := resource.ConfigMap(confWithDefaults)
+		configMap.Labels = desired.Labels
+		configMap.Data = desired.Data
 		if err := ctrl.SetControllerReference(instance, configMap, s.Scheme); err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to set controller reference for configMap")}
 		}

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -93,7 +93,7 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 			return subResult{err: emperror.Wrap(err, "failed to parse .spec.config.data")}
 		}
 		strippedReadonly := c.StripReadOnlyConfig()
-		confRuntime := c.JSON()
+		confRuntime := c.String()
 
 		// Update the config through API
 		r.log.V(1).Info("applying runtime config", "config", confRuntime)
@@ -143,7 +143,7 @@ func stripNonChangeableConfig(confDesired string, confLast string) (string, []st
 			if vdOk && vlOk && vd != "" && vl != "" && vl != "0" && vd != vl {
 				_ = cd.Strip(path)
 				stripped = append(stripped, path)
-				return cd.JSON(), stripped
+				return cd.String(), stripped
 			}
 		}
 	}

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -130,13 +130,15 @@ func stripNonChangeableConfig(confDesired string, confLast string) (string, []st
 	cl, _ := config.EMQXConfig(confLast)
 	if cd != nil && cl != nil {
 		for _, path := range dashboardConfigPaths {
-			vd, vdOk := cd.GetString(path)
-			vl, vlOk := cl.GetString(path)
+			vd, vdExists := cd.Get(path)
+			vl, vlExists := cl.Get(path)
+			sd, _ := config.AsString(vd)
+			sl, _ := config.AsString(vl)
 			// Disallow changing if following conditions are met:
 			// * Desired is configured and was configured previously (but not "0", i.e. disabled)
 			// * Desired is different from previous value
 			// Otherwise, listener is being enabled, which should be allowed.
-			if vdOk && vlOk && vd != "" && vl != "" && vl != "0" && vd != vl {
+			if vdExists && vlExists && sl != "0" && sd != sl {
 				_ = cd.Strip(path)
 				stripped = append(stripped, path)
 				return cd.String(), stripped

--- a/internal/controller/sync_emqx_config.go
+++ b/internal/controller/sync_emqx_config.go
@@ -93,7 +93,7 @@ func (s *syncConfig) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResul
 			return subResult{err: emperror.Wrap(err, "failed to parse .spec.config.data")}
 		}
 		strippedReadonly := c.StripReadOnlyConfig()
-		confRuntime := c.Print()
+		confRuntime := c.JSON()
 
 		// Update the config through API
 		r.log.V(1).Info("applying runtime config", "config", confRuntime)
@@ -143,7 +143,7 @@ func stripNonChangeableConfig(confDesired string, confLast string) (string, []st
 			if vdOk && vlOk && vd != "" && vl != "" && vl != "0" && vd != vl {
 				_ = cd.Strip(path)
 				stripped = append(stripped, path)
-				return cd.Print(), stripped
+				return cd.JSON(), stripped
 			}
 		}
 	}

--- a/internal/controller/sync_emqx_config_suite_test.go
+++ b/internal/controller/sync_emqx_config_suite_test.go
@@ -190,11 +190,11 @@ var _ = Describe("Reconciler syncConfig", Ordered, func() {
 
 		runtimeConfig, err := config.EMQXConfig(calls[0].Body)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(runtimeConfig.Get("node")).To(BeNil())
-		Expect(runtimeConfig.Get("rpc")).To(BeNil())
-		Expect(runtimeConfig.Get("cluster.name")).To(BeNil())
-		Expect(runtimeConfig.Get("cluster.links")).NotTo(BeNil())
-		Expect(runtimeConfig.Get("listeners")).NotTo(BeNil())
+		Expect(runtimeConfig.Find("node")).To(BeNil())
+		Expect(runtimeConfig.Find("rpc")).To(BeNil())
+		Expect(runtimeConfig.Find("cluster.name")).To(BeNil())
+		Expect(runtimeConfig.Find("cluster.links")).NotTo(BeNil())
+		Expect(runtimeConfig.Find("listeners")).NotTo(BeNil())
 
 		Expect(actualInstance(instance).Annotations).To(HaveKeyWithValue(
 			crdv2.AnnotationLastEMQXConfig,
@@ -271,7 +271,9 @@ func actualConfigMap(instance *crdv2.EMQX) *corev1.ConfigMap {
 }
 
 func configStringAt(conf *config.EMQX, path string) string {
-	value, ok := conf.GetString(path)
+	v, ok := conf.Get(path)
+	s, err := config.AsString(v)
 	Expect(ok).To(BeTrue())
-	return value
+	Expect(err).To(Succeed())
+	return s
 }

--- a/internal/controller/sync_emqx_config_suite_test.go
+++ b/internal/controller/sync_emqx_config_suite_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Reconciler syncConfig", Ordered, func() {
 		configMap := actualConfigMap(instance)
 		conf, err := config.EMQXConfig(configMap.Data[resources.BaseConfigFile])
 		Expect(err).NotTo(HaveOccurred())
-		Expect(conf.Get("dashboard.listeners.https.bind")).To(BeNil())
+		Expect(configStringAt(conf, "dashboard.listeners.https.bind")).To(Equal("18084"))
 		Expect(configStringAt(conf, "listeners.tcp.default.bind")).To(Equal("0.0.0.0:1884"))
 	})
 

--- a/internal/controller/sync_emqx_config_suite_test.go
+++ b/internal/controller/sync_emqx_config_suite_test.go
@@ -1,0 +1,277 @@
+package controller
+
+import (
+	"net/http"
+	"net/url"
+
+	crdv2 "github.com/emqx/emqx-operator/api/v2"
+	config "github.com/emqx/emqx-operator/internal/controller/config"
+	resources "github.com/emqx/emqx-operator/internal/controller/resources"
+	req "github.com/emqx/emqx-operator/internal/requester"
+	"github.com/lithammer/dedent"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("Reconciler syncConfig", Ordered, func() {
+	var ns *corev1.Namespace
+	var instance *crdv2.EMQX
+	var s *syncConfig
+
+	BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "sync-emqx-config-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+
+		instance = emqx.DeepCopy()
+		instance.Namespace = ns.Name
+		instance.Spec.Config.Data = dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
+
+		s = &syncConfig{emqxReconciler}
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	It("creates the ConfigMap and records last-applied config", func() {
+		Eventually(s.reconcile).WithArguments(newReconcileRound(), instance).
+			WithTimeout(timeout).
+			WithPolling(interval).
+			Should(Equal(subResult{}))
+
+		configMap := actualConfigMap(instance)
+		Expect(configMap.Data).To(HaveKeyWithValue(
+			resources.BaseConfigFile,
+			config.WithDefaults(instance.Spec.Config.Data),
+		))
+		Expect(configMap.Data).To(HaveKeyWithValue(resources.OverridesConfigFile, ""))
+		Expect(configMap.OwnerReferences).To(ContainElement(HaveField("Name", Equal(instance.Name))))
+
+		Expect(actualInstance(instance).Annotations).To(HaveKeyWithValue(
+			crdv2.AnnotationLastEMQXConfig,
+			instance.Spec.Config.Data,
+		))
+	})
+
+	It("updates the ConfigMap but defers runtime update until core nodes are ready", func() {
+		lastConfig := dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		nextConfig := dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1884"
+		`)
+		instance = establishConfig(s, instance, lastConfig)
+		instance = updateSpecConfig(instance, nextConfig)
+
+		calls := []syncConfigAPIRequest{}
+		round := newSyncConfigRound(&calls, 204)
+		Eventually(s.reconcile).WithArguments(round, instance).
+			WithTimeout(timeout).
+			WithPolling(interval).
+			Should(Equal(subResult{}))
+
+		configMap := actualConfigMap(instance)
+		Expect(configMap.Data[resources.BaseConfigFile]).To(Equal(config.WithDefaults(nextConfig)))
+		Expect(actualInstance(instance).Annotations).To(HaveKeyWithValue(
+			crdv2.AnnotationLastEMQXConfig,
+			lastConfig,
+		))
+		Expect(calls).To(BeEmpty())
+	})
+
+	It("strips non-changeable dashboard listener update", func() {
+		lastConfig := dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		nextConfig := dedent.Dedent(`
+			dashboard.listeners.http.bind = 18084
+			listeners.tcp.default.bind = "0.0.0.0:1884"
+		`)
+		instance = establishConfig(s, instance, lastConfig)
+		instance = updateSpecConfig(instance, nextConfig)
+
+		Eventually(s.reconcile).WithArguments(newReconcileRound(), instance).
+			WithTimeout(timeout).
+			WithPolling(interval).
+			Should(Equal(subResult{}))
+
+		configMap := actualConfigMap(instance)
+		conf, err := config.EMQXConfig(configMap.Data[resources.BaseConfigFile])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configStringAt(conf, "dashboard.listeners.http.bind")).To(Equal("18083"))
+		Expect(configStringAt(conf, "listeners.tcp.default.bind")).To(Equal("0.0.0.0:1884"))
+	})
+
+	It("strips non-changeable HTTPS dashboard listener update", func() {
+		lastConfig := dedent.Dedent(`
+			dashboard.listeners.https.bind = 18084
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		nextConfig := dedent.Dedent(`
+			dashboard.listeners.https.bind = 18085
+			listeners.tcp.default.bind = "0.0.0.0:1884"
+		`)
+		instance = establishConfig(s, instance, lastConfig)
+		instance = updateSpecConfig(instance, nextConfig)
+
+		Eventually(s.reconcile).WithArguments(newReconcileRound(), instance).
+			WithTimeout(timeout).
+			WithPolling(interval).
+			Should(Equal(subResult{}))
+
+		configMap := actualConfigMap(instance)
+		conf, err := config.EMQXConfig(configMap.Data[resources.BaseConfigFile])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conf.Get("dashboard.listeners.https.bind")).To(BeNil())
+		Expect(configStringAt(conf, "listeners.tcp.default.bind")).To(Equal("0.0.0.0:1884"))
+	})
+
+	It("allows enabling a previously disabled dashboard listener", func() {
+		lastConfig := dedent.Dedent(`
+			dashboard.listeners.http.bind = 0
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		nextConfig := dedent.Dedent(`
+			dashboard.listeners.http.bind = 18084
+			listeners.tcp.default.bind = "0.0.0.0:1884"
+		`)
+		instance = establishConfig(s, instance, lastConfig)
+		instance = updateSpecConfig(instance, nextConfig)
+
+		Eventually(s.reconcile).WithArguments(newReconcileRound(), instance).
+			WithTimeout(timeout).
+			WithPolling(interval).
+			Should(Equal(subResult{}))
+
+		configMap := actualConfigMap(instance)
+		conf, err := config.EMQXConfig(configMap.Data[resources.BaseConfigFile])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configStringAt(conf, "dashboard.listeners.http.bind")).To(Equal("18084"))
+		Expect(configStringAt(conf, "listeners.tcp.default.bind")).To(Equal("0.0.0.0:1884"))
+	})
+
+	It("applies runtime config when core nodes are ready and strips readonly runtime entries", func() {
+		lastConfig := dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		nextConfig := dedent.Dedent(`
+			node.name = "emqx@127.0.0.1"
+			rpc.tcp_client_num = 1
+			cluster.name = "readonly"
+			cluster.links.remote.server = "remote:1883"
+			listeners.tcp.default.bind = "0.0.0.0:1884"
+		`)
+		instance = establishConfig(s, instance, lastConfig)
+		instance = updateSpecConfig(instance, nextConfig)
+		instance.Status.SetTrueCondition(crdv2.CoreNodesReady)
+
+		calls := []syncConfigAPIRequest{}
+		round := newSyncConfigRound(&calls, 204)
+		Eventually(s.reconcile).WithArguments(round, instance).
+			WithTimeout(timeout).
+			WithPolling(interval).
+			Should(Equal(subResult{result: ctrl.Result{Requeue: true}}))
+
+		Expect(calls).To(ConsistOf(And(
+			HaveField("Method", Equal(http.MethodPut)),
+			HaveField("Path", Equal("api/v5/configs")),
+			HaveField("Header", HaveKeyWithValue("Content-Type", ConsistOf(Equal("text/plain")))),
+		)))
+
+		runtimeConfig, err := config.EMQXConfig(calls[0].Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(runtimeConfig.Get("node")).To(BeNil())
+		Expect(runtimeConfig.Get("rpc")).To(BeNil())
+		Expect(runtimeConfig.Get("cluster.name")).To(BeNil())
+		Expect(runtimeConfig.Get("cluster.links")).NotTo(BeNil())
+		Expect(runtimeConfig.Get("listeners")).NotTo(BeNil())
+
+		Expect(actualInstance(instance).Annotations).To(HaveKeyWithValue(
+			crdv2.AnnotationLastEMQXConfig,
+			nextConfig,
+		))
+	})
+
+	It("returns an error and keeps last-applied config when runtime update fails", func() {
+		lastConfig := dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1883"
+		`)
+		nextConfig := dedent.Dedent(`
+			listeners.tcp.default.bind = "0.0.0.0:1884"
+		`)
+		instance = establishConfig(s, instance, lastConfig)
+		instance = updateSpecConfig(instance, nextConfig)
+		instance.Status.SetTrueCondition(crdv2.CoreNodesReady)
+
+		calls := []syncConfigAPIRequest{}
+		result := s.reconcile(newSyncConfigRound(&calls, 500), instance)
+
+		Expect(result.result).To(Equal(ctrl.Result{}))
+		Expect(result.err).To(MatchError(ContainSubstring("failed to update emqx config through API")))
+		Expect(calls).To(HaveLen(1))
+		Expect(actualInstance(instance).Annotations).To(HaveKeyWithValue(
+			crdv2.AnnotationLastEMQXConfig,
+			lastConfig,
+		))
+	})
+})
+
+type syncConfigAPIRequest struct {
+	Method string
+	Path   string
+	Body   string
+	Header http.Header
+}
+
+func newSyncConfigRound(calls *[]syncConfigAPIRequest, statusCode int) *reconcileRound {
+	requester := req.NewMockRequester(
+		func(method string, u url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
+			*calls = append(*calls, syncConfigAPIRequest{
+				Method: method,
+				Path:   u.Path,
+				Body:   string(body),
+				Header: header,
+			})
+			return &http.Response{StatusCode: statusCode}, []byte("runtime update failed"), nil
+		},
+	)
+	return newReconcileRoundWithRequester(requester)
+}
+
+func establishConfig(s *syncConfig, instance *crdv2.EMQX, configData string) *crdv2.EMQX {
+	instance.Spec.Config.Data = configData
+	Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
+	Eventually(s.reconcile).WithArguments(newReconcileRound(), actualInstance(instance)).
+		WithTimeout(timeout).
+		WithPolling(interval).
+		Should(Equal(subResult{}))
+	return actualInstance(instance)
+}
+
+func updateSpecConfig(instance *crdv2.EMQX, configData string) *crdv2.EMQX {
+	instance.Spec.Config.Data = configData
+	Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
+	return actualInstance(instance)
+}
+
+func actualConfigMap(instance *crdv2.EMQX) *corev1.ConfigMap {
+	configMap := &corev1.ConfigMap{}
+	Expect(k8sClient.Get(ctx, instance.ConfigsNamespacedName(), configMap)).Should(Succeed())
+	return configMap
+}
+
+func configStringAt(conf *config.EMQX, path string) string {
+	value, ok := conf.GetString(path)
+	Expect(ok).To(BeTrue())
+	return value
+}

--- a/internal/controller/sync_emqx_config_test.go
+++ b/internal/controller/sync_emqx_config_test.go
@@ -24,22 +24,22 @@ import (
 
 func TestStripNonChangeableConfig(t *testing.T) {
 	t.Run("empty configs", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig("", "")
+		config, stripped := preserveNonChangeableConfig("", "")
 		assert.Equal(t, "", config)
 		assert.Equal(t, []string{}, stripped)
 	})
 
 	t.Run("http port changed", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig(
+		config, stripped := preserveNonChangeableConfig(
 			"dashboard.listeners.http.bind = 18083",
 			"dashboard.listeners.http.bind = 18084",
 		)
-		assert.Equal(t, "", config)
+		assert.Equal(t, `"dashboard" {"listeners":{"http":{"bind":18084}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
 	})
 
 	t.Run("http port unchanged", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig(
+		config, stripped := preserveNonChangeableConfig(
 			"dashboard.listeners.http.bind = 18083",
 			"dashboard.listeners.http.bind = 18083",
 		)
@@ -48,16 +48,16 @@ func TestStripNonChangeableConfig(t *testing.T) {
 	})
 
 	t.Run("https port changed", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig(
+		config, stripped := preserveNonChangeableConfig(
 			"dashboard.listeners.https.bind = 18083",
 			"dashboard.listeners.https.bind = 18084",
 		)
-		assert.Equal(t, "", config)
+		assert.Equal(t, `"dashboard" {"listeners":{"https":{"bind":18084}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.https.bind"}, stripped)
 	})
 
 	t.Run("https port enabled", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig(
+		config, stripped := preserveNonChangeableConfig(
 			"dashboard.listeners.https.bind = 18883",
 			"dashboard.listeners.https.bind = 0",
 		)
@@ -66,16 +66,16 @@ func TestStripNonChangeableConfig(t *testing.T) {
 	})
 
 	t.Run("both ports changed", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig(
+		config, stripped := preserveNonChangeableConfig(
 			"dashboard.listeners { http.bind = 18883, https.bind = 18884 }",
 			"dashboard.listeners { http.bind = 18083, https.bind = 18084 }",
 		)
-		assert.Equal(t, `"dashboard" {"listeners":{"https":{"bind":18884}}}`+"\n", config)
+		assert.Equal(t, `"dashboard" {"listeners":{"http":{"bind":18083},"https":{"bind":18884}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
 	})
 
 	t.Run("http port unchanged but different type", func(t *testing.T) {
-		config, stripped := stripNonChangeableConfig(
+		config, stripped := preserveNonChangeableConfig(
 			`dashboard.listeners.http.bind = 18083`,
 			`dashboard.listeners.http.bind = "18083"`,
 		)

--- a/internal/controller/sync_emqx_config_test.go
+++ b/internal/controller/sync_emqx_config_test.go
@@ -70,7 +70,7 @@ func TestStripNonChangeableConfig(t *testing.T) {
 			"dashboard.listeners { http.bind = 18883, https.bind = 18884 }",
 			"dashboard.listeners { http.bind = 18083, https.bind = 18084 }",
 		)
-		assert.JSONEq(t, `{"dashboard":{"listeners":{"https":{"bind":18884}}}}`, config)
+		assert.Equal(t, `"dashboard" {"listeners":{"https":{"bind":18884}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
 	})
 

--- a/internal/controller/sync_emqx_config_test.go
+++ b/internal/controller/sync_emqx_config_test.go
@@ -70,7 +70,17 @@ func TestStripNonChangeableConfig(t *testing.T) {
 			"dashboard.listeners { http.bind = 18883, https.bind = 18884 }",
 			"dashboard.listeners { http.bind = 18083, https.bind = 18084 }",
 		)
-		assert.Equal(t, "dashboard {listeners {https {bind = 18884}}}", config)
+		assert.JSONEq(t, `{"dashboard":{"listeners":{"https":{"bind":18884}}}}`, config)
 		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
 	})
+
+	t.Run("http port unchanged but different type", func(t *testing.T) {
+		config, stripped := stripNonChangeableConfig(
+			`dashboard.listeners.http.bind = 18083`,
+			`dashboard.listeners.http.bind = "18083"`,
+		)
+		assert.Equal(t, "dashboard.listeners.http.bind = 18083", config)
+		assert.Equal(t, []string{}, stripped)
+	})
+
 }


### PR DESCRIPTION
## Summary

1. Employ internal github.com/emqx/emqx-operator/hocon EMQX-flavored HOCON parser to deal with CR config snippets.
    * Replace custom serializer with thin wrapper over `json.Marshal(...)`
    * Adapt port mapping functions.
    * Verify on non-trivial config snippets.
2. Refine EMQX configuration sync reconciler.
    * Preserve non-changeable entries instead of stripping.
    * Avoid artificial early return after first-time sync.
    * Cover with envtest-style test suite.

Followup to #1209.