### PR TITLE
chore(manager): make k8s client cache slimmer

### DIFF
--- a/api/v3beta1/labels.go
+++ b/api/v3beta1/labels.go
@@ -18,13 +18,27 @@ package v3beta1
 
 import (
 	"maps"
+
+	"k8s.io/apimachinery/pkg/labels"
 )
+
+const DefaultManagedBy = "emqx-operator"
 
 func (instance *EMQX) DefaultLabels() map[string]string {
 	labels := map[string]string{}
 	labels[LabelInstance] = instance.Name
-	labels[LabelManagedBy] = "emqx-operator"
+	labels[LabelManagedBy] = DefaultManagedBy
 	return labels
+}
+
+func DefaultCacheLabels() labels.Set {
+	return labels.Set{
+		LabelManagedBy: DefaultManagedBy,
+	}
+}
+
+func DefaultCacheSelector() labels.Selector {
+	return labels.SelectorFromSet(DefaultCacheLabels())
 }
 
 func (instance *EMQX) DefaultLabelsWith(extraLabels ...map[string]string) map[string]string {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,8 @@ import (
 	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -175,6 +177,18 @@ func main() {
 
 		Cache: cache.Options{
 			DefaultNamespaces: watchedNamespacesCache(namespaces),
+			DefaultTransform:  cache.TransformStripManagedFields(),
+			ByObject: map[client.Object]cache.ByObject{
+				&appsv1.ReplicaSet{}: {
+					Label: crd.DefaultCacheSelector(),
+				},
+				&appsv1.StatefulSet{}: {
+					Label: crd.DefaultCacheSelector(),
+				},
+				&corev1.Pod{}: {
+					Label: crd.DefaultCacheSelector(),
+				},
+			},
 		},
 	})
 	if err != nil {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -88,9 +88,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 512Mi
           requests:
-            cpu: 10m
-            memory: 64Mi
+            cpu: 100m
+            memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Summary

This PR focuses on manager process memory usage.
* Tune K8s client cache options to avoid pulling unnecessary resources into caches during runtime.
* Ensure resource requests / limits are consistent across Helm and `install.yaml` manifest.

Addresses #1206.