### PR TITLE
fix(helm): run pre-upgrade for CRD webhooks unconditionally

### DIFF
--- a/deploy/charts/emqx-operator/templates/NOTES.txt
+++ b/deploy/charts/emqx-operator/templates/NOTES.txt
@@ -4,17 +4,16 @@ The operator is running in namespace: {{ .Release.Namespace }}
 
 Now you can create EMQX Custom Resources to deploy EMQX clusters.
 
+Pre-upgrade hooks ran automatically to ensure a smooth upgrade from any prior
+installation.
+
+The hooks:
 {{- if .Values.upgrade.preUpgradeCheck }}
-
-A pre-upgrade compatibility check Job ran automatically to ensure a smooth
-upgrade from any prior installation.
-
-The check:
   - Verified no legacy custom resources exist (emqxbrokers, emqxenterprises,
     emqxplugins) that would be destroyed when Helm removes their CRDs
+{{- end }}
   - Patched CRDs to remove conversion webhooks, preventing API server
     errors during the operator replacement window
 
-To skip the pre-upgrade Job on future installs (e.g. in air-gapped environments):
+To skip only the legacy custom resource check on future installs:
   --set upgrade.preUpgradeCheck=false
-{{- end }}

--- a/deploy/charts/emqx-operator/templates/pre-upgrade-check.yaml
+++ b/deploy/charts/emqx-operator/templates/pre-upgrade-check.yaml
@@ -32,6 +32,12 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
   - apps.emqx.io
   resources:
   - emqxbrokers
@@ -100,25 +106,31 @@ spec:
           # destroyed. Abort early and ask the user to migrate first.
           BLOCKED=""
 
-          if kubectl get crd emqxbrokers.apps.emqx.io >/dev/null 2>&1; then
-            N=$(kubectl get emqxbrokers --all-namespaces --no-headers 2>/dev/null | wc -l)
-            if [ "$N" -gt 0 ]; then
+          CRD=$(kubectl get crd emqxbrokers.apps.emqx.io --ignore-not-found -o name)
+          if [ -n "$CRD" ]; then
+            CRS=$(kubectl get emqxbrokers --all-namespaces --no-headers)
+            if [ -n "$CRS" ]; then
+              N=$(printf '%s\n' "$CRS" | wc -l)
               echo "ERROR: Found $N EmqxBroker CR(s)."
               BLOCKED="emqxbrokers $BLOCKED"
             fi
           fi
 
-          if kubectl get crd emqxenterprises.apps.emqx.io >/dev/null 2>&1; then
-            N=$(kubectl get emqxenterprises --all-namespaces --no-headers 2>/dev/null | wc -l)
-            if [ "$N" -gt 0 ]; then
+          CRD=$(kubectl get crd emqxenterprises.apps.emqx.io --ignore-not-found -o name)
+          if [ -n "$CRD" ]; then
+            CRS=$(kubectl get emqxenterprises --all-namespaces --no-headers)
+            if [ -n "$CRS" ]; then
+              N=$(printf '%s\n' "$CRS" | wc -l)
               echo "ERROR: Found $N EmqxEnterprise CR(s)."
               BLOCKED="emqxenterprises $BLOCKED"
             fi
           fi
 
-          if kubectl get crd emqxplugins.apps.emqx.io >/dev/null 2>&1; then
-            N=$(kubectl get emqxplugins --all-namespaces --no-headers 2>/dev/null | wc -l)
-            if [ "$N" -gt 0 ]; then
+          CRD=$(kubectl get crd emqxplugins.apps.emqx.io --ignore-not-found -o name)
+          if [ -n "$CRD" ]; then
+            CRS=$(kubectl get emqxplugins --all-namespaces --no-headers)
+            if [ -n "$CRS" ]; then
+              N=$(printf '%s\n' "$CRS" | wc -l)
               echo "ERROR: Found $N EmqxPlugin CR(s)."
               BLOCKED="emqxplugins $BLOCKED"
             fi

