### PR TITLE
fix: allow removing unavailable outdated replicants in rolling updates

### DIFF
--- a/internal/controller/load_state.go
+++ b/internal/controller/load_state.go
@@ -180,6 +180,14 @@ func (r *reconcileState) hasReplicants() bool {
 	return false
 }
 
+func (r *reconcileState) replicantPods() []*corev1.Pod {
+	pods := make([]*corev1.Pod, 0, len(r.pods))
+	for _, rs := range r.replicantSets {
+		pods = append(pods, r.podsManagedBy(rs)...)
+	}
+	return pods
+}
+
 // outdatedReplicantReplicaSets returns all replicant ReplicaSets except the update revision set,
 // sorted by creation timestamp (oldest first).
 func (r *reconcileState) outdatedReplicantSets(instance *crd.EMQX) []*appsv1.ReplicaSet {

--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -383,9 +383,10 @@ func (s *syncReplicantSets) outdatedReplicantAdmissions(
 }
 
 // evaluateReplicantAdmissions returns admissions for the given candidate pods.
-// Pods already annotated with scaling-down bypass the budget: they were committed
-// to in a previous reconcile iteration. The budget only limits how many *unannotated*
-// pods can be admitted per iteration.
+// Pods already annotated with scaling-down bypass the new-admission limit but keep
+// their regular budget slot: they were committed to in a previous reconcile
+// iteration. Removing an unavailable pod cannot reduce availability further, so it
+// does not consume budget; other unannotated pods do.
 // Candidates are evaluated in order, the caller controls which pods to consider:
 // * outdated pods for migration,
 // * "update" set's replicant pods for scale-down, etc.
@@ -402,22 +403,34 @@ func (s *syncReplicantSets) evaluateReplicantAdmissions(
 			Pod:       pod,
 			Admission: checkReplicantPodRemoval(instance, pod),
 		}
-		// Consume the budget:
-		budgetUsed += 1
-		if _, ok := pod.Annotations[crd.AnnotationScalingDown]; ok {
+		available := s.isReplicantAvailable(instance, pod)
+		_, annotated := pod.Annotations[crd.AnnotationScalingDown]
+		switch {
+		case annotated:
 			// Pod was already committed to in a previous reconcile.
-			// Including it so the controller can progress it toward removal.
+			// Include it so the controller can progress it toward removal, while
+			// reserving its regular budget slot until it is gone.
+			budgetUsed += 1
 			batch = append(batch, admission)
-			continue
+		case admission.Admission.Action == admissionRemove && !available:
+			// Removing an unavailable pod cannot increase unavailability.
+			batch = append(batch, admission)
+		default:
+			// Healthy, uncommitted pods consume the regular maxUnavailable budget.
+			budgetUsed += 1
+			// Otherwise, see if we have budget left:
+			if budgetUsed > budget {
+				continue
+			}
+			// If we do, include the admission:
+			batch = append(batch, admission)
 		}
-		// Otherwise, see if we have budget left:
-		if budgetUsed > budget {
-			continue
-		}
-		// If we do, include the admission:
-		batch = append(batch, admission)
 	}
 	return batch
+}
+
+func (*syncReplicantSets) isReplicantAvailable(instance *crd.EMQX, pod *corev1.Pod) bool {
+	return util.IsPodAvailable(pod, instance.Spec.ReplicantTemplate.Spec.MinReadySeconds)
 }
 
 // podIsActiveReplicant returns `false` if a pod is in the process of or going to be deleted,

--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -30,6 +30,8 @@ type replicantPodAdmission struct {
 	Pod       *corev1.Pod
 }
 
