### PR TITLE
chore(api): remove unnecessary / redundant securityContext defaults

### DIFF
--- a/api/v3beta1/emqx_types_spec.go
+++ b/api/v3beta1/emqx_types_spec.go
@@ -249,12 +249,11 @@ type EMQXReplicantTemplateSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/config/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 	// Pod-level security attributes and common container settings.
-	// +kubebuilder:default={runAsUser:1000,runAsGroup:1000,fsGroup:1000,fsGroupChangePolicy:Always,supplementalGroups: {1000}}
+	// +kubebuilder:default={runAsUser:1000,runAsGroup:1000,runAsNonRoot:true,fsGroup:1000,fsGroupChangePolicy:Always}
 	PodSecurityContext *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	// Security options the container should be run with.
 	// If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-	// +kubebuilder:default={runAsUser:1000,runAsGroup:1000,runAsNonRoot:true}
 	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
 	// List of initialization containers belonging to the pod.
 	// Init containers are executed in order prior to containers being started. If any

--- a/config/crd/bases/apps.emqx.io_emqxes.yaml
+++ b/config/crd/bases/apps.emqx.io_emqxes.yaml
@@ -1073,10 +1073,6 @@ spec:
                           type: string
                         type: array
                       containerSecurityContext:
-                        default:
-                          runAsGroup: 1000
-                          runAsNonRoot: true
-                          runAsUser: 1000
                         description: |-
                           Security options the container should be run with.
                           If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
@@ -6829,9 +6825,8 @@ spec:
                           fsGroup: 1000
                           fsGroupChangePolicy: Always
                           runAsGroup: 1000
+                          runAsNonRoot: true
                           runAsUser: 1000
-                          supplementalGroups:
-                          - 1000
                         description: Pod-level security attributes and common container
                           settings.
                         properties:
@@ -9506,10 +9501,6 @@ spec:
                           type: string
                         type: array
                       containerSecurityContext:
-                        default:
-                          runAsGroup: 1000
-                          runAsNonRoot: true
-                          runAsUser: 1000
                         description: |-
                           Security options the container should be run with.
                           If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
@@ -15065,9 +15056,8 @@ spec:
                           fsGroup: 1000
                           fsGroupChangePolicy: Always
                           runAsGroup: 1000
+                          runAsNonRoot: true
                           runAsUser: 1000
-                          supplementalGroups:
-                          - 1000
                         description: Pod-level security attributes and common container
                           settings.
                         properties:


### PR DESCRIPTION
## Summary

This PR revisits few CRD defaults currently associated with core / replicant template pods and containers.

Fixes #1224.