### PR TITLE
feat: use requester pod preference for `emqx ctl` as well

### DIFF
--- a/internal/controller/api_requester.go
+++ b/internal/controller/api_requester.go
@@ -32,14 +32,7 @@ func (b *apiRequesterBuilder) forCore(
 	state *reconcileState,
 	filter ...reconcileStatePodFilter,
 ) req.RequesterInterface {
-	filter = append(
-		filter,
-		podsWithRole{crd.RoleCore},
-		podsWithCondition{corev1.ContainersReady},
-		podsAlive{},
-	)
-	pods := state.listPods(filter...)
-	sortByPreference(state, pods)
+	pods := preferredCorePods(state, filter...)
 	for _, pod := range pods {
 		req := b.forPod(pod)
 		if req == nil {
@@ -48,6 +41,21 @@ func (b *apiRequesterBuilder) forCore(
 		return req
 	}
 	return nil
+}
+
+func preferredCorePods(
+	state *reconcileState,
+	filter ...reconcileStatePodFilter,
+) []*corev1.Pod {
+	filter = append(
+		filter,
+		podsWithRole{crd.RoleCore},
+		podsWithCondition{corev1.ContainersReady},
+		podsAlive{},
+	)
+	pods := state.listPods(filter...)
+	sortByPreference(state, pods)
+	return pods
 }
 
 // Prefer lower ordinals by default. If exactly one outdated core remains,

--- a/internal/controller/api_requester_test.go
+++ b/internal/controller/api_requester_test.go
@@ -7,6 +7,7 @@ import (
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	req "github.com/emqx/emqx-operator/internal/requester"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -206,6 +207,24 @@ func TestCorePreference(t *testing.T) {
 
 		assert.NotNil(t, requester)
 		assert.Equal(t, coreSetName+"-2", requester.GetDescription())
+	})
+
+	t.Run("returns eligible pods in preference order for non-HTTP callers", func(t *testing.T) {
+		state := &reconcileState{
+			coreSets: []*appsv1.StatefulSet{coreSet},
+			pods: []*corev1.Pod{
+				mkPod(coreSetName+"-0", "rev-new", "", true, true),
+				mkPod(coreSetName+"-1", "rev-new", "", false, false),
+				mkPod(coreSetName+"-2", "rev-old", "", true, false),
+				mkPod(coreSetName+"-3", "rev-new", "", true, false),
+			},
+		}
+
+		pods := preferredCorePods(state, podsManagedBy{coreSet})
+
+		require.Len(t, pods, 2)
+		assert.Equal(t, coreSetName+"-3", pods[0].Name)
+		assert.Equal(t, coreSetName+"-2", pods[1].Name)
 	})
 
 	t.Run("deprioritizes sole outdated pod over larger fresh ordinal", func(t *testing.T) {

--- a/internal/controller/ds_cleanup_sites.go
+++ b/internal/controller/ds_cleanup_sites.go
@@ -5,7 +5,6 @@ import (
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	"github.com/emqx/emqx-operator/internal/emqx/api"
 	"github.com/emqx/emqx-operator/internal/emqx/ctl"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Responsibilities:
@@ -51,8 +50,7 @@ func (c *dsCleanupSites) reconcile(r *reconcileRound, instance *crd.EMQX) subRes
 
 	// If there's no suitable EMQX API to query, switch to `emqx ctl`.
 	if req == nil {
-		pods := r.state.listPods(&podsManagedBy{coreSet}, &podsWithCondition{corev1.ContainersReady})
-		sortByCreationTimestamp(pods)
+		pods := preferredCorePods(r.state, podsManagedBy{coreSet})
 		if len(pods) == 0 {
 			r.log.V(1).Info("skipping DS site cleanup", "reason", "no core pods")
 			return reconcilePostpone()


### PR DESCRIPTION
## Summary

This PR enables same core pod preference logic employed by EMQX API requester (added in #1246) for `emqx ctl` invocations in `dsCleanupSites` reconcilers. This should help to avoid `dsCleanupSites` reconciler errors caused by races with core set scaling activities.
