### PR TITLE
feat: allow narrowing controller to several namespaces

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,7 +21,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"flag"
+	"fmt"
 	"os"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -35,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -82,7 +86,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
-	var singleNamespace string
+	var namespaces namespaceList
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -94,14 +98,18 @@ func main() {
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	flag.StringVar(&singleNamespace, "single-namespace", "",
-		"If set, restrict the client cache to this namespace only. Leave unset to watch all namespaces. "+
-			"Set to the respective namespace if manager is running with namespace-scoped RBAC roles.")
+	flag.Var(&namespaces, "watch-namespace",
+		"If set, restrict the controller to this namespace. May be specified multiple times. "+
+			"Set to the respective namespace if manager is running with namespace-scoped RBAC roles. "+
+			"Leave unset to watch all namespaces.")
 	opts := zap.Options{
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	sort.Strings(namespaces)
+	namespaces = slices.Compact(namespaces)
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -146,8 +154,6 @@ func main() {
 		// this setup is not recommended for production.
 	}
 
-	singleNamespace = strings.TrimSpace(singleNamespace)
-
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
@@ -168,7 +174,7 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 
 		Cache: cache.Options{
-			DefaultNamespaces: defaultNamespacesForCache(singleNamespace),
+			DefaultNamespaces: watchedNamespacesCache(namespaces),
 		},
 	})
 	if err != nil {
@@ -187,8 +193,8 @@ func main() {
 	err = wait.PollUntilContextTimeout(context.Background(), time.Second, time.Minute, true,
 		func(ctx context.Context) (bool, error) {
 			ns := "default"
-			if singleNamespace != "" {
-				ns = singleNamespace
+			if len(namespaces) > 0 {
+				ns = namespaces[0]
 			}
 			// To keep manager RBAC slimmer, try to get randomly named CR of respective kind.
 			crdName := types.NamespacedName{Name: "foobar", Namespace: ns}
@@ -233,11 +239,43 @@ func bailOut(err error, msg string, keysAndValues ...any) {
 	os.Exit(1)
 }
 
-// defaultNamespacesForCache maps controller-runtime's cache to one namespace when
-// --single-namespace is set, so list/watch requests stay namespaced (cluster Role is not required).
-func defaultNamespacesForCache(singleNamespace string) map[string]cache.Config {
-	if singleNamespace != "" {
-		return map[string]cache.Config{singleNamespace: {}}
+type namespaceList []string
+
+func (n *namespaceList) String() string {
+	if n == nil {
+		return ""
+	}
+	return strings.Join(*n, ",")
+}
+
+func (n *namespaceList) Set(value string) error {
+	namespace := strings.TrimSpace(value)
+	if namespace == "" {
+		return errors.New("must be non-empty")
+	}
+	if err := validateNamespace(namespace); err != nil {
+		return err
+	}
+	*n = append(*n, namespace)
+	return nil
+}
+
+func validateNamespace(namespace string) error {
+	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+// watchedNamespacesCache maps controller-runtime's cache to specific namespaces,
+// so list/watch requests stay namespaced when namespace-scoped RBAC is used.
+func watchedNamespacesCache(namespaces []string) map[string]cache.Config {
+	if len(namespaces) == 0 {
+		return nil
+	}
+	defaultNamespaces := make(map[string]cache.Config, len(namespaces))
+	for _, namespace := range namespaces {
+		defaultNamespaces[namespace] = cache.Config{}
+	}
+	return defaultNamespaces
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,7 +65,6 @@ func init() {
 
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - persistentvolumes
   - secrets
   - services
   verbs:

--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -1,29 +1,9 @@
-{{- if .Values.serviceAccount.create -}}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "emqx-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "emqx-operator.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
-kind: Role
-metadata:
-  name: {{ include "emqx-operator.fullname" . }}-manager-role
-  namespace: {{ .Release.Namespace }}
-{{- else }}
-kind: ClusterRole
-metadata:
-  name: {{ include "emqx-operator.fullname" . }}-manager-role
-{{- end }}
-  labels:
-    {{- include "emqx-operator.labels" . | nindent 4 }}
+{{- $watchNamespaces := default (list) .Values.watchNamespaces -}}
+{{- if .Values.singleNamespace -}}
+{{- $watchNamespaces = append $watchNamespaces .Release.Namespace -}}
+{{- end -}}
+{{- $watchNamespaces = $watchNamespaces | uniq -}}
+{{- define "emqx-operator.managerRules" }}
 rules:
 - apiGroups:
   - ""
@@ -136,30 +116,70 @@ rules:
   - list
   - update
   - watch
+{{- end }}
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "emqx-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "emqx-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if gt (len $watchNamespaces) 0 }}
+{{- range $namespace := $watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-{{- if .Values.singleNamespace }}
+kind: Role
+metadata:
+  name: {{ include "emqx-operator.fullname" $ }}-manager-role
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "emqx-operator.labels" $ | nindent 4 }}
+{{ include "emqx-operator.managerRules" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "emqx-operator.fullname" . }}-manager-rolebinding
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "emqx-operator.fullname" $ }}-manager-rolebinding
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "emqx-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "emqx-operator.fullname" $ }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "emqx-operator.serviceAccountName" $ }}
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- else }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-manager-role
+  labels:
+    {{- include "emqx-operator.labels" . | nindent 4 }}
+{{ include "emqx-operator.managerRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "emqx-operator.fullname" . }}-manager-rolebinding
-{{- end }}
   labels:
     {{- include "emqx-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  {{- if .Values.singleNamespace }}
-  kind: Role
-  {{- else }}
   kind: ClusterRole
-  {{- end }}
   name: {{ include "emqx-operator.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "emqx-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -29,7 +29,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - persistentvolumes
   - secrets
   - services
   verbs:

--- a/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager-rbac.yaml
@@ -1,7 +1,4 @@
 {{- $watchNamespaces := default (list) .Values.watchNamespaces -}}
-{{- if .Values.singleNamespace -}}
-{{- $watchNamespaces = append $watchNamespaces .Release.Namespace -}}
-{{- end -}}
 {{- $watchNamespaces = $watchNamespaces | uniq -}}
 {{- define "emqx-operator.managerRules" }}
 rules:

--- a/deploy/charts/emqx-operator/templates/controller-manager.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager.yaml
@@ -1,3 +1,8 @@
+{{- $watchNamespaces := default (list) .Values.watchNamespaces -}}
+{{- if .Values.singleNamespace -}}
+{{- $watchNamespaces = append $watchNamespaces .Release.Namespace -}}
+{{- end -}}
+{{- $watchNamespaces = $watchNamespaces | uniq -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,8 +40,10 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --zap-devel={{ .Values.development }}
-        {{- if .Values.singleNamespace }}
-        - --single-namespace={{ .Release.Namespace }}
+        {{- if gt (len $watchNamespaces) 0 }}
+        {{- range $namespace := $watchNamespaces }}
+        - --watch-namespace={{ $namespace }}
+        {{- end }}
         {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deploy/charts/emqx-operator/templates/controller-manager.yaml
+++ b/deploy/charts/emqx-operator/templates/controller-manager.yaml
@@ -1,7 +1,4 @@
 {{- $watchNamespaces := default (list) .Values.watchNamespaces -}}
-{{- if .Values.singleNamespace -}}
-{{- $watchNamespaces = append $watchNamespaces .Release.Namespace -}}
-{{- end -}}
 {{- $watchNamespaces = $watchNamespaces | uniq -}}
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/charts/emqx-operator/values.yaml
+++ b/deploy/charts/emqx-operator/values.yaml
@@ -5,14 +5,8 @@
 # If true, CRDs will not be installed.
 skipCRDs: false
 
-# If true, the operator watches only the namespace where it is deployed.
-# If false, the operator watches all namespaces.
-# If watchNamespaces is also set, the operator watches both those and its
-# own and namespace.
-singleNamespace: false
-
-# Namespaces the operator watches. Leave empty for cluster-wide watch unless
-# singleNamespace is true.
+# Namespaces the operator watches. Leave empty for cluster-wide watch.
+# To watch only the release namespace, set this to the release namespace.
 watchNamespaces: []
 
 # Development configures the logger to use a Zap development config

--- a/deploy/charts/emqx-operator/values.yaml
+++ b/deploy/charts/emqx-operator/values.yaml
@@ -7,7 +7,13 @@ skipCRDs: false
 
 # If true, the operator watches only the namespace where it is deployed.
 # If false, the operator watches all namespaces.
+# If watchNamespaces is also set, the operator watches both those and its
+# own and namespace.
 singleNamespace: false
+
+# Namespaces the operator watches. Leave empty for cluster-wide watch unless
+# singleNamespace is true.
+watchNamespaces: []
 
 # Development configures the logger to use a Zap development config
 # (stacktraces on warnings, no sampling), otherwise a Zap production

--- a/test/e2e-helm/helm_install_test.go
+++ b/test/e2e-helm/helm_install_test.go
@@ -116,10 +116,10 @@ var _ = Describe("Helm Install", Ordered, func() {
 		))
 	})
 
-	It("should install cleanly / single namespace", func() {
-		By("install 3.x chart with singleNamespace=true")
+	It("should install cleanly / one watch namespace", func() {
+		By("install 3.x chart with one watch namespace")
 		Expect(helmInstall(namespace,
-			"--set", "singleNamespace=true",
+			"--set-json", `watchNamespaces=["emqx-operator-fresh"]`,
 		)).To(Succeed())
 
 		By("verify CRDs are installed")
@@ -139,6 +139,67 @@ var _ = Describe("Helm Install", Ordered, func() {
 		Expect(Kubectl("get", "role", "emqx-operator-manager-role",
 			"-n", namespace)).To(Succeed())
 		Expect(Kubectl("get", "clusterrole", "emqx-operator-manager-role")).NotTo(Succeed())
+
+		By("verify operator logs do not show errors")
+		Consistently(KubectlOut, "30s", "5s").
+			WithArguments("logs", "-n", namespace,
+				"deployment/emqx-operator-controller-manager", "--tail=50",
+			).ShouldNot(Or(
+			ContainSubstring("ERROR"),
+			ContainSubstring("Error"),
+		))
+	})
+
+	It("should install cleanly / several watch namespaces", func() {
+		watchNamespaces := []string{
+			"emqx-operator-watch-a",
+			"emqx-operator-watch-b",
+		}
+		DeferCleanup(func() {
+			for _, ns := range watchNamespaces {
+				_ = Kubectl("delete", "ns", ns, "--ignore-not-found")
+			}
+		})
+
+		By("create watched namespaces")
+		for _, ns := range watchNamespaces {
+			_ = Kubectl("delete", "ns", ns, "--ignore-not-found")
+			Expect(Kubectl("create", "ns", ns)).To(Succeed())
+		}
+
+		By("install 3.x chart with watchNamespaces")
+		Expect(helmInstall(namespace,
+			"--set-json", `watchNamespaces=["emqx-operator-fresh","emqx-operator-watch-a","emqx-operator-watch-b"]`,
+		)).To(Succeed())
+
+		By("verify operator deployment is available")
+		Expect(Kubectl("wait", "deployment",
+			"emqx-operator-controller-manager",
+			"--for", "condition=Available",
+			"--namespace", namespace,
+			"--timeout", "1m",
+		)).To(Succeed())
+
+		By("verify CRDs are installed")
+		Expect(crdExists("emqxes.apps.emqx.io")).To(BeTrue())
+		// NOTE: Rebalance controller is disabled in this release. See api/v2beta1/rebalance_types.go.
+		// Expect(crdExists("rebalances.apps.emqx.io")).To(BeTrue())
+
+		By("verify no ClusterRoles exists for the manager")
+		Expect(resourceExists("clusterrole", "emqx-operator-manager-role")).To(BeFalse())
+		Expect(resourceExists("clusterrolebinding", "emqx-operator-manager-rolebinding")).To(BeFalse())
+
+		By("verify effective watch namespaces have manager RBAC")
+		Expect(Kubectl("get", "role", "emqx-operator-manager-role",
+			"-n", namespace)).To(Succeed())
+		Expect(Kubectl("get", "rolebinding", "emqx-operator-manager-rolebinding",
+			"-n", namespace)).To(Succeed())
+		for _, ns := range watchNamespaces {
+			Expect(Kubectl("get", "role", "emqx-operator-manager-role",
+				"-n", ns)).To(Succeed())
+			Expect(Kubectl("get", "rolebinding", "emqx-operator-manager-rolebinding",
+				"-n", ns)).To(Succeed())
+		}
 
 		By("verify operator logs do not show errors")
 		Consistently(KubectlOut, "30s", "5s").

--- a/test/e2e-helm/helm_suite_test.go
+++ b/test/e2e-helm/helm_suite_test.go
@@ -71,6 +71,10 @@ func crdExists(name string) bool {
 	return Kubectl("get", "crd", name) == nil
 }
 
+func resourceExists(kind, name string) bool {
+	return Kubectl("get", kind, name) == nil
+}
+
 // dumpHelmDiagnostics writes debug info for the given namespace to GinkgoWriter.
 func dumpHelmDiagnostics(namespace string) {
 	out, _ := Output("helm", "list", "--namespace", namespace)


### PR DESCRIPTION
## Summary

This PR introduces a command line flag and a Helm Chart value to allow users to configure controller to watch several specified namespaces, instead of either all of them or just the one operator is deployed into. When configured through Helm Chart, a set of role bindings are created automatically per configured namespace.

Port of #1219.
