### PR TITLE
fix(config): avoid escaping HTML characters during serialize

### DIFF
--- a/internal/controller/config/emqx.go
+++ b/internal/controller/config/emqx.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"sort"
@@ -25,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/emqx/emqx-operator/hocon"
+	json "github.com/json-iterator/go"
 	corev1 "k8s.io/api/core/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -78,6 +78,10 @@ func (c *EMQX) Copy() *EMQX {
 }
 
 func (c *EMQX) String() string {
+	var jsonc = json.Config{
+		EscapeHTML:  false,
+		SortMapKeys: true,
+	}.Froze()
 	var sb strings.Builder
 	roots := make([]string, 0, len(c.Config))
 	for r := range c.Config {
@@ -87,7 +91,7 @@ func (c *EMQX) String() string {
 	for _, root := range roots {
 		sb.WriteString(strconv.Quote(root))
 		sb.WriteString(" = ")
-		json, _ := json.Marshal(c.Config[root])
+		json, _ := jsonc.Marshal(c.Config[root])
 		sb.Write(json)
 		sb.WriteString("\n")
 	}

--- a/internal/controller/config/emqx_test.go
+++ b/internal/controller/config/emqx_test.go
@@ -357,6 +357,20 @@ func TestString(t *testing.T) {
 		assert.Equal(t, strings.TrimPrefix(expected, "\n"), got)
 	})
 
+	t.Run("unicode strings", func(t *testing.T) {
+		config, err := EMQXConfig(`desc = "описание"`)
+		assert.Nil(t, err)
+		got := config.String()
+		assert.Equal(t, "\"desc\" = \"описание\"\n", got)
+	})
+
+	t.Run("HTML characters are not escaped", func(t *testing.T) {
+		config, err := EMQXConfig(`filter = "(& (objectClass=user) (sAMAccountName=${username}))"`)
+		assert.Nil(t, err)
+		got := config.String()
+		assert.Equal(t, "\"filter\" = \"(& (objectClass=user) (sAMAccountName=${username}))\"\n", got)
+	})
+
 	t.Run("complex", func(t *testing.T) {
 		confString := `
 			license {

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -160,9 +160,8 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			By("create MQTTX client")
 			Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
 			defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml")
-			Expect(Kubectl("wait", "pod",
-				"--selector=app=mqttx",
-				"--for=condition=Ready",
+			Expect(Kubectl("wait", "deployment/mqttx",
+				"--for=condition=Available",
 				"--timeout=1m",
 			)).To(Succeed(), "Timed out waiting MQTTX to be ready")
 
@@ -265,9 +264,8 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			By("create MQTT workload")
 			Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
 			defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml")
-			Expect(Kubectl("wait", "pod",
-				"--selector=app=mqttx",
-				"--for=condition=Ready",
+			Expect(Kubectl("wait", "deployment/mqttx",
+				"--for=condition=Available",
 				"--timeout=1m",
 			)).To(Succeed(), "Timed out waiting MQTTX to be ready")
 
@@ -403,9 +401,8 @@ var _ = Describe("EMQX Test", Label("emqx"), Ordered, func() {
 			By("create MQTTX client")
 			Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
 			defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml")
-			Expect(Kubectl("wait", "pod",
-				"--selector=app=mqttx",
-				"--for=condition=Ready",
+			Expect(Kubectl("wait", "deployment/mqttx",
+				"--for=condition=Available",
 				"--timeout=1m",
 			)).To(Succeed(), "Timed out waiting for MQTTX to be ready")
 

--- a/test/e2e/rebalance_test.go
+++ b/test/e2e/rebalance_test.go
@@ -98,9 +98,8 @@ var _ = Describe("Rebalance Test", Label("rebalance"), Ordered, func() {
 		By("create MQTTX client workload")
 		Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
 		defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml")
-		Expect(Kubectl("wait", "pod",
-			"--selector=app=mqttx",
-			"--for=condition=Ready",
+		Expect(Kubectl("wait", "deployment/mqttx",
+			"--for=condition=Available",
 			"--timeout=1m",
 		)).To(Succeed(), "Timed out waiting for MQTTX to be ready")
 


### PR DESCRIPTION
## Summary

This PR disables Go's default `json/encoding` behavior of uescaping select HTML characters, as it breaks compatibility with EMQX-flavored HOCON parser.