--- a/deploy/charts/emqx-operator/templates/pre-upgrade-check.yaml
+++ b/deploy/charts/emqx-operator/templates/pre-upgrade-check.yaml
@@ -1,0 +1,137 @@
+{{- if .Values.upgrade.preUpgradeCheck }}
+{{- $podSecurityContext := mergeOverwrite
+                            (dict "runAsUser" 65534)
+                            (.Values.podSecurityContext)
+                            (.Values.upgrade.podSecurityContext | default (dict)) }}
+{{- $containerSecurityContext := mergeOverwrite
+                            (dict)
+                            (.Values.containerSecurityContext)
+                            (.Values.upgrade.containerSecurityContext | default (dict)) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "emqx-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+  labels:
+    {{- include "emqx-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - apps.emqx.io
+  resources:
+  - emqxbrokers
+  - emqxenterprises
+  - emqxplugins
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+  labels:
+    {{- include "emqx-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+subjects:
+- kind: ServiceAccount
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "emqx-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-15"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "emqx-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "emqx-operator.fullname" . }}-pre-upgrade-check
+      securityContext:
+        {{- toYaml $podSecurityContext | nindent 8 }}
+      containers:
+      - name: check
+        image: "{{ .Values.upgrade.image.repository }}:{{ .Values.upgrade.image.tag }}"
+        imagePullPolicy: {{ .Values.upgrade.image.pullPolicy }}
+        securityContext:
+          {{- toYaml $containerSecurityContext | nindent 12 }}
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          echo "=== EMQX Operator pre-upgrade compatibility check (2.2.x -> 2.3.x) ==="
+
+          # Legacy CRDs (emqxbrokers, emqxenterprises, emqxplugins) are present in
+          # 2.2.x chart templates but absent from 2.3.x, so Helm will delete them
+          # during upgrade. If any CRs exist under those CRDs they would be silently
+          # destroyed. Abort early and ask the user to migrate first.
+          BLOCKED=""
+
+          if kubectl get crd emqxbrokers.apps.emqx.io >/dev/null 2>&1; then
+            N=$(kubectl get emqxbrokers --all-namespaces --no-headers 2>/dev/null | wc -l)
+            if [ "$N" -gt 0 ]; then
+              echo "ERROR: Found $N EmqxBroker CR(s)."
+              BLOCKED="emqxbrokers $BLOCKED"
+            fi
+          fi
+
+          if kubectl get crd emqxenterprises.apps.emqx.io >/dev/null 2>&1; then
+            N=$(kubectl get emqxenterprises --all-namespaces --no-headers 2>/dev/null | wc -l)
+            if [ "$N" -gt 0 ]; then
+              echo "ERROR: Found $N EmqxEnterprise CR(s)."
+              BLOCKED="emqxenterprises $BLOCKED"
+            fi
+          fi
+
+          if kubectl get crd emqxplugins.apps.emqx.io >/dev/null 2>&1; then
+            N=$(kubectl get emqxplugins --all-namespaces --no-headers 2>/dev/null | wc -l)
+            if [ "$N" -gt 0 ]; then
+              echo "ERROR: Found $N EmqxPlugin CR(s)."
+              BLOCKED="emqxplugins $BLOCKED"
+            fi
+          fi
+
+          if [ -n "$BLOCKED" ]; then
+            echo ""
+            echo "Upgrade BLOCKED: legacy custom resources still exist ($BLOCKED)."
+            echo "These CRDs will be removed by the 2.3.x chart, which would destroy the CRs."
+            echo "Please migrate or delete these resources before upgrading."
+            echo "See: https://github.com/emqx/emqx-operator/blob/main-2.3/README.md#from-22x"
+            exit 1
+          fi
+
+          echo "=== Pre-upgrade compatibility check complete ==="
+{{- end }}

--- a/deploy/charts/emqx-operator/templates/pre-upgrade-webhooks.yaml
+++ b/deploy/charts/emqx-operator/templates/pre-upgrade-webhooks.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.upgrade.preUpgradeCheck }}
 {{- $podSecurityContext := mergeOverwrite
                             (dict "runAsUser" 65534)
                             (.Values.podSecurityContext)
@@ -11,7 +10,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-webhooks
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "emqx-operator.labels" . | nindent 4 }}
@@ -31,7 +30,6 @@ metadata:
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
-# Patch CRDs to remove conversion webhooks
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -39,15 +37,6 @@ rules:
   verbs:
   - get
   - patch
-# List legacy CRs to check if any exist before upgrade
-- apiGroups:
-  - apps.emqx.io
-  resources:
-  - emqxbrokers
-  - emqxenterprises
-  - emqxplugins
-  verbs:
-  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -65,13 +54,13 @@ roleRef:
   name: {{ include "emqx-operator.fullname" . }}-pre-upgrade
 subjects:
 - kind: ServiceAccount
-  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-webhooks
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade
+  name: {{ include "emqx-operator.fullname" . }}-pre-upgrade-webhooks
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "emqx-operator.labels" . | nindent 4 }}
@@ -88,7 +77,7 @@ spec:
         {{- include "emqx-operator.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "emqx-operator.fullname" . }}-pre-upgrade
+      serviceAccountName: {{ include "emqx-operator.fullname" . }}-pre-upgrade-webhooks
       securityContext:
         {{- toYaml $podSecurityContext | nindent 8 }}
       containers:
@@ -101,51 +90,8 @@ spec:
         - /bin/sh
         - -ec
         - |
-          echo "=== EMQX Operator pre-upgrade cleanup (2.2.x -> 2.3.x) ==="
+          echo "=== EMQX Operator conversion webhook cleanup (2.2.x -> 2.3.x) ==="
 
-          # Step 1: Check for existing legacy custom resources.
-          #
-          # Legacy CRDs (emqxbrokers, emqxenterprises, emqxplugins) are present in
-          # 2.2.x chart templates but absent from 2.3.x, so Helm will delete them
-          # during upgrade. If any CRs exist under those CRDs they would be silently
-          # destroyed. Abort early and ask the user to migrate first.
-          BLOCKED=""
-
-          if kubectl get crd emqxbrokers.apps.emqx.io >/dev/null 2>&1; then
-            N=$(kubectl get emqxbrokers --all-namespaces --no-headers 2>/dev/null | wc -l)
-            if [ "$N" -gt 0 ]; then
-              echo "ERROR: Found $N EmqxBroker CR(s)."
-              BLOCKED="emqxbrokers $BLOCKED"
-            fi
-          fi
-
-          if kubectl get crd emqxenterprises.apps.emqx.io >/dev/null 2>&1; then
-            N=$(kubectl get emqxenterprises --all-namespaces --no-headers 2>/dev/null | wc -l)
-            if [ "$N" -gt 0 ]; then
-              echo "ERROR: Found $N EmqxEnterprise CR(s)."
-              BLOCKED="emqxenterprises $BLOCKED"
-            fi
-          fi
-
-          if kubectl get crd emqxplugins.apps.emqx.io >/dev/null 2>&1; then
-            N=$(kubectl get emqxplugins --all-namespaces --no-headers 2>/dev/null | wc -l)
-            if [ "$N" -gt 0 ]; then
-              echo "ERROR: Found $N EmqxPlugin CR(s)."
-              BLOCKED="emqxplugins $BLOCKED"
-            fi
-          fi
-
-          if [ -n "$BLOCKED" ]; then
-            echo ""
-            echo "Upgrade BLOCKED: legacy custom resources still exist ($BLOCKED)."
-            echo "These CRDs will be removed by the 2.3.x chart, which would destroy the CRs."
-            echo "Please migrate or delete these resources before upgrading."
-            echo "See: https://github.com/emqx/emqx-operator/blob/main-2.3/README.md#from-22x"
-            exit 1
-          fi
-
-          # Step 2: Patch CRDs to remove conversion webhooks.
-          #
           # The 2.2.x chart configures Webhook conversion on emqxes and rebalances
           # CRDs, pointing at the operator's webhook endpoint. During upgrade Helm
           # will tear down the old Deployment (and its Service) before applying the
@@ -153,17 +99,48 @@ spec:
           # would fail to serve any request that triggers CRD conversion, because the
           # webhook endpoint no longer exists. Patching the strategy to None *before*
           # Helm starts the upgrade avoids this.
-          echo "--- Patching CRD emqxes.apps.emqx.io ..."
-          kubectl patch crd emqxes.apps.emqx.io \
-            --type=json \
-            -p='[{"op":"replace","path":"/spec/conversion","value":{"strategy":"None"}}]' \
-              || echo "*** not found or already patched, skipping."
+          STRATEGY=$(kubectl get crd emqxes.apps.emqx.io \
+            --ignore-not-found \
+            -o jsonpath='{.spec.conversion.strategy}')
+          case "$STRATEGY" in
+            Webhook)
+              echo "--- Patching CRD emqxes.apps.emqx.io ..."
+              kubectl patch crd emqxes.apps.emqx.io \
+                --type=json \
+                -p='[{"op":"replace","path":"/spec/conversion","value":{"strategy":"None"}}]'
+              ;;
+            "")
+              echo "--- CRD emqxes.apps.emqx.io not found, skipping."
+              ;;
+            None)
+              echo "--- CRD emqxes.apps.emqx.io already up-to-date."
+              ;;
+            *)
+              echo "ERROR: CRD emqxes.apps.emqx.io has unexpected conversion strategy: $STRATEGY"
+              exit 1
+              ;;
+          esac
 
