### PR TITLE
fix(config): correctly pass config update to EMQX API

### DIFF
--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -86,7 +86,7 @@ func (c *EMQX) String() string {
 	sort.Strings(roots)
 	for _, root := range roots {
 		sb.WriteString(strconv.Quote(root))
-		sb.WriteString(" ")
+		sb.WriteString(" = ")
 		json, _ := json.Marshal(c.Config[root])
 		sb.Write(json)
 		sb.WriteString("\n")

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -315,7 +315,7 @@ func TestGetListenersServicePorts(t *testing.T) {
 	})
 }
 
-func TestJSON(t *testing.T) {
+func TestString(t *testing.T) {
 	t.Run("empty config", func(t *testing.T) {
 		config, err := EMQXConfig("")
 		assert.Nil(t, err)
@@ -331,8 +331,8 @@ func TestJSON(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.String()
 		expected := dedent.Dedent(`
-			"cluster" {"core_nodes":["emqx@node1.emqx.io","emqx@node2.emqx.io"]}
-			"node" {"name":"emqx@127.0.0.1"}
+			"cluster" = {"core_nodes":["emqx@node1.emqx.io","emqx@node2.emqx.io"]}
+			"node" = {"name":"emqx@127.0.0.1"}
 		`)
 		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
@@ -342,7 +342,7 @@ func TestJSON(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.String()
 		expected := dedent.Dedent(`
-			"cluster" {"core_nodes":[]}
+			"cluster" = {"core_nodes":[]}
 		`)
 		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
@@ -352,7 +352,7 @@ func TestJSON(t *testing.T) {
 		assert.Nil(t, err)
 		got := config.String()
 		expected := dedent.Dedent(`
-			"cluster" {"seed_nodes":[["emqx@node1.emqx.io"],[]]}
+			"cluster" = {"seed_nodes":[["emqx@node1.emqx.io"],[]]}
 		`)
 		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
@@ -410,6 +410,14 @@ func TestJSON(t *testing.T) {
 				}
 				]
 			}
+			authentication = [
+			{
+				backend = built_in_database
+				mechanism = password_based
+				password_hash_algorithm {name = sha256, salt_position = suffix}
+				user_id_type = username
+			},
+			]
 			rule_engine {
 				ignore_sys_message = true
 				jq_function_default_timeout = "10s"
@@ -475,7 +483,7 @@ func TestStrip(t *testing.T) {
 		got := config.Strip("dashboard.config.file")
 		assert.Equal(t, got, false)
 		assert.Equal(t,
-			`"dashboard" {"listeners":{"http":{"bind":18083}}}`+"\n",
+			`"dashboard" = {"listeners":{"http":{"bind":18083}}}`+"\n",
 			config.String(),
 		)
 	})
@@ -498,7 +506,7 @@ func TestStrip(t *testing.T) {
 		got := config.Strip("dashboard.listeners.https.bind")
 		assert.Equal(t, got, true)
 		assert.Equal(t,
-			`"dashboard" {"listeners":{"http":{"bind":18083}}}`+"\n",
+			`"dashboard" = {"listeners":{"http":{"bind":18083}}}`+"\n",
 			config.String(),
 		)
 	})

--- a/internal/controller/sync_emqx_config_suite_test.go
+++ b/internal/controller/sync_emqx_config_suite_test.go
@@ -171,6 +171,7 @@ var _ = Describe("Reconciler syncConfig", Ordered, func() {
 			cluster.links.remote.server = "remote:1883"
 			listeners.tcp.default.bind = "0.0.0.0:1884"
 		`)
+		instance.Spec.Config.Mode = "Replace"
 		instance = establishConfig(s, instance, lastConfig)
 		instance = updateSpecConfig(instance, nextConfig)
 		instance.Status.SetTrueCondition(crdv2.CoreNodesReady)
@@ -184,7 +185,8 @@ var _ = Describe("Reconciler syncConfig", Ordered, func() {
 
 		Expect(calls).To(ConsistOf(And(
 			HaveField("Method", Equal(http.MethodPut)),
-			HaveField("Path", Equal("api/v5/configs")),
+			HaveField("URL.Path", Equal("api/v5/configs")),
+			HaveField("URL.RawQuery", Equal("ignore_readonly=true&mode=replace")),
 			HaveField("Header", HaveKeyWithValue("Content-Type", ConsistOf(Equal("text/plain")))),
 		)))
 
@@ -228,17 +230,17 @@ var _ = Describe("Reconciler syncConfig", Ordered, func() {
 
 type syncConfigAPIRequest struct {
 	Method string
-	Path   string
+	URL    url.URL
 	Body   string
 	Header http.Header
 }
 
 func newSyncConfigRound(calls *[]syncConfigAPIRequest, statusCode int) *reconcileRound {
 	requester := req.NewMockRequester(
-		func(method string, u url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
+		func(method string, url url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
 			*calls = append(*calls, syncConfigAPIRequest{
 				Method: method,
-				Path:   u.Path,
+				URL:    url,
 				Body:   string(body),
 				Header: header,
 			})

--- a/internal/controller/sync_emqx_config_test.go
+++ b/internal/controller/sync_emqx_config_test.go
@@ -34,7 +34,7 @@ func TestStripNonChangeableConfig(t *testing.T) {
 			"dashboard.listeners.http.bind = 18083",
 			"dashboard.listeners.http.bind = 18084",
 		)
-		assert.Equal(t, `"dashboard" {"listeners":{"http":{"bind":18084}}}`+"\n", config)
+		assert.Equal(t, `"dashboard" = {"listeners":{"http":{"bind":18084}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
 	})
 
@@ -52,7 +52,7 @@ func TestStripNonChangeableConfig(t *testing.T) {
 			"dashboard.listeners.https.bind = 18083",
 			"dashboard.listeners.https.bind = 18084",
 		)
-		assert.Equal(t, `"dashboard" {"listeners":{"https":{"bind":18084}}}`+"\n", config)
+		assert.Equal(t, `"dashboard" = {"listeners":{"https":{"bind":18084}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.https.bind"}, stripped)
 	})
 
@@ -70,7 +70,7 @@ func TestStripNonChangeableConfig(t *testing.T) {
 			"dashboard.listeners { http.bind = 18883, https.bind = 18884 }",
 			"dashboard.listeners { http.bind = 18083, https.bind = 18084 }",
 		)
-		assert.Equal(t, `"dashboard" {"listeners":{"http":{"bind":18083},"https":{"bind":18884}}}`+"\n", config)
+		assert.Equal(t, `"dashboard" = {"listeners":{"http":{"bind":18083},"https":{"bind":18884}}}`+"\n", config)
 		assert.Equal(t, []string{"dashboard.listeners.http.bind"}, stripped)
 	})
 

--- a/internal/emqx/api/api.go
+++ b/internal/emqx/api/api.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"syscall"
 
 	emperror "emperror.dev/errors"
@@ -56,18 +57,27 @@ func delete(req req.RequesterInterface, path string) ([]byte, error) {
 	return request(req, "DELETE", path, nil, nil)
 }
 
-func request(req req.RequesterInterface, method string, path string, body []byte, header http.Header) ([]byte, error) {
+func request(req req.RequesterInterface, method string, path string, body []byte, header http.Header, query ...string) ([]byte, error) {
 	if req == nil {
 		return nil, emperror.New("no requester")
 	}
-	url := req.GetURL(path)
-	resp, body, err := req.Request(method, url, body, header)
+	reqUrl := req.GetURL(path)
+	values := url.Values{}
+	for i := 0; i < len(query); i += 2 {
+		value := ""
+		if i+1 < len(query) {
+			value = query[i+1]
+		}
+		values.Add(query[i], value)
+	}
+	reqUrl.RawQuery = values.Encode()
+	resp, body, err := req.Request(method, reqUrl, body, header)
 	if err != nil {
-		return nil, emperror.Wrapf(err, "error accessing %s API %s", req.GetDescription(), url.String())
+		return nil, emperror.Wrapf(err, "error accessing %s API %s", req.GetDescription(), reqUrl.String())
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		err := apiError{StatusCode: resp.StatusCode, Message: string(body)}
-		return nil, emperror.Wrapf(err, "error accessing %s API %s", req.GetDescription(), url.String())
+		return nil, emperror.Wrapf(err, "error accessing %s API %s", req.GetDescription(), reqUrl.String())
 	}
 	return body, nil
 }

--- a/internal/emqx/api/config.go
+++ b/internal/emqx/api/config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	req "github.com/emqx/emqx-operator/internal/requester"
 )
@@ -17,9 +18,13 @@ func Configs(req req.RequesterInterface) (string, error) {
 }
 
 func UpdateConfigs(req req.RequesterInterface, mode, config string) error {
+	query := []string{"ignore_readonly", "true"}
+	if mode != "" {
+		query = append(query, "mode", strings.ToLower(mode))
+	}
 	header := http.Header{}
 	header.Set("Content-Type", "text/plain")
-	_, err := request(req, "PUT", "api/v5/configs", []byte(config), header)
+	_, err := request(req, "PUT", "api/v5/configs", []byte(config), header, query...)
 	if err != nil {
 		return err
 	}

--- a/internal/emqx/api/config_test.go
+++ b/internal/emqx/api/config_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	req "github.com/emqx/emqx-operator/internal/requester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateConfigsModeQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		expected string
+	}{
+		{name: "empty mode",
+			mode: "", expected: "ignore_readonly=true"},
+		{name: "lowercase mode",
+			mode: "Replace", expected: "ignore_readonly=true&mode=replace"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actual url.URL
+			requester := req.NewMockRequester(
+				func(method string, u url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
+					actual = u
+					assert.Equal(t, http.MethodPut, method)
+					assert.Equal(t, "api/v5/configs", u.Path)
+					assert.Equal(t, "text/plain", header.Get("Content-Type"))
+					assert.Equal(t, "config", string(body))
+					return &http.Response{StatusCode: http.StatusNoContent}, nil, nil
+				},
+			)
+
+			err := UpdateConfigs(requester, tt.mode, "config")
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual.RawQuery)
+		})
+	}
+}

--- a/internal/emqx/api/request_test.go
+++ b/internal/emqx/api/request_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	req "github.com/emqx/emqx-operator/internal/requester"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestQueryPairs(t *testing.T) {
+	var actual url.URL
+	requester := req.NewMockRequester(
+		func(method string, u url.URL, body []byte, header http.Header) (*http.Response, []byte, error) {
+			actual = u
+			return &http.Response{StatusCode: http.StatusNoContent}, nil, nil
+		},
+	)
+
+	_, err := request(requester, http.MethodGet, "api/v5/configs", nil, nil, "mode", "replace", "dry_run")
+	require.NoError(t, err)
+	assert.Equal(t, "dry_run=&mode=replace", actual.RawQuery)
+}

--- a/internal/requester/requester.go
+++ b/internal/requester/requester.go
@@ -16,7 +16,7 @@ type HeaderOpt struct {
 }
 
 type RequesterInterface interface {
-	GetURL(path string, query ...string) url.URL
+	GetURL(path string) url.URL
 	GetHost() string
 	GetUsername() string
 	GetPassword() string
@@ -55,20 +55,12 @@ func (requester *Requester) GetDescription() string {
 	return requester.Description
 }
 
-func (requester *Requester) GetURL(path string, query ...string) url.URL {
-	url := url.URL{
+func (requester *Requester) GetURL(path string) url.URL {
+	return url.URL{
 		Scheme: requester.GetSchema(),
 		Host:   requester.GetHost(),
 		Path:   path,
 	}
-	for _, q := range query {
-		if url.RawQuery == "" {
-			url.RawQuery = q
-			continue
-		}
-		url.RawQuery += "&" + q
-	}
-	return url
 }
 
 var httpClient = &http.Client{
@@ -133,12 +125,12 @@ func NewMockRequester(mockFunc MockRequesterFunc) *MockRequester {
 	return &MockRequester{mockFunc: mockFunc}
 }
 
-func (f *MockRequester) GetURL(path string, query ...string) url.URL { return url.URL{Path: path} }
-func (f *MockRequester) GetSchema() string                           { return "http" }
-func (f *MockRequester) GetHost() string                             { return "" }
-func (f *MockRequester) GetUsername() string                         { return "" }
-func (f *MockRequester) GetPassword() string                         { return "" }
-func (f *MockRequester) GetDescription() string                      { return "MockRequester" }
+func (f *MockRequester) GetURL(path string) url.URL { return url.URL{Path: path} }
+func (f *MockRequester) GetSchema() string          { return "http" }
+func (f *MockRequester) GetHost() string            { return "" }
+func (f *MockRequester) GetUsername() string        { return "" }
+func (f *MockRequester) GetPassword() string        { return "" }
+func (f *MockRequester) GetDescription() string     { return "MockRequester" }
 
 func (f *MockRequester) Request(method string, url url.URL, body []byte, header http.Header) (resp *http.Response, respBody []byte, err error) {
 	return f.mockFunc(method, url, body, header)


### PR DESCRIPTION
## Summary

This PR:
1. Fixes a subtle issue with serializing HOCON objects containing non-object root.
2. Passes CR's `config.mode` to EMQX Config API, was accidentally ignored before.

Followup to #1212.
