### PR TITLE
fix: avoid force-leaving replicant nodes

### DIFF
--- a/internal/controller/sync_cluster_membership.go
+++ b/internal/controller/sync_cluster_membership.go
@@ -11,7 +11,6 @@ import (
 
 // Responsibilities:
 // - Removes EMQX cores from the cluster that should no longer be a member, because of scale-down.
-// - Removes EMQX replicants that no longer have a corresponding pod.
 type syncClusterMembership struct {
 	*EMQXReconciler
 }
@@ -47,19 +46,6 @@ func (s *syncClusterMembership) reconcile(r *reconcileRound, instance *crd.EMQX)
 			continue
 		}
 		// Cores having higher pod ordinals should be force-left:
-		staleNodes = append(staleNodes, &node)
-	}
-
-	for _, node := range instance.Status.ReplicantNodes {
-		// Running replicants / replicants still having respective pods should not be force-left:
-		if node.Status != api.NodeStatusStopped {
-			continue
-		}
-		pod := r.state.podWithName(node.PodName)
-		if pod != nil {
-			continue
-		}
-		// Stopped replicants w/o respective pods should be force-left:
 		staleNodes = append(staleNodes, &node)
 	}
 

--- a/internal/controller/sync_cluster_membership_suite_test.go
+++ b/internal/controller/sync_cluster_membership_suite_test.go
@@ -215,7 +215,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 		Expect(forceLeftNodes).To(BeEmpty())
 	})
 
-	It("force-leaves stale replicant nodes whose pods are gone", func() {
+	It("does NOT force-leave stopped replicant nodes whose pods are gone", func() {
 		instance.Status.CoreNodes = []crd.EMQXNode{
 			{Name: emqxNodeName(corePod0.Name), PodName: corePod0.Name, Status: "running"},
 		}
@@ -227,7 +227,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
-		Expect(forceLeftNodes).To(ConsistOf("emqx@10.0.0.11"))
+		Expect(forceLeftNodes).To(BeEmpty())
 	})
 
 	It("does NOT force-leave stopped replicant whose pod still exists", func() {


### PR DESCRIPTION
## Summary

This PR changes the behavior of `syncClusterMembership` reconciler. It now leaves handling of stopped replicant nodes up to the EMQX cluster: replicants are usually removed from cluster views automatically and as such API considers this as an invalid request.