### PR TITLE
ci: tighten workflow token permissions

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -2,6 +2,9 @@ name: Run Gitlint
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   gitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/emqx/emqx-operator/security/code-scanning/16](https://github.com/emqx/emqx-operator/security/code-scanning/16)

Add an explicit `permissions` block to `.github/workflows/lint.yml` so the workflow does not rely on ambient defaults.  
Best single fix without changing behavior: set workflow-level permissions to:

- `contents: read`

This is sufficient for checkout/lint in the shown workflow and aligns with CodeQL’s suggested minimal baseline. Place it near the top-level keys (after `on:` and before `jobs:`) so it applies to all jobs unless overridden later.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