+type replicantAvailability map[*corev1.Pod]bool
+
 func (s *syncReplicantSets) reconcile(r *reconcileRound, instance *crd.EMQX) subResult {
 	updateRs := r.state.updateReplicantSet(instance)
 	currentRs := r.state.currentReplicantSet(instance)
@@ -108,9 +110,10 @@ func (s *syncReplicantSets) scaleDown(
 	// At least 1 removal should be allowed if MaxUnavailable is 0.
 	excessReplicas := max(0, currentReplicas-desiredReplicas)
 	maxUnavailable := max(1, instance.Spec.NumMaxUnavailableReplicantReplicas())
-	excessUnavailable := max(0, desiredReplicas-updateRs.Status.AvailableReplicas)
+	availability, numAvailable := s.snapshotAvailability(instance, pods)
+	excessUnavailable := max(0, desiredReplicas-numAvailable)
 	budget := max(0, min(maxUnavailable-excessUnavailable, excessReplicas))
-	admissions := s.evaluateReplicantAdmissions(instance, pods, budget)
+	admissions := s.evaluateReplicantAdmissions(instance, pods, budget, availability)
 	for _, pa := range admissions {
 		err := s.onReplicantAdmission(r, instance, pa.Pod, pa.Admission)
 		if err != nil {
@@ -376,10 +379,11 @@ func (s *syncReplicantSets) outdatedReplicantAdmissions(
 ) []replicantPodAdmission {
 	specReplicas := instance.Spec.NumReplicantReplicas()
 	maxUnavailable := instance.Spec.NumMaxUnavailableReplicantReplicas()
-	extraAvailable := r.state.numAvailableReplicants() - specReplicas
-	budget := maxUnavailable + extraAvailable
+	availability, numAvailable := s.snapshotAvailability(instance, r.state.replicantPods())
+	extraAvailable := numAvailable - specReplicas
+	budget := max(0, maxUnavailable+extraAvailable)
 	outdatedPods := r.state.outdatedReplicantPods(instance)
-	return s.evaluateReplicantAdmissions(instance, outdatedPods, budget)
+	return s.evaluateReplicantAdmissions(instance, outdatedPods, budget, availability)
 }
 
 // evaluateReplicantAdmissions returns admissions for the given candidate pods.
@@ -394,6 +398,7 @@ func (s *syncReplicantSets) evaluateReplicantAdmissions(
 	instance *crd.EMQX,
 	candidates []*corev1.Pod,
 	budget int32,
+	availability replicantAvailability,
 ) []replicantPodAdmission {
 	batch := []replicantPodAdmission{}
 	budgetUsed := int32(0)
@@ -403,7 +408,7 @@ func (s *syncReplicantSets) evaluateReplicantAdmissions(
 			Pod:       pod,
 			Admission: checkReplicantPodRemoval(instance, pod),
 		}
-		available := s.isReplicantAvailable(instance, pod)
+		available := availability[pod]
 		_, annotated := pod.Annotations[crd.AnnotationScalingDown]
 		switch {
 		case annotated:
@@ -427,6 +432,22 @@ func (s *syncReplicantSets) evaluateReplicantAdmissions(
 		}
 	}
 	return batch
+}
+
+func (s *syncReplicantSets) snapshotAvailability(
+	instance *crd.EMQX,
+	pods []*corev1.Pod,
+) (replicantAvailability, int32) {
+	availability := replicantAvailability{}
+	numAvailable := int32(0)
+	for _, pod := range pods {
+		available := s.isReplicantAvailable(instance, pod)
+		availability[pod] = available
+		if available {
+			numAvailable += 1
+		}
+	}
+	return availability, numAvailable
 }
 
 func (*syncReplicantSets) isReplicantAvailable(instance *crd.EMQX, pod *corev1.Pod) bool {

--- a/internal/controller/sync_replicant_sets_suite_test.go
+++ b/internal/controller/sync_replicant_sets_suite_test.go
@@ -141,7 +141,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 			resources = append(resources, updateReplicant)
 
 			update.Status.Replicas = 1
-			update.Status.ReadyReplicas = 1
+			update.Status.ReadyReplicas = 0
 			update.Status.AvailableReplicas = 0
 			current.Status.Replicas = 3
 			current.Status.ReadyReplicas = 3
@@ -159,7 +159,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 					UpdateReplicas:  1,
 					CurrentRevision: currentRevision,
 					CurrentReplicas: 3,
-					ReadyReplicas:   4,
+					ReadyReplicas:   3,
 				},
 				ReplicantNodes: []crd.EMQXNode{
 					{Name: "emqx@10.0.0.1", PodName: currentReplicants[0].Name, Status: "running"},
@@ -536,9 +536,6 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 		It("respects maxUnavailable budget during scale-down", func() {
 			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{MaxUnavailable: ptr.To(intstr.FromInt(1))}
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(0))
-			instance.Status.ReplicantNodesStatus.ReadyReplicas = 0
-			rs.Status.AvailableReplicas = 0
-			Expect(k8sClient.Status().Update(ctx, rs)).Should(Succeed())
 
 			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
@@ -916,14 +913,13 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		}
 		_ = util.AttachPodAnnotation(currentPod, crd.AnnotationScalingDown, "true")
 		Expect(k8sClient.Update(ctx, currentPod)).Should(Succeed())
-		updatePod.Status.Conditions = []corev1.PodCondition{
+		currentPod.Status.Conditions = []corev1.PodCondition{
 			{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()},
 		}
 		Expect(k8sClient.Status().Update(ctx, currentPod)).Should(Succeed())
+		current.Status.ReadyReplicas = 0
 		current.Status.AvailableReplicas = 0
 		Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
-		update.Status.AvailableReplicas = 0
-		Expect(k8sClient.Status().Update(ctx, update)).Should(Succeed())
 		instance.Status.NodeEvacuations = []crd.NodeEvacuationStatus{
 			{NodeName: "emqx@10.0.0.1", State: "evicting_conns"},
 		}
@@ -953,7 +949,12 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		}
 		_ = util.AttachPodAnnotation(currentPod, crd.AnnotationScalingDown, "true")
 		Expect(k8sClient.Update(ctx, currentPod)).Should(Succeed())
-		// Make update RS unavailable so budget = 0.
+		// Make the update pod unavailable so budget = 0.
+		updatePod.Status.Conditions = []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()},
+		}
+		Expect(k8sClient.Status().Update(ctx, updatePod)).Should(Succeed())
+		update.Status.ReadyReplicas = 0
 		update.Status.AvailableReplicas = 0
 		Expect(k8sClient.Status().Update(ctx, update)).Should(Succeed())
 		instance.Status.ReplicantNodes[0].Sessions = 0

--- a/internal/controller/sync_replicant_sets_suite_test.go
+++ b/internal/controller/sync_replicant_sets_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"time"
 
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	util "github.com/emqx/emqx-operator/internal/controller/util"
@@ -29,14 +30,41 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 		updateRevision  string = "update"
 	)
 
-	updateLabels := emqx.DefaultLabelsWith(
-		crd.ReplicantLabels(),
-		map[string]string{crd.LabelPodTemplateHash: updateRevision},
-	)
-	currentLabels := emqx.DefaultLabelsWith(
-		crd.ReplicantLabels(),
-		map[string]string{crd.LabelPodTemplateHash: currentRevision},
-	)
+	mkReplicantSet := func(revision, image string, replicas int32) *appsv1.ReplicaSet {
+		labels := emqx.DefaultLabelsWith(
+			crd.ReplicantLabels(),
+			map[string]string{crd.LabelPodTemplateHash: revision},
+		)
+		return &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: emqx.Name + "-",
+				Namespace:    ns.Name,
+				Labels:       labels,
+			},
+			Spec: appsv1.ReplicaSetSpec{
+				Replicas: ptr.To(replicas),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: labels,
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "emqx", Image: image}},
+					},
+				},
+			},
+		}
+	}
+
+	mkReadyCondition := func(status corev1.ConditionStatus, sinceAgo time.Duration) corev1.PodCondition {
+		return corev1.PodCondition{
+			Type:               corev1.PodReady,
+			Status:             status,
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-sinceAgo)),
+		}
+	}
 
 	BeforeAll(func() {
 		ns = &corev1.Namespace{
@@ -68,44 +96,22 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 					Replicas: ptr.To(int32(3)),
 				},
 			}
+			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt(1)),
+				MaxSurge:       ptr.To(intstr.FromInt(0)),
+			}
 
 			resources = []client.Object{}
 