-          echo "--- Patching CRD rebalances.apps.emqx.io ..."
-          kubectl patch crd rebalances.apps.emqx.io \
-            --type=json \
-            -p='[{"op":"replace","path":"/spec/conversion","value":{"strategy":"None"}}]' \
-              || echo "*** not found or already patched, skipping."
+          STRATEGY=$(kubectl get crd rebalances.apps.emqx.io \
+            --ignore-not-found \
+            -o jsonpath='{.spec.conversion.strategy}')
+          case "$STRATEGY" in
+            Webhook)
+              echo "--- Patching CRD rebalances.apps.emqx.io ..."
+              kubectl patch crd rebalances.apps.emqx.io \
+                --type=json \
+                -p='[{"op":"replace","path":"/spec/conversion","value":{"strategy":"None"}}]'
+              ;;
+            "")
+              echo "--- CRD rebalances.apps.emqx.io not found, skipping."
+              ;;
+            None)
+              echo "--- CRD rebalances.apps.emqx.io already up-to-date."
+              ;;
+            *)
+              echo "ERROR: CRD rebalances.apps.emqx.io has unexpected conversion strategy: $STRATEGY"
+              exit 1
+              ;;
+          esac
 
-          echo "=== Pre-upgrade cleanup complete ==="
-{{- end }}
+          echo "=== Conversion webhook cleanup complete ==="

