### PR TITLE
fix: track replicants in CR status until empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
           retention-days: 1
 
   test-e2e-helm:
-    name: E2E Helm Upgrade Tests
+    name: E2E Helm Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
   test-e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    env:
+      TEST_E2E_DIAGNOSTIC_REPORT_PATH: ${{ github.workspace }}/test-report
     steps:
       - uses: actions/checkout@v6
 
@@ -45,6 +47,13 @@ jobs:
       - run: go mod tidy
 
       - run: make test-e2e
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: test-report-e2e
+          path: ${{ env.TEST_E2E_DIAGNOSTIC_REPORT_PATH }}
+          if-no-files-found: ignore
 
       - run: go tool covdata textfmt -i /tmp/kind/data/emqx-operator-system/test-e2e-coverage -o ${{ github.workspace }}/cover.e2e.out
 

--- a/api/v3beta1/const.go
+++ b/api/v3beta1/const.go
@@ -21,10 +21,15 @@ import corev1 "k8s.io/api/core/v1"
 const DefaultContainerName string = "emqx"
 
 const (
+	RoleCore      string = "core"
+	RoleReplicant string = "replicant"
+)
+
+const (
 	// labels
 	LabelInstance        string = "apps.emqx.io/instance"   // my-emqx
 	LabelManagedBy       string = "apps.emqx.io/managed-by" // emqx-operator
-	LabelDBRole          string = "apps.emqx.io/db-role"    // core, replicant
+	LabelMriaRole        string = "apps.emqx.io/db-role"    // core, replicant
 	LabelPodTemplateHash string = "apps.emqx.io/pod-template-hash"
 
 	// LabelForceRetirement is a label intended for users to force Operator to

--- a/api/v3beta1/emqx_types_spec.go
+++ b/api/v3beta1/emqx_types_spec.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 // EMQXSpec defines the desired state of EMQX.
@@ -309,7 +310,7 @@ type ServiceTemplate struct {
 }
 
 func (spec *EMQXSpec) HasReplicants() bool {
-	return spec.ReplicantTemplate != nil && spec.ReplicantTemplate.Spec.Replicas != nil && *spec.ReplicantTemplate.Spec.Replicas > 0
+	return spec.ReplicantTemplate != nil && ptr.Deref(spec.ReplicantTemplate.Spec.Replicas, 1) > 0
 }
 
 func (spec *EMQXSpec) IsEvacuationEnabled() bool {

--- a/api/v3beta1/emqx_types_status.go
+++ b/api/v3beta1/emqx_types_status.go
@@ -154,8 +154,8 @@ func (s EMQXStatus) FindNodeByPodName(pod string, roles ...string) *EMQXNode {
 		scanReplicants = true
 	} else {
 		for _, r := range roles {
-			scanCores = scanCores || r == "core"
-			scanReplicants = scanReplicants || r == "replicant"
+			scanCores = scanCores || r == RoleCore
+			scanReplicants = scanReplicants || r == RoleReplicant
 		}
 	}
 	if scanCores {

--- a/api/v3beta1/labels.go
+++ b/api/v3beta1/labels.go
@@ -36,9 +36,9 @@ func (instance *EMQX) DefaultLabelsWith(extraLabels ...map[string]string) map[st
 }
 
 func CoreLabels() map[string]string {
-	return map[string]string{LabelDBRole: "core"}
+	return map[string]string{LabelMriaRole: RoleCore}
 }
 
 func ReplicantLabels() map[string]string {
-	return map[string]string{LabelDBRole: "replicant"}
+	return map[string]string{LabelMriaRole: RoleReplicant}
 }

--- a/internal/controller/add_core_set.go
+++ b/internal/controller/add_core_set.go
@@ -190,7 +190,7 @@ func generateStatefulSet(instance *crd.EMQX) *appsv1.StatefulSet {
 								},
 								{
 									Name:  "EMQX_NODE__ROLE",
-									Value: roleCore,
+									Value: crd.RoleCore,
 								},
 								cookie.EnvVar(),
 								bootstrapAPIKeys.EnvVar(),

--- a/internal/controller/add_core_set_test.go
+++ b/internal/controller/add_core_set_test.go
@@ -49,7 +49,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		assert.Equal(t, "core-label-value", got.Labels["core-label-key"])
 		assert.Equal(t, "emqx", got.Labels[crd.LabelInstance])
 		assert.Equal(t, "emqx-operator", got.Labels[crd.LabelManagedBy])
-		assert.Equal(t, "core", got.Labels[crd.LabelDBRole])
+		assert.Equal(t, "core", got.Labels[crd.LabelMriaRole])
 		// Single StatefulSet: name is deterministic, no hash suffix.
 		assert.Equal(t, "emqx-core", got.Name)
 		assert.Equal(t, emqx.Namespace, got.Namespace)
@@ -63,14 +63,14 @@ func TestGetNewStatefulSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crd.LabelInstance:  "emqx",
 			crd.LabelManagedBy: "emqx-operator",
-			crd.LabelDBRole:    "core",
+			crd.LabelMriaRole:  "core",
 			"core-label-key":   "core-label-value",
 		}, got.Spec.Template.Labels)
 
 		assert.EqualValues(t, map[string]string{
 			crd.LabelInstance:  "emqx",
 			crd.LabelManagedBy: "emqx-operator",
-			crd.LabelDBRole:    "core",
+			crd.LabelMriaRole:  "core",
 		}, got.Spec.Selector.MatchLabels)
 	})
 