-			update = &appsv1.ReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: emqx.Name + "-",
-					Namespace:    ns.Name,
-					Labels:       updateLabels,
-				},
-				Spec: appsv1.ReplicaSetSpec{
-					Replicas: ptr.To(int32(1)),
-					Selector: &metav1.LabelSelector{
-						MatchLabels: updateLabels,
-					},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: updateLabels,
-						},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{Name: "emqx", Image: "emqx"},
-							},
-						},
-					},
-				},
-			}
-			current = update.DeepCopy()
-			current.Labels = currentLabels
-			current.Spec.Selector.MatchLabels = currentLabels
-			current.Spec.Template.Labels = currentLabels
-			current.Spec.Replicas = ptr.To(int32(3))
+			update = mkReplicantSet(updateRevision, "emqx", 1)
+			current = mkReplicantSet(currentRevision, "emqx:0", 3)
 			Expect(k8sClient.Create(ctx, update)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, current)).Should(Succeed())
 
 			resources = append(resources, current, update)
 
 			currentReplicants = []*corev1.Pod{}
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName:    current.Name + "-" + currentRevision + fmt.Sprint(i) + "-",
@@ -116,6 +122,8 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 					Spec: current.Spec.Template.Spec,
 				}
 				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				pod.Status.Conditions = []corev1.PodCondition{mkReadyCondition(corev1.ConditionTrue, time.Minute)}
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
 				currentReplicants = append(currentReplicants, pod)
 				resources = append(resources, pod)
 			}