--- a/deploy/charts/emqx-operator/values.yaml
+++ b/deploy/charts/emqx-operator/values.yaml
@@ -70,33 +70,31 @@ tolerations: []
 affinity: {}
 
 ## Upgrade settings.
-## A pre-install/pre-upgrade Job runs automatically to ensure a smooth
-## upgrade from earlier chart versions:
-##   1. Checks for legacy custom resources (emqxbrokers, emqxenterprises,
-##      emqxplugins) and blocks the upgrade if any exist, because Helm
-##      will delete those CRDs (and their CRs) during the upgrade.
-##   2. Patches CRD conversion webhooks to strategy "None" so the API
-##      server does not fail while the old operator is being replaced.
+## Pre-install/pre-upgrade hooks run automatically to ensure a smooth upgrade
+## from earlier chart versions. A dedicated hook always patches CRD conversion
+## webhooks to strategy "None" so the API server does not fail while the old
+## operator is being replaced. It can also check for legacy custom resources
+## (emqxbrokers, emqxenterprises, emqxplugins) and block the upgrade before Helm
+## deletes those CRDs and their CRs.
 ##
-## The Job is fully idempotent and becomes a no-op on fresh installs.
+## The hooks are fully idempotent and become no-ops on fresh installs.
 upgrade:
-  ## Run the pre-upgrade compatibility check Job.
-  ## Enabled by default so that upgrades from 2.2.x work out of the box.
-  ## Set to false to skip the Job entirely (e.g. in air-gapped
-  ## environments where pulling the kubectl image is not possible).
+  ## Check for legacy custom resources before upgrading and block the upgrade
+  ## if any exist. Disabling this check does not disable the mandatory CRD
+  ## conversion webhook cleanup hook.
   preUpgradeCheck: true
 
-  ## Image used for the pre-upgrade cleanup Job.
+  ## Image used for the pre-upgrade hooks.
   ## Must include kubectl and sh.
   image:
     repository: alpine/k8s
     tag: "1.31.4"
     pullPolicy: IfNotPresent
 
-  ## Optional pod security context overrides for the pre-upgrade Job.
+  ## Optional pod security context overrides for the pre-upgrade Jobs.
   ## Defaults to podSecurityContext, with runAsUser=65534 added when no UID is set.
   podSecurityContext: {}
 
