### PR TITLE
fix(pdb): avoid creating PDBs if budgets are undefined

### DIFF
--- a/api/v2/emqx_types_spec.go
+++ b/api/v2/emqx_types_spec.go
@@ -317,6 +317,10 @@ func (spec *EMQXSpec) HasReplicants() bool {
 	return spec.ReplicantTemplate != nil && ptr.Deref(spec.ReplicantTemplate.Spec.Replicas, 1) > 0
 }
 
+func (spec *EMQXReplicantTemplateSpec) PodDisruptionBudgetEnabled() bool {
+	return spec.MinAvailable != nil || spec.MaxUnavailable != nil
+}
+
 func (s *ServiceTemplate) IsEnabled() bool {
 	return s.Enabled != nil && *s.Enabled
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 
 require (
 	emperror.dev/errors v0.8.1
-	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 emperror.dev/errors v0.8.1 h1:UavXZ5cSX/4u9iyvH6aDcuGkVjeexUGJ7Ij7G4VfQT0=
 emperror.dev/errors v0.8.1/go.mod h1:YcRvLPh626Ubn2xqtoprejnA5nFha+TJ+2vew48kWuE=
-github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
-github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=

--- a/internal/controller/add_pdb.go
+++ b/internal/controller/add_pdb.go
@@ -2,14 +2,12 @@ package controller
 
 import (
 	emperror "emperror.dev/errors"
-	semver "github.com/Masterminds/semver/v3"
 	crdv2 "github.com/emqx/emqx-operator/api/v2"
 	policyv1 "k8s.io/api/policy/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/discovery"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	kubeConfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 type addPdb struct {
@@ -17,94 +15,92 @@ type addPdb struct {
 }
 
 func (a *addPdb) reconcile(r *reconcileRound, instance *crdv2.EMQX) subResult {
-	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(kubeConfig.GetConfigOrDie())
-	kubeVersion, _ := discoveryClient.ServerVersion()
-	v, _ := semver.NewVersion(kubeVersion.String())
-
-	pdbList := []client.Object{}
-	if v.LessThan(semver.MustParse("1.21")) {
-		corePdb, replPdb := generatePodDisruptionBudgetV1beta1(instance)
-		pdbList = append(pdbList, corePdb)
-		if replPdb != nil {
-			pdbList = append(pdbList, replPdb)
-		}
-	} else {
-		corePdb, replPdb := generatePodDisruptionBudget(instance)
-		pdbList = append(pdbList, corePdb)
-		if replPdb != nil {
-			pdbList = append(pdbList, replPdb)
-		}
+	if err := a.reconcilePodDisruptionBudget(
+		r,
+		instance,
+		instance.Spec.CoreTemplate.Spec.PodDisruptionBudgetEnabled(),
+		generateCorePodDisruptionBudget(instance),
+	); err != nil {
+		return subResult{err: emperror.Wrap(err, "failed to reconcile core PDB")}
 	}
 
-	if err := a.CreateOrUpdateList(r.ctx, a.Scheme, r.log, instance, pdbList); err != nil {
-		return subResult{err: emperror.Wrap(err, "failed to create or update PDBs")}
+	if err := a.reconcilePodDisruptionBudget(
+		r,
+		instance,
+		instance.Spec.HasReplicants() && instance.Spec.ReplicantTemplate.Spec.PodDisruptionBudgetEnabled(),
+		generateReplicantPodDisruptionBudget(instance),
+	); err != nil {
+		return subResult{err: emperror.Wrap(err, "failed to reconcile replicant PDB")}
 	}
+
 	return subResult{}
 }
 
-func generatePodDisruptionBudget(instance *crdv2.EMQX) (*policyv1.PodDisruptionBudget, *policyv1.PodDisruptionBudget) {
-	corePdb := &policyv1.PodDisruptionBudget{
+func (a *addPdb) reconcilePodDisruptionBudget(
+	r *reconcileRound,
+	instance *crdv2.EMQX,
+	enabled bool,
+	pdb *policyv1.PodDisruptionBudget,
+) error {
+	if enabled {
+		return a.CreateOrUpdate(r.ctx, a.Scheme, r.log, instance, pdb)
+	}
+	return a.removeStalePodDisruptionBudget(r, pdb)
+}
+
+func (a *addPdb) removeStalePodDisruptionBudget(r *reconcileRound, pdb *policyv1.PodDisruptionBudget) error {
+	err := a.Client.Delete(r.ctx, pdb)
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+func generateCorePodDisruptionBudget(instance *crdv2.EMQX) *policyv1.PodDisruptionBudget {
+	template := instance.Spec.CoreTemplate
+	return newPodDisruptionBudget(
+		instance,
+		instance.CoreNamespacedName().Name,
+		instance.DefaultLabelsWith(crdv2.CoreLabels(), template.Labels),
+		template.Spec.MinAvailable,
+		template.Spec.MaxUnavailable,
+	)
+}
+
+func generateReplicantPodDisruptionBudget(instance *crdv2.EMQX) *policyv1.PodDisruptionBudget {
+	template := ptr.Deref(instance.Spec.ReplicantTemplate, crdv2.EMQXReplicantTemplate{})
+	return newPodDisruptionBudget(
+		instance,
+		instance.ReplicantNamespacedName().Name,
+		instance.DefaultLabelsWith(crdv2.ReplicantLabels(), template.Labels),
+		template.Spec.MinAvailable,
+		template.Spec.MaxUnavailable,
+	)
+}
+
+func newPodDisruptionBudget(
+	instance *crdv2.EMQX,
+	name string,
+	selector map[string]string,
+	minAvailable,
+	maxUnavailable *intstr.IntOrString,
+) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "policy/v1",
 			Kind:       "PodDisruptionBudget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: instance.Namespace,
-			Name:      instance.CoreNamespacedName().Name,
+			Name:      name,
 			Labels:    instance.DefaultLabelsWith(instance.Labels),
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: instance.DefaultLabelsWith(crdv2.CoreLabels(), instance.Spec.CoreTemplate.Labels),
+				MatchLabels: selector,
 			},
-			MinAvailable:   instance.Spec.CoreTemplate.Spec.MinAvailable,
-			MaxUnavailable: instance.Spec.CoreTemplate.Spec.MaxUnavailable,
+			MinAvailable:   minAvailable,
+			MaxUnavailable: maxUnavailable,
 		},
 	}
-
-	if instance.Spec.HasReplicants() {
-		replPdb := corePdb.DeepCopy()
-		replPdb.Name = instance.ReplicantNamespacedName().Name
-		replPdb.Spec.Selector.MatchLabels = instance.DefaultLabelsWith(
-			crdv2.ReplicantLabels(),
-			instance.Spec.ReplicantTemplate.Labels,
-		)
-		replPdb.Spec.MinAvailable = instance.Spec.ReplicantTemplate.Spec.MinAvailable
-		replPdb.Spec.MaxUnavailable = instance.Spec.ReplicantTemplate.Spec.MaxUnavailable
-		return corePdb, replPdb
-	}
-	return corePdb, nil
-}
-
-func generatePodDisruptionBudgetV1beta1(instance *crdv2.EMQX) (*policyv1beta1.PodDisruptionBudget, *policyv1beta1.PodDisruptionBudget) {
-	corePdb := &policyv1beta1.PodDisruptionBudget{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "policy/v1",
-			Kind:       "PodDisruptionBudget",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: instance.Namespace,
-			Name:      instance.CoreNamespacedName().Name,
-			Labels:    instance.DefaultLabelsWith(instance.Labels),
-		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: instance.DefaultLabelsWith(crdv2.CoreLabels(), instance.Spec.CoreTemplate.Labels),
-			},
-			MinAvailable:   instance.Spec.CoreTemplate.Spec.MinAvailable,
-			MaxUnavailable: instance.Spec.CoreTemplate.Spec.MaxUnavailable,
-		},
-	}
-	if instance.Spec.HasReplicants() {
-		replPdb := corePdb.DeepCopy()
-		replPdb.Name = instance.ReplicantNamespacedName().Name
-		replPdb.Spec.Selector.MatchLabels = instance.DefaultLabelsWith(
-			crdv2.ReplicantLabels(),
-			instance.Spec.ReplicantTemplate.Labels,
-		)
-		replPdb.Spec.MinAvailable = instance.Spec.ReplicantTemplate.Spec.MinAvailable
-		replPdb.Spec.MaxUnavailable = instance.Spec.ReplicantTemplate.Spec.MaxUnavailable
-		return corePdb, replPdb
-	}
-	return corePdb, nil
 }

--- a/internal/controller/add_pdb_suite_test.go
+++ b/internal/controller/add_pdb_suite_test.go
@@ -1,0 +1,95 @@
+package controller
+
+import (
+	crdv2 "github.com/emqx/emqx-operator/api/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Reconciler addPdb", Ordered, func() {
+	var ns *corev1.Namespace
+	var instance *crdv2.EMQX
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "controller-v2-add-pdb-test",
+				Labels: map[string]string{
+					"test": "e2e",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+	})
+
+	BeforeEach(func() {
+		instance = emqx.DeepCopy()
+		instance.Namespace = ns.Name
+		instance.Spec.ReplicantTemplate = &crdv2.EMQXReplicantTemplate{
+			Spec: crdv2.EMQXReplicantTemplateSpec{
+				Replicas: ptr.To(int32(1)),
+			},
+		}
+	})
+
+	It("skips PDBs when minAvailable and maxUnavailable are both nil", func() {
+		a := &addPdb{emqxReconciler}
+
+		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
+			Should(Equal(subResult{}))
+		Consistently(podDisruptionBudgets).WithArguments(instance).
+			WithTimeout(interval * 3).
+			WithPolling(interval).
+			Should(BeEmpty())
+	})
+
+	It("creates and removes PDBs when transitioning from and to both nil", func() {
+		a := &addPdb{emqxReconciler}
+
+		maxUnavailable := intstr.FromInt32(1)
+		minAvailable := intstr.FromString("50%")
+		instance.Spec.CoreTemplate.Spec.MaxUnavailable = &maxUnavailable
+		instance.Spec.ReplicantTemplate.Spec.MinAvailable = &minAvailable
+		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
+			Should(Equal(subResult{}))
+
+		Eventually(podDisruptionBudgets).WithArguments(instance).
+			Should(ConsistOf(
+				And(
+					HaveField("Name", Equal(instance.CoreName())),
+					HaveField("Spec.MaxUnavailable", HaveValue(Equal(maxUnavailable))),
+				),
+				And(
+					HaveField("Name", Equal(instance.ReplicantName())),
+					HaveField("Spec.MinAvailable", HaveValue(Equal(minAvailable))),
+				),
+			))
+
+		instance.Spec.CoreTemplate.Spec.MaxUnavailable = nil
+		instance.Spec.ReplicantTemplate.Spec.MinAvailable = nil
+		Eventually(a.reconcile).WithArguments(newReconcileRound(), instance).
+			Should(Equal(subResult{}))
+
+		Eventually(podDisruptionBudgets).WithArguments(instance).
+			Should(BeEmpty())
+	})
+})
+
+func podDisruptionBudgets(instance *crdv2.EMQX) []policyv1.PodDisruptionBudget {
+	list := &policyv1.PodDisruptionBudgetList{}
+	_ = k8sClient.List(ctx, list,
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels(instance.DefaultLabels()),
+	)
+	return list.Items
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
+	"github.com/onsi/gomega"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 
@@ -89,6 +90,9 @@ func TestControllers(t *testing.T) {
 var _ = BeforeSuite(func() {
 	timeout = time.Second * 10
 	interval = time.Second
+
+	gomega.SetDefaultEventuallyTimeout(timeout)
+	gomega.SetDefaultEventuallyPollingInterval(interval)
 
 	logger = zap.New(
 		zap.WriteTo(GinkgoWriter),


### PR DESCRIPTION
## Summary

This PR fixes the behavior of Operator when PDB budgets in CR templates are undefined, which is the default.

Currently, if budgets are undefined Operator still creates a PDB per workload (core + replicants if enabled) with correspondingly undefined budgets. This is allowed by the PDB controller but essentially non-functional: undefined budgets disallow evictions altogether.

This PR changes the default behavior: if both `minAvailable` and `maxUnavailable` are undefined no PDBs are created.

Fixes #1227.

### Compatibility

No attempt to preserve current behavior is made. Once upgraded, Operator will delete PDBs if respective CR has undefined (default) budgets.