@@ -177,7 +177,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 					Name:      "emqx-core-data",
 					Namespace: "emqx",
 					Labels: map[string]string{
-						crd.LabelDBRole:    "core",
+						crd.LabelMriaRole:  "core",
 						crd.LabelInstance:  "emqx",
 						crd.LabelManagedBy: "emqx-operator",
 					},
@@ -224,7 +224,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 					Name:      "emqx-core-data",
 					Namespace: "emqx",
 					Labels: map[string]string{
-						crd.LabelDBRole:    "core",
+						crd.LabelMriaRole:  "core",
 						crd.LabelInstance:  "emqx",
 						crd.LabelManagedBy: "emqx-operator",
 					},

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -243,7 +243,7 @@ func generateReplicaSet(instance *crd.EMQX) *appsv1.ReplicaSet {
 								},
 								{
 									Name:  "EMQX_NODE__ROLE",
-									Value: roleReplicant,
+									Value: crd.RoleReplicant,
 								},
 								cookie.EnvVar(),
 							}, template.Spec.Env...),

--- a/internal/controller/add_replicant_set.go
+++ b/internal/controller/add_replicant_set.go
@@ -25,7 +25,7 @@ type addReplicantSet struct {
 
 func (a *addReplicantSet) reconcile(r *reconcileRound, instance *crd.EMQX) subResult {
 	// Cluster w/o replicants, skip this step.
-	if instance.Spec.ReplicantTemplate == nil {
+	if !instance.Spec.HasReplicants() {
 		return subResult{}
 	}
 

--- a/internal/controller/add_replicant_set_suite_test.go
+++ b/internal/controller/add_replicant_set_suite_test.go
@@ -186,21 +186,16 @@ var _ = DescribeClientFaultMatrix("Reconciler addReplicantSet", Ordered, func() 
 			))
 		})
 
-		It("should scale down replicaSet", func() {
+		It("should do nothing", func() {
 			// Set replicas count to 0:
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 			// Reconciliation step should succeed:
 			Eventually(a.reconcile).WithArguments(round, instance).
 				Should(BeSuccessfulReconcile())
-			// Status conditions should reset:
-			Expect(actualObject(instance)).To(And(
-				HaveCondition(crd.Ready, HaveField("Status", Equal(metav1.ConditionFalse))),
-				HaveCondition(crd.ReplicantNodesProgressing, HaveField("Status", Equal(metav1.ConditionTrue))),
-			))
-			// ReplicaSet should be updated in place:
+			// ReplicaSet scaling is handled by syncReplicantSets:
 			Expect(replicantSets(instance)).To(ConsistOf(
-				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(3))),
 			))
 		})
 

--- a/internal/controller/add_replicant_set_test.go
+++ b/internal/controller/add_replicant_set_test.go
@@ -54,7 +54,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		assert.Equal(t, "repl-label-value", got.Labels["repl-label-key"])
 		assert.Equal(t, "emqx", got.Labels[crd.LabelInstance])
 		assert.Equal(t, "emqx-operator", got.Labels[crd.LabelManagedBy])
-		assert.Equal(t, "replicant", got.Labels[crd.LabelDBRole])
+		assert.Equal(t, "replicant", got.Labels[crd.LabelMriaRole])
 		assert.Equal(t, "emqx-replicant-"+got.Labels[crd.LabelPodTemplateHash], got.Name)
 		assert.Equal(t, emqx.Namespace, got.Namespace)
 		assert.EqualValues(t, int32(0), got.Spec.MinReadySeconds)
@@ -69,7 +69,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crd.LabelInstance:        "emqx",
 			crd.LabelManagedBy:       "emqx-operator",
-			crd.LabelDBRole:          "replicant",
+			crd.LabelMriaRole:        "replicant",
 			crd.LabelPodTemplateHash: got.Labels[crd.LabelPodTemplateHash],
 			"repl-label-key":         "repl-label-value",
 		}, got.Spec.Template.Labels)