-  ## Optional container security context overrides for the pre-upgrade Job.
+  ## Optional container security context overrides for the pre-upgrade Jobs.
   ## Defaults to containerSecurityContext.
   containerSecurityContext: {}

--- a/test/e2e-helm/helm_install_test.go
+++ b/test/e2e-helm/helm_install_test.go
@@ -40,17 +40,20 @@ func helmInstall(namespace string, extraArgs ...string) error { //nolint:unparam
 }
 
 // helmUpgrade upgrades to the local 2.3.x chart in the given namespace with --wait.
-func helmUpgrade(namespace string) error {
-	return Run("helm", "upgrade",
+func helmUpgrade(namespace string, extraArgs ...string) error {
+	args := []string{
+		"upgrade",
 		helmReleaseName,
 		localChartPath,
 		"--namespace", namespace,
-		"--set", "image.repository="+operatorImageRepo,
-		"--set", "image.tag="+operatorImageTag,
+		"--set", "image.repository=" + operatorImageRepo,
+		"--set", "image.tag=" + operatorImageTag,
 		"--set", "image.pullPolicy=Never",
 		"--wait",
 		"--timeout", "2m",
-	)
+	}
+	args = append(args, extraArgs...)
+	return Run("helm", args...)
 }
 
 // helmCleanup removes all resources that 2.3.x chart may have left behind in
@@ -61,6 +64,8 @@ func helmCleanup(namespace string) {
 	_ = Kubectl("delete", "clusterrolebinding", "emqx-operator-manager-rolebinding", "--ignore-not-found")
 	_ = Kubectl("delete", "clusterrole", "emqx-operator-pre-upgrade", "--ignore-not-found")
 	_ = Kubectl("delete", "clusterrolebinding", "emqx-operator-pre-upgrade", "--ignore-not-found")
+	_ = Kubectl("delete", "clusterrole", "emqx-operator-pre-upgrade-check", "--ignore-not-found")
+	_ = Kubectl("delete", "clusterrolebinding", "emqx-operator-pre-upgrade-check", "--ignore-not-found")
 	_ = Kubectl("delete", "crd", "emqxes.apps.emqx.io", "--ignore-not-found")
 	_ = Kubectl("delete", "crd", "rebalances.apps.emqx.io", "--ignore-not-found")
 	_ = Kubectl("delete", "ns", namespace, "--ignore-not-found")

--- a/test/e2e-helm/helm_upgrade_test.go
+++ b/test/e2e-helm/helm_upgrade_test.go
@@ -104,16 +104,15 @@ var _ = Describe("Helm Upgrade / 2.2.x", Ordered, func() {
 		Expect(helmUpgrade(namespace)).To(Succeed())
 
 		By("verify pre-upgrade completed successfully")
-		var jobList batchv1.JobList
 		Eventually(KubectlOut).
 			WithArguments("get", "jobs", "--namespace", namespace, "-o", "json").
 			Should(
 				// Hook jobs may be cleaned up already (hook-succeeded policy),
 				// which is fine: it means they completed successfully.
-				BeUnmarshalledAs(&jobList, HaveField("Items", Or(
+				BeUnmarshalledAs(&batchv1.JobList{}, HaveField("Items", Or(
 					BeEmpty(),
 					ContainElement(And(
-						HaveField("Name", Equal("pre-upgrade")),
+						HaveField("Name", Equal("emqx-operator-pre-upgrade-webhooks")),
 						HaveField("Status.Succeeded", BeNumerically(">=", 1)),
 					)),
 				))),
@@ -122,9 +121,8 @@ var _ = Describe("Helm Upgrade / 2.2.x", Ordered, func() {
 
 		By("verify CRDs no longer have conversion webhooks")
 		for _, crdName := range []string{"emqxes.apps.emqx.io", "rebalances.apps.emqx.io"} {
-			var crd apiextv1.CustomResourceDefinition
 			Expect(KubectlOut("get", "crd", crdName, "-o", "json")).To(
-				BeUnmarshalledAs(&crd, Or(
+				BeUnmarshalledAs(&apiextv1.CustomResourceDefinition{}, Or(
 					HaveField("Spec.Conversion", BeNil()),
 					HaveField("Spec.Conversion.Strategy", Equal(apiextv1.NoneConverter)),
 				)),
@@ -139,14 +137,13 @@ var _ = Describe("Helm Upgrade / 2.2.x", Ordered, func() {
 			"emqx-operator-validating-webhook-configuration")).To(BeFalse())
 
 		By("verify 2.3.x operator deployment is running")
-		var deployment appsv1.Deployment
 		Eventually(KubectlOut).
 			WithArguments("get", "deployment",
 				"emqx-operator-controller-manager",
 				"--namespace", namespace,
 				"-o", "json",
 			).
-			Should(BeUnmarshalledAs(&deployment,
+			Should(BeUnmarshalledAs(&appsv1.Deployment{},
 				HaveField("Status.AvailableReplicas", BeNumerically(">=", 1)),
 			))
 
@@ -157,6 +154,70 @@ var _ = Describe("Helm Upgrade / 2.2.x", Ordered, func() {
 			"emqxenterprises CRD should be removed after upgrade")
 		Expect(crdExists("emqxplugins.apps.emqx.io")).To(BeFalse(),
 			"emqxplugins CRD should be removed after upgrade")
+	})
+})
+
+//nolint:errcheck
+var _ = Describe("Helm Upgrade / 2.2.x / legacy check disabled", Ordered, func() {
+
+	const namespace = "emqx-operator-no-legacy-check"
+
+	BeforeAll(func() {
+		By("clean up any leftover resources from previous test runs")
+		helmCleanup(namespace)
+		cleanup22x()
+
+		By("create test namespace")
+		Expect(Kubectl("create", "ns", namespace)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		helmCleanup(namespace)
+		cleanup22x()
+	})
+
+	AfterEach(func() {
+		if CurrentSpecReport().Failed() {
+			dumpHelmDiagnostics(namespace)
+		}
+	})
+
+	It("should always remove conversion webhooks", func() {
+		By("install emqx-operator 2.2.x from Helm repo")
+		Expect(helmInstall22x(namespace)).To(Succeed())
+
+		By("verify 2.2.x CRDs use conversion webhooks")
+		for _, crdName := range []string{"emqxes.apps.emqx.io", "rebalances.apps.emqx.io"} {
+			Expect(KubectlOut("get", "crd", crdName, "-o", "json")).To(
+				BeUnmarshalledAs(&apiextv1.CustomResourceDefinition{},
+					HaveField("Spec.Conversion.Strategy", Equal(apiextv1.WebhookConverter)),
+				),
+				"%s should use webhook conversion before upgrade", crdName,
+			)
+		}
+
+		By("upgrade to 2.3.x with only the legacy custom resource check disabled")
+		Expect(helmUpgrade(namespace, "--set", "upgrade.preUpgradeCheck=false")).To(Succeed())
+
+		By("verify only the dedicated webhook cleanup hook was rendered")
+		Expect(Output("helm", "get", "hooks", helmReleaseName, "--namespace", namespace)).To(
+			And(
+				ContainSubstring("name: emqx-operator-pre-upgrade-webhooks"),
+				ContainSubstring("kubectl patch crd emqxes.apps.emqx.io"),
+				ContainSubstring("kubectl patch crd rebalances.apps.emqx.io"),
+				Not(ContainSubstring("name: emqx-operator-pre-upgrade-check")),
+			))
+
+		By("verify CRDs no longer have conversion webhooks")
+		for _, crdName := range []string{"emqxes.apps.emqx.io", "rebalances.apps.emqx.io"} {
+			Expect(KubectlOut("get", "crd", crdName, "-o", "json")).To(
+				BeUnmarshalledAs(&apiextv1.CustomResourceDefinition{}, Or(
+					HaveField("Spec.Conversion", BeNil()),
+					HaveField("Spec.Conversion.Strategy", Equal(apiextv1.NoneConverter)),
+				)),
+				"%s should have None or no conversion strategy after upgrade", crdName,
+			)
+		}
 	})
 })
 


### PR DESCRIPTION
## Summary

This PR refines 2.2.x upgrade procedure and removes conditional patching of legacy CRDs. Disabling `preUpgradeCheck` when upgrading from 2.2.x could have caused incomplete upgrades and degraded operation.