@@ -185,7 +193,9 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 		})
 
 		It("drains up to maxUnavailable old pods in one reconcile", func() {
-			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{MaxUnavailable: ptr.To(intstr.FromInt(3))}
+			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt32(*current.Spec.Replicas)),
+			}
 			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
@@ -201,11 +211,9 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 			)
 		})
 
-		It("drains no pods if maxUnavailable reached", func() {
-			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{MaxUnavailable: ptr.To(intstr.FromInt(3))}
-			Expect(actualObject(current)).To(Not(BeNil()))
-			current.Status.AvailableReplicas = 0
-			Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
+		It("drains no healthy pods if maxUnavailable reached", func() {
+			instance.Spec.ReplicantTemplate.Spec.Replicas =
+				ptr.To(1 + *instance.Spec.ReplicantTemplate.Spec.Replicas)
 			s := &syncReplicantSets{emqxReconciler()}
 			round := newReconcileRound()
 			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
@@ -274,6 +282,122 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 		})
 	})
 
+	Context("rolling update multi-revision", func() {
+		var update, current, broken *appsv1.ReplicaSet
+		var currentReplicants []*corev1.Pod
+		var brokenReplicant *corev1.Pod
+		var resources []client.Object
+
+		const brokenRevision = "broken"
+
+		BeforeEach(func() {
+			instance = emqx.DeepCopy()
+			instance.Namespace = ns.Name
+			instance.Spec.ReplicantTemplate = &crd.EMQXReplicantTemplate{
+				Spec: crd.EMQXReplicantTemplateSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+			}
+			instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{
+				MaxUnavailable: ptr.To(intstr.FromInt(1)),
+				MaxSurge:       ptr.To(intstr.FromInt(0)),
+			}
+
+			current = mkReplicantSet(currentRevision, "emqx", 2)
+			broken = mkReplicantSet(brokenRevision, "emqx:broken", 1)
+			update = mkReplicantSet(updateRevision, "emqx:new", 0)
+			Expect(k8sClient.Create(ctx, current)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, update)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, broken)).Should(Succeed())
+
+			resources = append(resources, current, update, broken)
+
+			currentReplicants = []*corev1.Pod{}
+			for i := range 2 {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName:    current.Name + "-" + fmt.Sprint(i) + "-",
+						Namespace:       ns.Name,
+						Labels:          current.Spec.Template.Labels,
+						OwnerReferences: ownerReferences(current),
+					},
+					Spec: current.Spec.Template.Spec,
+				}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				pod.Status.Conditions = []corev1.PodCondition{mkReadyCondition(corev1.ConditionTrue, time.Minute)}
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+				currentReplicants = append(currentReplicants, pod)
+				resources = append(resources, pod)
+			}
+
+			brokenReplicant = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName:    broken.Name + "-",
+					Namespace:       ns.Name,
+					Labels:          broken.Spec.Template.Labels,
+					OwnerReferences: ownerReferences(broken),
+				},
+				Spec: broken.Spec.Template.Spec,
+			}
+			Expect(k8sClient.Create(ctx, brokenReplicant)).Should(Succeed())
+			resources = append(resources, brokenReplicant)
+
+			current.Status.Replicas = 2
+			current.Status.ReadyReplicas = 2
+			current.Status.AvailableReplicas = 2
+			Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
+			broken.Status.Replicas = 1
+			Expect(k8sClient.Status().Update(ctx, broken)).Should(Succeed())
+
+			instance.Status = crd.EMQXStatus{
+				CoreNodesStatus: crd.CoreNodesStatus{ReadyReplicas: 1},
+				ReplicantNodesStatus: crd.ReplicantNodesStatus{
+					CurrentRevision: currentRevision,
+					CurrentReplicas: 2,
+					UpdateRevision:  updateRevision,
+					ReadyReplicas:   2,
+				},
+				ReplicantNodes: []crd.EMQXNode{
+					{Name: "emqx@10.0.0.1", PodName: currentReplicants[0].Name, Status: "running"},
+					{Name: "emqx@10.0.0.2", PodName: currentReplicants[1].Name, Status: "running"},
+				},
+			}
+		})
+
+		AfterEach(func() {
+			slices.Reverse(resources)
+			for _, resource := range resources {
+				_ = k8sClient.Delete(ctx, resource)
+			}
+		})
+
+		It("cleans up an unavailable outdated revision when maxUnavailable is reached", func() {
+			s := &syncReplicantSets{emqxReconciler()}
+			round := newReconcileRound()
+			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+			Eventually(s.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
+
+			Expect(actualObject(brokenReplicant)).To(
+				HaveField("Annotations", HaveKey(corev1.PodDeletionCost)),
+			)
+			Expect(actualObject(broken)).To(
+				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+			)
+			for _, pod := range currentReplicants {
+				Expect(actualObject(pod)).To(Not(
+					HaveField("Annotations", HaveKey(corev1.PodDeletionCost)),
+				))
+			}
+			Expect(actualObject(current)).To(
+				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(2))),
+			)
+			Expect(actualObject(update)).To(
+				HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(0))),
+			)
+		})
+	})
+
 	Context("scale-up / scale-down", func() {
 		var rs *appsv1.ReplicaSet
 		var replicants []*corev1.Pod
@@ -334,6 +458,8 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 					Spec: rs.Spec.Template.Spec,
 				}
 				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				pod.Status.Conditions = []corev1.PodCondition{mkReadyCondition(corev1.ConditionTrue, 0)}
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
 				replicants = append(replicants, pod)
 				resources = append(resources, pod)
 			}