@@ -77,7 +77,7 @@ func TestGetNewReplicaSet(t *testing.T) {
 		assert.EqualValues(t, map[string]string{
 			crd.LabelInstance:        "emqx",
 			crd.LabelManagedBy:       "emqx-operator",
-			crd.LabelDBRole:          "replicant",
+			crd.LabelMriaRole:        "replicant",
 			crd.LabelPodTemplateHash: got.Labels[crd.LabelPodTemplateHash],
 			"repl-label-key":         "repl-label-value",
 		}, got.Spec.Selector.MatchLabels)

--- a/internal/controller/add_service_test.go
+++ b/internal/controller/add_service_test.go
@@ -80,7 +80,7 @@ func TestGenerateDashboardService(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			crd.LabelInstance:  "emqx",
 			crd.LabelManagedBy: "emqx-operator",
-			crd.LabelDBRole:    "core",
+			crd.LabelMriaRole:  "core",
 		}, got.Spec.Selector)
 	})
 
@@ -208,7 +208,7 @@ func TestGenerateListenersService(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			crd.LabelInstance:  "emqx",
 			crd.LabelManagedBy: "emqx-operator",
-			crd.LabelDBRole:    "core",
+			crd.LabelMriaRole:  "core",
 		}, got.Spec.Selector)
 	})
 

--- a/internal/controller/api_requester.go
+++ b/internal/controller/api_requester.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	emperror "emperror.dev/errors"
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	config "github.com/emqx/emqx-operator/internal/controller/config"
 	resources "github.com/emqx/emqx-operator/internal/controller/resources"
 	req "github.com/emqx/emqx-operator/internal/requester"
@@ -28,7 +29,7 @@ func (b *apiRequesterBuilder) forOldestCore(
 	state *reconcileState,
 	filter ...reconcileStatePodFilter,
 ) req.RequesterInterface {
-	pods := state.listPods(podsWithRole{roleCore})
+	pods := state.listPods(podsWithRole{crd.RoleCore})
 	sortByCreationTimestamp(pods)
 outer:
 	for _, pod := range pods {

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	k8s "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -163,6 +164,20 @@ func (r *reconcileState) updateReplicantSet(instance *crd.EMQX) *appsv1.ReplicaS
 		}
 	}
 	return nil
+}
+
+func (r *reconcileState) hasReplicants() bool {
+	for _, rs := range r.replicantSets {
+		if rs.Status.Replicas > 0 || ptr.Deref(rs.Spec.Replicas, 1) > 0 {
+			return true
+		}
+	}
+	for _, pod := range r.pods {
+		if pod.Labels[crd.LabelMriaRole] == crd.RoleReplicant {
+			return true
+		}
+	}
+	return false
 }
 
 // outdatedReplicantReplicaSets returns all replicant ReplicaSets except the update revision set,

--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -14,11 +14,6 @@ import (
 	k8s "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	roleCore      = "core"
-	roleReplicant = "replicant"
-)
-
 type reconcileState struct {
 	coreSets      []*appsv1.StatefulSet
 	replicantSets []*appsv1.ReplicaSet
@@ -45,7 +40,7 @@ type podsWithRole struct {
 }
 
 func (filter podsWithRole) passes(pod *corev1.Pod) bool {
-	return pod.Labels[crd.LabelDBRole] == filter.string
+	return pod.Labels[crd.LabelMriaRole] == filter.string
 }
 
 type podsAlive struct{}

--- a/internal/controller/retire_core_pods.go
+++ b/internal/controller/retire_core_pods.go
@@ -66,7 +66,7 @@ func (*retireCorePods) corePodRetirementReady(r *reconcileRound, instance *crd.E
 		return true, "retirement forced"
 	}
 
-	node := instance.Status.FindNodeByPodName(pod.Name, roleCore)
+	node := instance.Status.FindNodeByPodName(pod.Name, crd.RoleCore)
 	if node != nil {
 		return false, fmt.Sprintf("node %s is still present in cluster status", node.Name)
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -154,7 +154,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	restConfig, err := testEnv.Start()

--- a/internal/controller/sync_core_set.go
+++ b/internal/controller/sync_core_set.go
@@ -216,7 +216,7 @@ func (s *syncCoreSet) updateEvacuationState(r *reconcileRound, instance *crd.EMQ
 			continue
 		}
 		node := instance.Status.FindNode(evacuation.NodeName)
-		if node == nil || node.Role != roleCore || node.PodName == "" {
+		if node == nil || node.Role != crd.RoleCore || node.PodName == "" {
 			continue
 		}
 		pod := r.state.podWithName(node.PodName)
@@ -297,7 +297,7 @@ func checkCorePodRemoval(
 		}
 	}
 
-	nodeInfo := status.FindNodeByPodName(pod.Name, roleCore)
+	nodeInfo := status.FindNodeByPodName(pod.Name, crd.RoleCore)
 
 	if nodeInfo == nil {
 		return admission.remove("node is out of cluster")
@@ -373,7 +373,7 @@ func (s *syncCoreSet) startEvacuation(
 	instance *crd.EMQX,
 	pod *corev1.Pod,
 ) error {
-	nodeInfo := instance.Status.FindNodeByPodName(pod.Name, roleCore)
+	nodeInfo := instance.Status.FindNodeByPodName(pod.Name, crd.RoleCore)
 	if nodeInfo == nil {
 		return emperror.New("no corresponding node in cluster status")
 	}

--- a/internal/controller/sync_core_set_suite_test.go
+++ b/internal/controller/sync_core_set_suite_test.go
@@ -77,7 +77,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 				Labels: map[string]string{
 					crd.LabelInstance:                     "emqx",
 					crd.LabelManagedBy:                    "emqx-operator",
-					crd.LabelDBRole:                       "core",
+					crd.LabelMriaRole:                     "core",
 					appsv1.ControllerRevisionHashLabelKey: currentRevision,
 				},
 				OwnerReferences: ownerReferences(coreSet),

--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -202,7 +202,7 @@ func (s *syncReplicantSets) stopStaleReplicantEvacuation(
 	instance *crd.EMQX,
 	pod *corev1.Pod,
 ) (bool, error) {
-	nodeInfo := instance.Status.FindNodeByPodName(pod.Name, roleReplicant)
+	nodeInfo := instance.Status.FindNodeByPodName(pod.Name, crd.RoleReplicant)
 	if nodeInfo == nil {
 		return false, emperror.Errorf("missing replicant %s node information", pod.Name)
 	}
@@ -459,7 +459,7 @@ func checkReplicantPodRemoval(instance *crd.EMQX, pod *corev1.Pod) replicantAdmi
 		}
 	}
 
-	nodeInfo := status.FindNodeByPodName(pod.Name, roleReplicant)
+	nodeInfo := status.FindNodeByPodName(pod.Name, crd.RoleReplicant)
 	if nodeInfo == nil {
 		return replicantAdmission{Action: admissionRemove, Reason: "node is out of cluster"}
 	}
@@ -494,7 +494,7 @@ func checkReplicantPodRemoval(instance *crd.EMQX, pod *corev1.Pod) replicantAdmi
 
 // startReplicantEvacuation calls the EMQX evacuation API for a replicant pod (side effect only).
 func (s *syncReplicantSets) startEvacuation(r *reconcileRound, instance *crd.EMQX, pod *corev1.Pod) error {
-	nodeInfo := instance.Status.FindNodeByPodName(pod.Name, roleReplicant)
+	nodeInfo := instance.Status.FindNodeByPodName(pod.Name, crd.RoleReplicant)
 	if nodeInfo == nil {
 		return emperror.New("no corresponding replicant node in cluster status")
 	}

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -394,15 +394,15 @@ func (u *updateStatus) updateEMQXNodesStatus(r *reconcileRound, instance *crd.EM
 		}
 		list := &status.CoreNodes
 		host := parseNodeName(n.Node, instance).hostName
-		if node.Role == roleReplicant {
+		if node.Role == crd.RoleReplicant {
 			list = &status.ReplicantNodes
 		}
 		for _, pod := range r.state.pods {
-			if node.Role == roleCore && strings.HasPrefix(host, pod.Name) {
+			if node.Role == crd.RoleCore && strings.HasPrefix(host, pod.Name) {
 				node.PodName = pod.Name
 				break
 			}
-			if node.Role == roleReplicant && host == pod.Status.PodIP {
+			if node.Role == crd.RoleReplicant && host == pod.Status.PodIP {
 				node.PodName = pod.Name
 				break
 			}

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -21,7 +21,7 @@ type updateStatus struct {
 
 func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResult {
 	status := u.inheritStatus(instance)
-	hasReplicants := instance.Spec.HasReplicants()
+	hasReplicants := instance.Spec.HasReplicants() || r.state.hasReplicants()
 
 	// Core: count pods on each revision for rolling update progress.
 	coreSet := r.state.coreSet()
@@ -244,8 +244,7 @@ func evaluateReplicantNodesProgressing(s *reconcileState, instance *crd.EMQX) {
 	cond := crd.ReplicantNodesProgressing
 	status := &instance.Status
 
-	if !instance.Spec.HasReplicants() {
-		status.RemoveCondition(crd.ReplicantNodesProgressing)
+	if !instance.Spec.HasReplicants() && !s.hasReplicants() {
 		return
 	}
 
@@ -329,7 +328,7 @@ func evaluateReady(s *reconcileState, instance *crd.EMQX) {
 		return
 	}
 
-	if instance.Spec.HasReplicants() {
+	if instance.Spec.HasReplicants() || s.hasReplicants() {
 		if !evaluateReplicantsReady(s, instance) {
 			status.SetCondition(crd.Ready, metav1.ConditionFalse,
 				"ReplicantNodesProgressing",

--- a/internal/controller/update_emqx_status.go
+++ b/internal/controller/update_emqx_status.go
@@ -20,14 +20,12 @@ type updateStatus struct {
 }
 
 func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResult {
-	status := &instance.Status
+	status := u.inheritStatus(instance)
+	hasReplicants := instance.Spec.HasReplicants()
 
 	// Core: count pods on each revision for rolling update progress.
 	coreSet := r.state.coreSet()
-	status.CoreReplicas = 0
 	status.CoreSelector = labels.Set(instance.DefaultLabelsWith(crd.CoreLabels())).String()
-	status.CoreNodesStatus.UpdatedReplicas = 0
-	status.CoreNodesStatus.CurrentReplicas = 0
 	if coreSet != nil {
 		status.CoreReplicas = coreSet.Status.Replicas
 		for _, pod := range r.state.podsManagedBy(coreSet) {
@@ -40,21 +38,24 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 		}
 	}
 
-	status.ReplicantReplicas = 0
-	status.ReplicantSelector = ""
-	if instance.Spec.HasReplicants() {
-		status.ReplicantReplicas = r.state.numReplicants()
+	if hasReplicants {
 		status.ReplicantSelector = labels.Set(instance.DefaultLabelsWith(crd.ReplicantLabels())).String()
+		status.ReplicantReplicas = r.state.numReplicants()
 	}
 
 	// Replicant: multi-ReplicaSet pattern retained.
-	currentReplicantSet, updateReplicantSet := switchReplicantSet(r, instance)
+	var currentReplicantSet, updateReplicantSet *appsv1.ReplicaSet
+	if hasReplicants {
+		currentReplicantSet, updateReplicantSet = switchReplicantSet(r, instance)
+	}
 
 	status.ReplicantNodesStatus.ReadyReplicas = 0
 	if currentReplicantSet != nil {
+		status.ReplicantNodesStatus.CurrentRevision = currentReplicantSet.Labels[crd.LabelPodTemplateHash]
 		status.ReplicantNodesStatus.CurrentReplicas = currentReplicantSet.Status.Replicas
 	}
 	if updateReplicantSet != nil {
+		status.ReplicantNodesStatus.UpdateRevision = updateReplicantSet.Labels[crd.LabelPodTemplateHash]
 		status.ReplicantNodesStatus.UpdateReplicas = updateReplicantSet.Status.Replicas
 	}
 
@@ -66,7 +67,14 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 		if err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to get node status")}
 		}
-		u.updateEMQXNodesStatus(r, instance, nodes)
+		emqxNodes := u.getEMQXNodeList(r, instance, nodes)
+		for _, n := range emqxNodes {
+			if n.Role == crd.RoleReplicant {
+				status.ReplicantNodes = append(status.ReplicantNodes, n)
+			} else {
+				status.CoreNodes = append(status.CoreNodes, n)
+			}
+		}
 	}
 
 	status.CoreNodesStatus.ReadyReplicas = 0
@@ -75,16 +83,17 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 			status.CoreNodesStatus.ReadyReplicas++
 		}
 	}
-	for _, node := range status.ReplicantNodes {
-		if node.Status == api.NodeStatusRunning {
-			status.ReplicantNodesStatus.ReadyReplicas++
+	if hasReplicants {
+		for _, node := range status.ReplicantNodes {
+			if node.Status == api.NodeStatusRunning {
+				status.ReplicantNodesStatus.ReadyReplicas++
+			}
 		}
 	}
 
 	if req != nil {
 		clusterEvacuationsStatus, err := api.ClusterEvacuationStatus(req)
 		if err == nil {
-			status.NodeEvacuations = []crd.NodeEvacuationStatus{}
 			for _, ns := range clusterEvacuationsStatus {
 				status.NodeEvacuations = append(status.NodeEvacuations, crd.NodeEvacuationStatus{
 					NodeName:               ns.Node,
@@ -147,12 +156,43 @@ func (u *updateStatus) reconcile(r *reconcileRound, instance *crd.EMQX) subResul
 	}
 
 	// update status condition
+	instance.Status = status
 	evaluateStatusConditions(r.state, instance)
 
 	if err := u.Client.Status().Update(r.ctx, instance); err != nil {
 		return subResult{err: emperror.Wrap(err, "failed to update status")}
 	}
 	return subResult{}
+}
+
+// inheritStatus builds a minimal EMQXStatus with information that has to be
+// preserved across reconcile rounds.
+func (u *updateStatus) inheritStatus(instance *crd.EMQX) crd.EMQXStatus {
+	status := crd.EMQXStatus{
+		Conditions:     u.inheritConditions(instance),
+		CoreNodes:      []crd.EMQXNode{},
+		ReplicantNodes: []crd.EMQXNode{},
+	}
+	if instance.Spec.HasReplicants() {
+		status.ReplicantNodesStatus = crd.ReplicantNodesStatus{
+			CollisionCount: instance.Status.ReplicantNodesStatus.CollisionCount,
+		}
+	}
+	return status
+}
+
+func (*updateStatus) inheritConditions(instance *crd.EMQX) []metav1.Condition {
+	if instance.Spec.HasReplicants() {
+		return append([]metav1.Condition(nil), instance.Status.Conditions...)
+	}
+	next := make([]metav1.Condition, 0, len(instance.Status.Conditions))
+	for _, condition := range instance.Status.Conditions {
+		if condition.Type == crd.ReplicantNodesProgressing {
+			continue
+		}
+		next = append(next, condition)
+	}
+	return next
 }
 
 // evaluateStatusConditions evaluates all conditions independently from current state.
@@ -363,16 +403,11 @@ func switchReplicantSet(
 			current = update
 		}
 	}
-	if current != nil {
-		instance.Status.ReplicantNodesStatus.CurrentRevision = current.Labels[crd.LabelPodTemplateHash]
-	}
 	return current, update
 }
 
-func (u *updateStatus) updateEMQXNodesStatus(r *reconcileRound, instance *crd.EMQX, nodes []api.EMQXNode) {
-	status := &instance.Status
-	status.CoreNodes = []crd.EMQXNode{}
-	status.ReplicantNodes = []crd.EMQXNode{}
+func (u *updateStatus) getEMQXNodeList(r *reconcileRound, instance *crd.EMQX, nodes []api.EMQXNode) []crd.EMQXNode {
+	list := make([]crd.EMQXNode, 0, len(nodes))
 	slices.SortFunc(nodes, func(a, b api.EMQXNode) int {
 		// Use seconds granularity to avoid jitter in ordering
 		asec := a.Uptime / 1000
@@ -392,11 +427,7 @@ func (u *updateStatus) updateEMQXNodesStatus(r *reconcileRound, instance *crd.EM
 			Sessions:    n.Connections,
 			Connections: n.LiveConnections,
 		}
-		list := &status.CoreNodes
 		host := parseNodeName(n.Node, instance).hostName
-		if node.Role == crd.RoleReplicant {
-			list = &status.ReplicantNodes
-		}
 		for _, pod := range r.state.pods {
 			if node.Role == crd.RoleCore && strings.HasPrefix(host, pod.Name) {
 				node.PodName = pod.Name
@@ -407,6 +438,7 @@ func (u *updateStatus) updateEMQXNodesStatus(r *reconcileRound, instance *crd.EM
 				break
 			}
 		}
-		*list = append(*list, node)
+		list = append(list, node)
 	}
+	return list
 }

--- a/test/e2e/assert.go
+++ b/test/e2e/assert.go
@@ -23,6 +23,19 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+var (
+	emqxLabels = labels.Set(map[string]string{
+		crd.LabelInstance:  "emqx",
+		crd.LabelManagedBy: "emqx-operator",
+	})
+	emqxReplicantLabels = labels.Set(map[string]string{
+		crd.LabelInstance:  "emqx",
+		crd.LabelManagedBy: "emqx-operator",
+		crd.LabelMriaRole:  "replicant",
+	})
 )
 
 func EMQXReady(g Gomega, afterTime ...metav1.Time) {
@@ -63,7 +76,7 @@ func CoresStable(g Gomega, coreReplicas int) {
 	)
 
 	g.Expect(KubectlOut("get", "pod",
-		"--selector", "apps.emqx.io/instance=emqx,apps.emqx.io/managed-by=emqx-operator",
+		"--selector", emqxLabels.String(),
 		"-o", "json",
 	)).To(
 		BeUnmarshalledAs(&corev1.PodList{}, HaveField("Items",
@@ -96,6 +109,12 @@ func NoReplicants(g Gomega) {
 	g.Expect(KubectlOut("get", "emqx", "emqx",
 		"-o", "jsonpath={.status.replicantNodes}",
 	)).To(BeEmpty(), "EMQX cluster status lists replicant nodes")
+	g.Expect(KubectlOut("get", "pods",
+		"--selector", emqxReplicantLabels.String(),
+		"-o", "json",
+	)).To(BeUnmarshalledAs(&corev1.PodList{},
+		HaveField("Items", BeEmpty()),
+	))
 }
 
 func ReplicantsStable(g Gomega, replicantReplicas int) {

--- a/test/e2e/assert.go
+++ b/test/e2e/assert.go
@@ -78,7 +78,7 @@ func CoresStable(g Gomega, coreReplicas int) {
 	)
 
 	g.Expect(KubectlOut("get", "pvc",
-		"--selector", crd.LabelDBRole+"=core,"+crd.LabelManagedBy+"=emqx-operator",
+		"--selector", crd.LabelMriaRole+"=core,"+crd.LabelManagedBy+"=emqx-operator",
 		"-o", "json",
 	)).To(
 		BeUnmarshalledAs(&corev1.PersistentVolumeClaimList{}, HaveField("Items", And(

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -145,7 +145,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			By("fetch core StatefulSet")
 			var stsListBefore appsv1.StatefulSetList
 			Expect(KubectlOut("get", "statefulset",
-				"--selector", crd.LabelDBRole+"=core",
+				"--selector", crd.LabelMriaRole+"="+crd.RoleCore,
 				"-o", "json",
 			)).To(UnmarshalInto(&stsListBefore))
 			Expect(stsListBefore.Items).To(HaveLen(1), "More than one core StatefulSet")
@@ -170,7 +170,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			By("verify exactly one core StatefulSet was updated")
 			var stsList appsv1.StatefulSetList
 			Expect(KubectlOut("get", "statefulset",
-				"--selector", crd.LabelDBRole+"=core",
+				"--selector", crd.LabelMriaRole+"="+crd.RoleCore,
 				"-o", "json",
 			)).To(UnmarshalInto(&stsList))
 
@@ -386,7 +386,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			By("fetch core StatefulSet")
 			var stsListBefore appsv1.StatefulSetList
 			Expect(KubectlOut("get", "statefulset",
-				"--selector", crd.LabelDBRole+"=core",
+				"--selector", crd.LabelMriaRole+"="+crd.RoleCore,
 				"-o", "json",
 			)).To(UnmarshalInto(&stsListBefore))
 			Expect(stsListBefore.Items).To(HaveLen(1), "More than one core StatefulSet")
@@ -421,7 +421,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			By("verify exactly one core StatefulSet was updated")
 			var stsList appsv1.StatefulSetList
 			Expect(KubectlOut("get", "statefulset",
-				"--selector", crd.LabelDBRole+"=core",
+				"--selector", crd.LabelMriaRole+"="+crd.RoleCore,
 				"-o", "json",
 			)).To(UnmarshalInto(&stsList))
 
@@ -477,13 +477,13 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)).To(UnmarshalInto(&pods), "Failed to list EMQX pods")
 			Expect(pods.Items).To(HaveLen(4), "EMQX cluster does not have 4 pods")
 			for _, pod := range pods.Items {
-				if pod.Labels[crd.LabelDBRole] == "core" {
+				if pod.Labels[crd.LabelMriaRole] == crd.RoleCore {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crd.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionTrue)),
 					)))
 				}
-				if pod.Labels[crd.LabelDBRole] == "replicant" {
+				if pod.Labels[crd.LabelMriaRole] == crd.RoleReplicant {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crd.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionFalse)),
@@ -529,7 +529,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			By("fetch core StatefulSet")
 			var stsListBefore appsv1.StatefulSetList
 			Expect(KubectlOut("get", "statefulset",
-				"--selector", crd.LabelDBRole+"=core",
+				"--selector", crd.LabelMriaRole+"="+crd.RoleCore,
 				"-o", "json",
 			)).To(UnmarshalInto(&stsListBefore))
 			Expect(stsListBefore.Items).To(HaveLen(1), "More than one core StatefulSet")
@@ -553,7 +553,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			By("verify exactly one core StatefulSet was updated")
 			var stsList appsv1.StatefulSetList
 			Expect(KubectlOut("get", "statefulset",
-				"--selector", crd.LabelDBRole+"=core",
+				"--selector", crd.LabelMriaRole+"="+crd.RoleCore,
 				"-o", "json",
 			)).To(UnmarshalInto(&stsList))
 
@@ -631,13 +631,13 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)).To(UnmarshalInto(&pods), "Failed to list EMQX pods")
 			Expect(pods.Items).To(HaveLen(4))
 			for _, pod := range pods.Items {
-				if pod.Labels[crd.LabelDBRole] == "core" {
+				if pod.Labels[crd.LabelMriaRole] == crd.RoleCore {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crd.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionTrue)),
 					)))
 				}
-				if pod.Labels[crd.LabelDBRole] == "replicant" {
+				if pod.Labels[crd.LabelMriaRole] == crd.RoleReplicant {
 					Expect(pod.Status.Conditions).To(ContainElement(And(
 						HaveField("Type", Equal(crd.DSReplicationSite)),
 						HaveField("Status", Equal(corev1.ConditionFalse)),
@@ -697,7 +697,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 
 			By("verify the selector matches replicant pods")
 			Expect(scale.Status.Selector).To(
-				ContainSubstring(crd.LabelDBRole+"=replicant"),
+				ContainSubstring(crd.LabelMriaRole+"="+crd.RoleReplicant),
 				"Scale selector should include the replicant role label",
 			)
 			Expect(scale.Status.Selector).To(

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -440,6 +440,51 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 			)).To(Equal("0"))
 		})
 
+		It("scale replicants down to zero", func() {
+			By("fetch current replicant nodes")
+			var replicantNodes []crd.EMQXNode
+			Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status.replicantNodes}")).
+				To(UnmarshalInto(&replicantNodes), "Failed to get EMQX replicant nodes")
+			Expect(replicantNodes).NotTo(BeEmpty(), "No replicant nodes were present before scaling down")
+
+			By("fetch existing replicant ReplicaSets")
+			var rsBefore appsv1.ReplicaSetList
+			Expect(KubectlOut("get", "replicaset",
+				"--selector", crd.LabelInstance+"=emqx,"+crd.LabelMriaRole+"="+crd.RoleReplicant,
+				"-o", "json",
+			)).To(UnmarshalInto(&rsBefore), "Failed to list replicant ReplicaSets")
+			Expect(rsBefore.Items).NotTo(BeEmpty(), "No replicant ReplicaSets were present before scaling down")
+
+			By("scale replicants to zero and constrain revision history")
+			const revisionHistoryLimit = 1
+			replicantReplicas = 0
+			changeTime := metav1.Now()
+			Expect(Kubectl("patch", "emqx", "emqx",
+				"--type", "json",
+				"--patch", `[
+						{"op": "replace", "path": "/spec/replicantTemplate/spec/replicas", "value": 0},
+						{"op": "replace", "path": "/spec/revisionHistoryLimit", "value": `+fmt.Sprint(revisionHistoryLimit)+`}
+					]`,
+			)).To(Succeed(), "Failed to scale replicants down to 0")
+
+			By("wait for EMQX to stabilize without replicants")
+			Eventually(EMQXReady).WithArguments(changeTime).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(NoReplicants).Should(Succeed())
+
+			By("verify replicant ReplicaSets are retained according to revisionHistoryLimit")
+			Eventually(KubectlOut).WithArguments("get", "replicaset",
+				"--selector", emqxReplicantLabels.String(),
+				"-o", "json",
+			).Should(BeUnmarshalledAs(&appsv1.ReplicaSetList{}, HaveField("Items", And(
+				HaveLen(revisionHistoryLimit),
+				HaveEach(And(
+					HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+					HaveField("Status.Replicas", BeEquivalentTo(0)),
+				)),
+			))))
+		})
+
 		It("delete cluster", func() {
 			Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
 			Expect(Kubectl("get", "emqx", "emqx")).To(HaveOccurred(), "EMQX cluster still exists")

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -55,8 +55,8 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 
 	const (
 		emqxCRBasic      = "test/e2e/files/resources/emqx.yaml"
-		emqxImage        = "emqx/emqx:5.10.0"
-		emqxImageUpgrade = "emqx/emqx:5.10.1"
+		emqxImage        = "emqx/emqx:6.2.1"
+		emqxImageUpgrade = "emqx/emqx:6.2.2"
 	)
 
 	BeforeAll(func() {
@@ -83,7 +83,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 		}
 	})
 
-	Context("EMQX Cluster", func() {
+	Context("EMQX Cluster", Label("smoke"), func() {
 		// Initial number of core replicas:
 		var coreReplicas = 2
 

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -80,6 +80,7 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 	AfterEach(func() {
 		if CurrentSpecReport().Failed() {
 			PrintDiagnosticReport(namespace)
+			DumpDiagnosticReport(namespace, "emqx", CurrentSpecReport().StartTime)
 		}
 	})
 


### PR DESCRIPTION
## Summary

This PR:
* Ensures CR status carries _consistent_ representation of cluster state.
     * This is of course not strict point-in-time consistency, as it's hard to achieve given status is a representation of k8s resources state and few separate EMQX API requests.
* Addresses a couple of minor issues arising when replicants replicas is changed to zero from a positive value.
* Makes few cosmetic fixes.

Partial port of #1210.