@@ -664,6 +790,20 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		}
 		Expect(k8sClient.Create(ctx, currentPod)).Should(Succeed())
 
+		currentPod.Status.Conditions = []corev1.PodCondition{
+			{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * time.Minute)),
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, currentPod)).Should(Succeed())
+
+		current.Status.Replicas = 1
+		current.Status.ReadyReplicas = 1
+		current.Status.AvailableReplicas = 1
+		Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
+
 		// Create "update" (new) RS with a different hash label.
 		updateLabels := emqx.DefaultLabelsWith(
 			crd.ReplicantLabels(),
@@ -710,7 +850,11 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		}
 		Expect(k8sClient.Create(ctx, updatePod)).Should(Succeed())
 		updatePod.Status.Conditions = []corev1.PodCondition{
-			{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
+			{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+			},
 		}
 		Expect(k8sClient.Status().Update(ctx, updatePod)).Should(Succeed())
 
@@ -740,10 +884,19 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		}
 	})
 
-	It("replicants not available", func() {
-		round := newReconcileRound()
+	It("update replicants not yet available", func() {
+		instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{
+			MaxUnavailable: ptr.To(intstr.FromInt(0)),
+			MaxSurge:       ptr.To(intstr.FromInt(1)),
+		}
+		updatePod.Status.Conditions = []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()},
+		}
+		Expect(k8sClient.Status().Update(ctx, updatePod)).Should(Succeed())
+		update.Status.ReadyReplicas = 0
 		update.Status.AvailableReplicas = 0
 		Expect(k8sClient.Status().Update(ctx, update)).Should(Succeed())
+		round := newReconcileRound()
 		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
 		s := &syncReplicantSets{emqxReconciler()}
 		admissions := s.outdatedReplicantAdmissions(round, instance)
@@ -757,8 +910,18 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		//    the maxUnavailable budget.
 		// The controller must still include the pod in admissions because it has
 		// the annotation.
+		instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{
+			MaxUnavailable: ptr.To(intstr.FromInt(0)),
+			MaxSurge:       ptr.To(intstr.FromInt(1)),
+		}
 		_ = util.AttachPodAnnotation(currentPod, crd.AnnotationScalingDown, "true")
 		Expect(k8sClient.Update(ctx, currentPod)).Should(Succeed())
+		updatePod.Status.Conditions = []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()},
+		}
+		Expect(k8sClient.Status().Update(ctx, currentPod)).Should(Succeed())
+		current.Status.AvailableReplicas = 0
+		Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
 		update.Status.AvailableReplicas = 0
 		Expect(k8sClient.Status().Update(ctx, update)).Should(Succeed())
 		instance.Status.NodeEvacuations = []crd.NodeEvacuationStatus{
@@ -784,6 +947,10 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 		//    Budget is 0 but the annotation lets it bypass the budget.
 		// The controller must still include the pod in admissions (because it has
 		// the annotation) and allow it to be scheduled for removal.
+		instance.Spec.UpdateStrategy.Replicants = &crd.ReplicantsUpdateStrategy{
+			MaxUnavailable: ptr.To(intstr.FromInt(0)),
+			MaxSurge:       ptr.To(intstr.FromInt(1)),
+		}
 		_ = util.AttachPodAnnotation(currentPod, crd.AnnotationScalingDown, "true")
 		Expect(k8sClient.Update(ctx, currentPod)).Should(Succeed())
 		// Make update RS unavailable so budget = 0.

--- a/test/e2e/emqx_test.go
+++ b/test/e2e/emqx_test.go
@@ -522,6 +522,78 @@ var _ = Describe("EMQX Cluster", Label("emqx"), Ordered, func() {
 		})
 	})
 
+	Context("EMQX Core-Replicant Cluster / Botched Rolling Updates", func() {
+		const (
+			coreReplicas      = 2
+			replicantReplicas = 2
+		)
+
+		It("deploy cluster", func() {
+			By("create EMQX cluster")
+			emqxCR := PatchDocument(
+				FromYAMLFile(emqxCRBasic),
+				withImage(emqxImage),
+				withCores(coreReplicas),
+				withReplicants(replicantReplicas),
+				withConfig(),
+			)
+			Expect(KubectlStdin(emqxCR, "apply", "-f", "-")).To(Succeed())
+			By("wait for EMQX cluster to be ready")
+			Eventually(EMQXReady).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+		})
+
+		It("trigger botched rolling updates", func() {
+			By("create MQTT workload")
+			Expect(Kubectl("apply", "-f", "test/e2e/files/resources/mqttx.yaml")).To(Succeed())
+			defer Kubectl("delete", "-f", "test/e2e/files/resources/mqttx.yaml")
+			Expect(Kubectl("wait", "pod",
+				"--selector=app=mqttx",
+				"--for=condition=Ready",
+				"--timeout=1m",
+			)).To(Succeed(), "Timed out waiting MQTTX to be ready")
+
+			By("lookup initial EMQX status")
+			var statusInitial crd.EMQXStatus
+			Eventually(EMQXReady).Should(Succeed())
+			Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status}")).
+				To(UnmarshalInto(&statusInitial))
+
+			By("specify incorrect EMQX image")
+			changedAt1 := metav1.Now()
+			Expect(Kubectl("patch", "emqx", "emqx",
+				"--type", "json",
+				"--patch", `[
+					{"op": "replace", "path": "/spec/image", "value": "emqx/emqx:6.Y.ZZZ"}
+				]`)).
+				To(Succeed())
+			Consistently(EMQXReady, "30s", "3s").WithArguments(changedAt1).Should(Not(Succeed()))
+
+			Expect(KubectlOut("get", "emqx", "emqx", "-o", "jsonpath={.status}")).
+				To(BeUnmarshalledAs(&crd.EMQXStatus{}, And(
+					HaveField("CoreNodesStatus.ReadyReplicas", Equal(statusInitial.CoreNodesStatus.ReadyReplicas-1)),
+					HaveField("ReplicantNodesStatus.ReadyReplicas", Equal(statusInitial.ReplicantNodesStatus.ReadyReplicas-1)),
+				)), "exactly 1 core and replicant replica went unavailable")
+
+			By("restore correct EMQX image")
+			changedAt2 := metav1.Now()
+			Expect(Kubectl("patch", "emqx", "emqx",
+				"--type", "json",
+				"--patch", `[
+					{"op": "replace", "path": "/spec/image", "value": "`+emqxImageUpgrade+`"}
+				]`)).
+				To(Succeed())
+			Eventually(EMQXReady).WithArguments(changedAt2).Should(Succeed())
+			Eventually(CoresStable).WithArguments(coreReplicas).Should(Succeed())
+			Eventually(ReplicantsStable).WithArguments(replicantReplicas).Should(Succeed())
+		})
+
+		It("delete cluster", func() {
+			Expect(Kubectl("delete", "emqx", "emqx")).To(Succeed())
+		})
+	})
+
 	Context("EMQX Core-Replicant DS-Enabled Cluster", func() {
 		// Initial number of core and replicant replicas:
 		var coreReplicas = 2


### PR DESCRIPTION
## Summary

This PR ensures core-replicant rolling update liveness under tight replicant update strategy: `syncReplicantSets` now adopts Deployment-style rollout policy of allowing removing unready outdated replicants without consuming rollout budgets. To increase consistency of scaling / rollout decisions, availability counters are now computed directly instead of being sourced from ReplicaSet statuses.

Addresses #1214.