### PR TITLE
fix: track retirement through pod ordinal watermark

### DIFF
--- a/api/v3beta1/const.go
+++ b/api/v3beta1/const.go
@@ -31,10 +31,6 @@ const (
 	LabelManagedBy       string = "apps.emqx.io/managed-by" // emqx-operator
 	LabelMriaRole        string = "apps.emqx.io/db-role"    // core, replicant
 	LabelPodTemplateHash string = "apps.emqx.io/pod-template-hash"
-
-	// LabelForceRetirement is a label intended for users to force Operator to
-	// skip normal scale-down retirement guardrails.
-	LabelForceRetirement string = "apps.emqx.io/force-retirement" // true
 )
 
 const (
@@ -44,11 +40,11 @@ const (
 	// Pods with this annotation bypass the maxUnavailable budget on subsequent reconcile
 	// iterations, preventing deadlocks when evacuation makes the pod unavailable.
 	AnnotationScalingDown string = "apps.emqx.io/scaling-down"
-)
 
-const (
-	// finalizers
-	FinalizerScaleDownRetirement string = "apps.emqx.io/scale-down-retirement"
+	// StatefulSet annotations controlling reuse of scaled-down core pod ordinals.
+	// Lowering the watermark to the current replica count unconditionally authorizes reuse.
+	AnnotationCoreRetirementOrdinalWatermark string = "apps.emqx.io/core-retirement-pod-ordinal-watermark"
+	AnnotationCoreRetirementOrdinalUpdatedAt string = "apps.emqx.io/core-retirement-pod-ordinal-updated-at"
 )
 
 const (

--- a/internal/controller/add_core_set.go
+++ b/internal/controller/add_core_set.go
@@ -34,6 +34,7 @@ func (a *addCoreSet) reconcile(r *reconcileRound, instance *crd.EMQX) subResult 
 			"statefulSet", klog.KObj(coreSet),
 			"reason", "no existing statefulSet",
 		)
+		util.AttachAnnotations(coreSet, initialCoreSetRetirementState(coreSet).annotations())
 		if err := a.Create(r.ctx, coreSet); err != nil {
 			if k8sErrors.IsAlreadyExists(emperror.Cause(err)) {
 				return reconcileRequeue()
@@ -42,6 +43,14 @@ func (a *addCoreSet) reconcile(r *reconcileRound, instance *crd.EMQX) subResult 
 		}
 		// Force Requeue to give StatefulSet controller time to reflect status.
 		return reconcileRequeueAfter(time.Second)
+	} else {
+		// StatefulSet already exists.
+		// Preserve retirement annotations.
+		util.UnsetAnnotations(coreSet, coreSetRetirementAnnotations...)
+		util.AttachAnnotations(coreSet, util.PeekAnnotations(existing, coreSetRetirementAnnotations...))
+		// Preserve the live replica count.
+		// This update should not bypass syncCoreSet reusable-ordinal admission check.
+		coreSet.Spec.Replicas = existing.Spec.Replicas
 	}
 
 	// StatefulSet exists.

--- a/internal/controller/add_core_set_suite_test.go
+++ b/internal/controller/add_core_set_suite_test.go
@@ -1,11 +1,15 @@
 package controller
 
 import (
+	"time"
+
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
 	. "github.com/emqx/emqx-operator/test/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,8 +19,15 @@ import (
 var _ = DescribeClientFaultMatrix("Reconciler addCoreSet", Ordered, func() {
 	var ns *corev1.Namespace
 	var instance *crd.EMQX
-	var a *addCoreSet
-	var round *reconcileRound
+
+	listCoreSets := func() []appsv1.StatefulSet {
+		list := &appsv1.StatefulSetList{}
+		_ = k8sClient.List(ctx, list,
+			client.InNamespace(instance.Namespace),
+			client.MatchingLabels(instance.DefaultLabelsWith(crd.CoreLabels())),
+		)
+		return list.Items
+	}
 
 	BeforeAll(func() {
 		// Create namespace:
@@ -30,37 +41,78 @@ var _ = DescribeClientFaultMatrix("Reconciler addCoreSet", Ordered, func() {
 		// Create instance:
 		instance = emqx.DeepCopy()
 		instance.Namespace = ns.Name
+		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(2))
 		Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 	})
 
-	BeforeEach(func() {
-		// Instantiate reconciler:
-		a = &addCoreSet{emqxReconciler()}
-		round = newReconcileRound()
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+	AfterEach(func() {
+		Expect(k8sClient.DeleteAllOf(ctx, &appsv1.StatefulSet{}, client.InNamespace(ns.Name))).
+			To(Succeed())
 	})
 
 	It("should create statefulSet", func() {
-		Eventually(a.reconcile).WithArguments(round, instance).
+		round := newReconcileRound()
+		a := &addCoreSet{emqxReconciler()}
+		Eventually(runRoundReconcile).WithArguments(round, instance, a).
 			Should(BeSuccessfulReconcile())
-		Expect(coreSets(instance)).To(ConsistOf(
-			HaveField("Spec.Template.Spec.Containers", ConsistOf(
-				HaveField("Image", Equal(instance.Spec.Image)))),
+		Expect(listCoreSets()).To(ConsistOf(
+			And(
+				HaveField("Spec.Template.Spec.Containers", ConsistOf(
+					HaveField("Image", Equal(instance.Spec.Image)))),
+				HaveField("Annotations", And(
+					HaveKey(crd.AnnotationCoreRetirementOrdinalWatermark),
+					HaveKey(crd.AnnotationCoreRetirementOrdinalUpdatedAt),
+				)),
+			),
 		))
 	})
 
 	It("change image updates existing statefulSet in place", func() {
+		// Create initial coreSet:
+		round := newReconcileRound()
+		a := &addCoreSet{emqxReconciler()}
+		Eventually(runRoundReconcile).WithArguments(round, instance, a).
+			Should(BeSuccessfulReconcile())
+		// Simulate scaling and retirement activities in the meantime:
+		coreSets := listCoreSets()
+		Expect(coreSets).To(HaveLen(1))
+		coreSet := &coreSets[0]
+		retirement := &coreSetRetirement{
+			watermark: 42,
+			updatedAt: time.Now().Add(-time.Minute),
+		}
+		coreSet.Spec.Replicas = ptr.To(int32(5))
+		util.AttachAnnotations(coreSet, retirement.annotations())
+		Expect(k8sClient.Update(ctx, coreSet)).To(Succeed())
+		// Update container image:
 		instance.Spec.Image = "emqx/emqx"
-		Eventually(a.reconcile).WithArguments(round, instance).
+		Eventually(runRoundReconcile).WithArguments(round, instance, a).
 			Should(BeSuccessfulReconcile())
 		Expect(actualObject(instance)).To(And(
 			HaveCondition(crd.Ready, HaveField("Status", Equal(metav1.ConditionFalse))),
 			HaveCondition(crd.CoreNodesProgressing, HaveField("Status", Equal(metav1.ConditionTrue))),
 		))
-		Expect(coreSets(instance)).To(ConsistOf(
+		Eventually(ensureReconcileState).WithArguments(round, instance).
+			Should(Succeed())
+		// Postconditions:
+		// - container image is updated in place
+		// - number of replicas is unchanged
+		// - coreSet retirement annotations preserved
+		Expect(listCoreSets()).To(ConsistOf(And(
+			HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(5))),
 			HaveField("Spec.Template.Spec.Containers", ConsistOf(
 				HaveField("Image", Equal("emqx/emqx")))),
-		))
+			HaveField("Annotations", And(
+				HaveKeyWithValue(
+					crd.AnnotationCoreRetirementOrdinalWatermark,
+					"42",
+				),
+				HaveKeyWithValue(
+					crd.AnnotationCoreRetirementOrdinalUpdatedAt,
+					retirement.updatedAt.UTC().Format(time.RFC3339Nano),
+				),
+			)),
+		)))
 	})
 
 	AfterAll(func() {
@@ -68,12 +120,3 @@ var _ = DescribeClientFaultMatrix("Reconciler addCoreSet", Ordered, func() {
 		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
 	})
 })
-
-func coreSets(instance *crd.EMQX) []appsv1.StatefulSet {
-	list := &appsv1.StatefulSetList{}
-	_ = k8sClient.List(ctx, list,
-		client.InNamespace(instance.Namespace),
-		client.MatchingLabels(instance.DefaultLabelsWith(crd.CoreLabels())),
-	)
-	return list.Items
-}

--- a/internal/controller/add_core_set_test.go
+++ b/internal/controller/add_core_set_test.go
@@ -45,7 +45,7 @@ func TestGetNewStatefulSet(t *testing.T) {
 		conf, _ := config.EMQXConfigWithDefaults(emqx.Spec.Config.Data)
 		got := newStatefulSet(emqx, conf)
 
-		assert.Equal(t, emqx.Spec.CoreTemplate.Annotations, got.Annotations)
+		assert.Equal(t, "core-annotation-value", got.Annotations["core-annotation-key"])
 		assert.Equal(t, "core-label-value", got.Labels["core-label-key"])
 		assert.Equal(t, "emqx", got.Labels[crd.LabelInstance])
 		assert.Equal(t, "emqx-operator", got.Labels[crd.LabelManagedBy])

--- a/internal/controller/add_service_suite_test.go
+++ b/internal/controller/add_service_suite_test.go
@@ -91,20 +91,22 @@ var _ = DescribeClientFaultMatrix("Reconciler addService", Ordered, func() {
 		}
 
 		round := newReconcileRoundWithRequester(validConfigRequester)
-		round.state.replicantSets = []*appsv1.ReplicaSet{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "emqx-rev-current",
-					Labels: map[string]string{crd.LabelPodTemplateHash: "rev-current"},
+		round.state = &reconcileState{
+			replicantSets: []*appsv1.ReplicaSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "emqx-rev-current",
+						Labels: map[string]string{crd.LabelPodTemplateHash: "rev-current"},
+					},
+					Status: appsv1.ReplicaSetStatus{ReadyReplicas: 1},
 				},
-				Status: appsv1.ReplicaSetStatus{ReadyReplicas: 1},
-			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "emqx-rev-update",
-					Labels: map[string]string{crd.LabelPodTemplateHash: "rev-update"},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "emqx-rev-update",
+						Labels: map[string]string{crd.LabelPodTemplateHash: "rev-update"},
+					},
+					Status: appsv1.ReplicaSetStatus{ReadyReplicas: 0},
 				},
-				Status: appsv1.ReplicaSetStatus{ReadyReplicas: 0},
 			},
 		}
 

--- a/internal/controller/core_set_retirement.go
+++ b/internal/controller/core_set_retirement.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025-2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// coreSetRetirement serializes reuse of core StatefulSet ordinals after
+// scale-down. For a StatefulSet with N replicas, ordinals in [N, watermark)
+// are retiring and must not be reused.
+//   - Watermark equal to N means that no ordinal is awaiting retirement.
+//   - Values above N may represent multiple retirements that are drained from
+//     the highest ordinal down.
+type coreSetRetirement struct {
+	// watermark is the exclusive upper bound of the retiring ordinal range.
+	// User is allowed to overwrite it as an escape hatch for stuck retirement
+	// progress, implementation must anticipate this.
+	watermark int32
+	// updatedAt marks the beginning of the current retirement epoch for
+	// retirement deadlines. It is deliberately preserved while a multi-ordinal
+	// range is drained.
+	updatedAt time.Time
+}
+
+var coreSetRetirementAnnotations = []string{
+	crd.AnnotationCoreRetirementOrdinalWatermark,
+	crd.AnnotationCoreRetirementOrdinalUpdatedAt,
+}
+
+// loadCoreSetRetirement initializes missing StatefulSet annotations and loads
+// the reusable core pod ordinal state for the rest of the reconciliation round.
+type loadCoreSetRetirement struct {
+	*EMQXReconciler
+}
+
+func (l *loadCoreSetRetirement) reconcile(r *reconcileRound, _ *crd.EMQX) subResult {
+	coreSet := r.state.coreSet()
+	if coreSet == nil {
+		return subResult{}
+	}
+	state, err := readCoreSetRetirementState(coreSet)
+	if err != nil {
+		return reconcileError(err)
+	}
+	if state == nil || state.watermark < util.NumReplicas(coreSet) {
+		r.coreRetirement = initialCoreSetRetirementState(coreSet)
+		util.AttachAnnotations(coreSet, r.coreRetirement.annotations())
+		if err := l.Client.Update(r.ctx, coreSet); err != nil {
+			return reconcileError(fmt.Errorf("failed to reinitialize retirement state: %w", err))
+		}
+		return subResult{}
+	}
+
+	r.coreRetirement = state
+	return subResult{}
+}
+
+func loadCoreSetRetirementState(r *reconcileRound) (*coreSetRetirement, error) {
+	coreSet := r.state.coreSet()
+	if coreSet == nil {
+		return nil, nil
+	}
+	state, err := readCoreSetRetirementState(coreSet)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+func newCoreSetRetirementState(watermark int32) *coreSetRetirement {
+	return &coreSetRetirement{
+		watermark: watermark,
+		updatedAt: time.Now(),
+	}
+}
+
+func initialCoreSetRetirementState(coreSet *appsv1.StatefulSet) *coreSetRetirement {
+	return newCoreSetRetirementState(util.NumReplicas(coreSet))
+}
+
+func readCoreSetRetirementState(coreSet *appsv1.StatefulSet) (*coreSetRetirement, error) {
+	var err error
+	annotations := coreSet.GetAnnotations()
+	watermarkString, hasWatermark := annotations[crd.AnnotationCoreRetirementOrdinalWatermark]
+	updatedAtString, hasUpdatedAt := annotations[crd.AnnotationCoreRetirementOrdinalUpdatedAt]
+
+	if !hasWatermark || !hasUpdatedAt {
+		return nil, nil
+	}
+
+	watermark, err := strconv.ParseInt(watermarkString, 10, 32)
+	if err != nil || watermark < 0 {
+		return nil, fmt.Errorf("invalid reusable core pod ordinal watermark %q", watermarkString)
+	}
+	updatedAt, err := time.Parse(time.RFC3339Nano, updatedAtString)
+	if err != nil {
+		return nil, fmt.Errorf("invalid reusable core pod ordinal update timestamp %q", updatedAtString)
+	}
+
+	return &coreSetRetirement{watermark: int32(watermark), updatedAt: updatedAt}, nil
+}
+
+func (s *coreSetRetirement) annotations() map[string]string {
+	return map[string]string{
+		crd.AnnotationCoreRetirementOrdinalWatermark: strconv.FormatInt(int64(s.watermark), 10),
+		crd.AnnotationCoreRetirementOrdinalUpdatedAt: s.updatedAt.UTC().Format(time.RFC3339Nano),
+	}
+}
+
+func (s *coreSetRetirement) isRetiringOrdinal(coreSet *appsv1.StatefulSet, ordinal int) bool {
+	return ordinal >= int(util.NumReplicas(coreSet)) && ordinal < int(s.watermark)
+}

--- a/internal/controller/core_set_retirement_suite_test.go
+++ b/internal/controller/core_set_retirement_suite_test.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"time"
+
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeClientFaultMatrix("Reconciler loadCoreSetRetirement", Ordered, func() {
+	var ns *corev1.Namespace
+	var instance *crd.EMQX
+
+	mkCoreSet := func(name string, replicas int32) *appsv1.StatefulSet {
+		labels := instance.DefaultLabelsWith(crd.CoreLabels())
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: instance.Namespace,
+				Labels:    labels,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: name,
+				Replicas:    ptr.To(replicas),
+				Selector:    &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "emqx", Image: "emqx"}},
+					},
+				},
+			},
+		}
+	}
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "controller-core-set-retirement-test-",
+			Labels:       map[string]string{"test": "e2e"},
+		}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		instance = emqx.DeepCopy()
+		instance.Namespace = ns.Name
+	})
+
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.DeleteAllOf(ctx, &appsv1.StatefulSet{}, client.InNamespace(ns.Name))).
+			To(Succeed())
+	})
+
+	DescribeTable("initializes missing annotations",
+		func(name string, annotations map[string]string) {
+			coreSet := mkCoreSet(name, 3)
+			coreSet.Annotations = annotations
+			Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+
+			round := newReconcileRound()
+			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+			reconciler := &loadCoreSetRetirement{emqxReconciler()}
+			Eventually(reconciler.reconcile).WithArguments(round, instance).
+				Should(BeSuccessfulReconcile())
+
+			actual, err := actualObject(coreSet)
+			Expect(err).NotTo(HaveOccurred())
+			state, err := readCoreSetRetirementState(actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).NotTo(BeNil())
+			Expect(state.watermark).To(Equal(int32(3)))
+			Expect(state.updatedAt).NotTo(BeZero())
+		},
+		Entry("when both are absent", "emqx-core-missing-pair", nil),
+		Entry("when the pair is incomplete", "emqx-core-incomplete-pair", map[string]string{
+			crd.AnnotationCoreRetirementOrdinalWatermark: "1",
+		}),
+	)
+
+	It("normalizes a watermark below the live replica count", func() {
+		coreSet := mkCoreSet("emqx-core-low-watermark", 3)
+		startedAt := time.Now().Add(-time.Hour).Truncate(time.Nanosecond)
+		retirement := &coreSetRetirement{watermark: 1, updatedAt: startedAt}
+		util.AttachAnnotations(coreSet, retirement.annotations())
+		Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+
+		round := newReconcileRound()
+		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		reconciler := &loadCoreSetRetirement{emqxReconciler()}
+		Eventually(reconciler.reconcile).WithArguments(round, instance).
+			Should(BeSuccessfulReconcile())
+
+		actual, err := actualObject(coreSet)
+		Expect(err).NotTo(HaveOccurred())
+		state, err := readCoreSetRetirementState(actual)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.watermark).To(Equal(int32(3)))
+		Expect(state.updatedAt).To(BeTemporally(">", startedAt))
+	})
+
+	It("rejects invalid annotations", func() {
+		coreSet := mkCoreSet("emqx-core-invalid-retirement-state", 3)
+		coreSet.Annotations = map[string]string{
+			crd.AnnotationCoreRetirementOrdinalWatermark: "invalid",
+			crd.AnnotationCoreRetirementOrdinalUpdatedAt: "invalid",
+		}
+		Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+
+		round := newReconcileRound()
+		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		reconciler := &loadCoreSetRetirement{emqxReconciler()}
+		result := reconciler.reconcile(round, instance)
+		Expect(result.err).To(MatchError(ContainSubstring("invalid reusable core pod ordinal watermark")))
+		Expect(round.coreRetirement).To(BeNil())
+	})
+})

--- a/internal/controller/core_set_retirement_test.go
+++ b/internal/controller/core_set_retirement_test.go
@@ -1,0 +1,45 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestCoreSetRetirementState(t *testing.T) {
+	coreSet := &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(4))}}
+	now := time.Now().Truncate(time.Nanosecond)
+	retirement := &coreSetRetirement{watermark: 5, updatedAt: now}
+	util.AttachAnnotations(coreSet, retirement.annotations())
+
+	state, err := readCoreSetRetirementState(coreSet)
+	require.NoError(t, err)
+	assert.Equal(t, int32(5), state.watermark)
+	assert.Equal(t, now.UTC(), state.updatedAt)
+
+	coreSet.Annotations[crd.AnnotationCoreRetirementOrdinalWatermark] = "6"
+	state, err = readCoreSetRetirementState(coreSet)
+	require.NoError(t, err)
+	assert.Equal(t, int32(6), state.watermark)
+
+	coreSet.Annotations[crd.AnnotationCoreRetirementOrdinalWatermark] = "-1"
+	_, err = readCoreSetRetirementState(coreSet)
+	require.ErrorContains(t, err, "invalid reusable core pod ordinal watermark")
+}
+
+func TestRetiringCorePodOrdinalRange(t *testing.T) {
+	coreSet := &appsv1.StatefulSet{Spec: appsv1.StatefulSetSpec{Replicas: ptr.To(int32(3))}}
+	state := &coreSetRetirement{watermark: 6}
+
+	assert.False(t, state.isRetiringOrdinal(coreSet, 2))
+	assert.True(t, state.isRetiringOrdinal(coreSet, 3))
+	assert.True(t, state.isRetiringOrdinal(coreSet, 4))
+	assert.True(t, state.isRetiringOrdinal(coreSet, 5))
+	assert.False(t, state.isRetiringOrdinal(coreSet, 6))
+}

--- a/internal/controller/ds_update_replica_sets.go
+++ b/internal/controller/ds_update_replica_sets.go
@@ -52,7 +52,6 @@ func (u *dsUpdateReplicaSets) reconcile(r *reconcileRound, instance *crd.EMQX) s
 
 	// Compute the current sites.
 	currentSites := r.dsReplication.TargetSites()
-
 	// Compute the target sites.
 	targetSites := []string{}
 	for _, site := range r.dsCluster.Sites {
@@ -65,9 +64,8 @@ func (u *dsUpdateReplicaSets) reconcile(r *reconcileRound, instance *crd.EMQX) s
 			continue
 		}
 		// Exclude retiring core nodes:
-		pod := r.state.podWithName(nodeName.podName)
 		ordinal := util.PodOrdinal(nodeName.podName)
-		if pod != nil && isPodScaleDownRetiring(pod) {
+		if r.coreRetirement.isRetiringOrdinal(coreSet, ordinal) {
 			continue
 		}
 		// Exclude unrecognizable core pods:

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -52,6 +52,8 @@ type reconcileRound struct {
 	requester apiRequester
 	// Populated by loadState reconciler:
 	state *reconcileState
+	// Populated by loadCoreSetRetirement reconciler:
+	coreRetirement *coreSetRetirement
 	// Populated by dsLoadClusterState reconciler:
 	dsCluster     *api.DSCluster
 	dsReplication *api.DSReplicationStatus
@@ -157,6 +159,7 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		&addCoreSet{r},
 		&addReplicantSet{r},
 		&addService{r},
+		&loadCoreSetRetirement{r},
 		&dsLoadClusterState{r},
 		&dsCleanupSites{r},
 		&dsUpdateReplicaSets{r},

--- a/internal/controller/retire_core_pods.go
+++ b/internal/controller/retire_core_pods.go
@@ -7,9 +7,9 @@ import (
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	util "github.com/emqx/emqx-operator/internal/controller/util"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type forcedRetirementCondition int
@@ -19,17 +19,18 @@ const (
 	condFallback
 )
 
-// Kubernetes sets DeletionTimestamp to the scheduled end of graceful termination,
-// so retirement timeouts measured from it include the pod's grace period.
 var corePodForcedRetirementTimeout = map[forcedRetirementCondition]time.Duration{
-	// causeEMQXAPIUnavailable applies after both pod deletion and continuous EMQX API unavailability have begun.
+	// condEMQXAPIUnavailable applies after both ordinal retirement and continuous EMQX API unavailability have begun.
 	condEMQXAPIUnavailable: time.Minute,
-	// causeFallback defines the unconditional hard retirement deadline.
+	// condFallback defines the unconditional hard retirement deadline.
+	// The hard fallback timeout bypasses membership, DS, and PVC checks,
+	// but still requires the pod to be absent.
 	condFallback: time.Minute * 10,
 }
 
-// retireCorePods releases scale-down pod finalizers after other reconcilers
-// have removed the old node identity from EMQX membership and DS metadata.
+// retireCorePods normally advances the reusable ordinal watermark after the
+// retiring core has left EMQX membership and DS metadata, and its pod and PVCs
+// are gone.
 type retireCorePods struct {
 	*EMQXReconciler
 }
@@ -40,110 +41,142 @@ func (s *retireCorePods) reconcile(r *reconcileRound, instance *crd.EMQX) subRes
 		return subResult{}
 	}
 
-	for _, pod := range r.state.podsManagedBy(coreSet) {
-		// No finalizer attached, skip:
-		if !controllerutil.ContainsFinalizer(pod, crd.FinalizerScaleDownRetirement) {
-			continue
-		}
-
-		// Has finalizer but no deletion was requested, reconcile:
-		if pod.DeletionTimestamp == nil {
-			// If this replica is in the range of desired number of replicas, drop the finalizer:
-			ordinal := util.PodOrdinal(pod.Name)
-			if ordinal >= 0 && ordinal < int(instance.Spec.NumCoreReplicas()) {
-				err := removeScaleDownRetirementFinalizer(r.ctx, s.Client, pod)
-				if err != nil {
-					return subResult{err: err}
-				}
-			}
-			continue
-		}
-
-		ready, reason := s.corePodRetirementReady(r, instance, pod)
-		if !ready {
-			r.log.V(1).Info("core pod retirement pending",
-				"reason", reason,
-				"pod", klog.KObj(pod),
-			)
-			continue
-		}
-
-		err := removeScaleDownRetirementFinalizer(r.ctx, s.Client, pod)
-		if err == nil {
-			logArgs := []any{"pod", klog.KObj(pod)}
-			if reason != "" {
-				logArgs = append(logArgs, "reason", reason)
-				s.EventRecorder.Eventf(
-					instance,
-					corev1.EventTypeWarning,
-					"CorePodForceRetired",
-					"Core pod %s retirement guardrails bypassed: %s",
-					pod.Name,
-					reason,
-				)
-			} else {
-				s.EventRecorder.Eventf(
-					instance,
-					corev1.EventTypeNormal,
-					"CorePodRetired",
-					"Core pod %s retired",
-					pod.Name,
-				)
-			}
-			r.log.V(1).Info("core pod retired", logArgs...)
-		} else {
-			return subResult{err: err}
-		}
+	currentReplicas := util.NumReplicas(coreSet)
+	if r.coreRetirement.watermark == currentReplicas {
+		return subResult{}
 	}
 
+	ordinal := int(r.coreRetirement.watermark - 1)
+	podName := fmt.Sprintf("%s-%d", coreSet.Name, ordinal)
+	podObject := client.ObjectKey{Namespace: coreSet.Namespace, Name: podName}
+
+	if pod := r.state.podWithName(podName); pod != nil {
+		return reconcilePostpone()
+	}
+
+	decision := s.corePodRetirementReady(r, instance, podName)
+	if decision.err != nil {
+		return reconcileError(decision.err)
+	}
+	if !decision.ready {
+		r.log.V(1).Info("core pod retirement pending", "reason", decision.reason, "pod", podObject)
+		return reconcilePostpone()
+	}
+
+	r.coreRetirement.watermark -= 1
+	util.AttachAnnotations(coreSet, r.coreRetirement.annotations())
+	if err := s.Client.Update(r.ctx, coreSet); err != nil {
+		return reconcileError(fmt.Errorf("failed to advance reusable core pod ordinal watermark: %w", err))
+	}
+
+	logArgs := []any{"pod", podObject}
+	if decision.reason != "" {
+		logArgs = append(logArgs, "reason", decision.reason)
+		s.EventRecorder.Eventf(
+			instance,
+			corev1.EventTypeWarning,
+			"CorePodForceRetired",
+			"Core pod %s retirement guardrails bypassed: %s",
+			podName,
+			decision.reason,
+		)
+	} else {
+		s.EventRecorder.Eventf(
+			instance,
+			corev1.EventTypeNormal,
+			"CorePodRetired",
+			"Core pod %s retired and its ordinal is reusable",
+			podName,
+		)
+	}
+	r.log.V(1).Info("core pod ordinal made reusable", logArgs...)
 	return subResult{}
 }
 
-func (*retireCorePods) corePodRetirementReady(r *reconcileRound, instance *crd.EMQX, pod *corev1.Pod) (bool, string) {
-	now := time.Now()
+type retirementDecision struct {
+	ready  bool
+	reason string
+	err    error
+}
 
-	if pod.Labels[crd.LabelForceRetirement] == "true" {
-		return true, "retirement forced"
-	}
+func retirementReady(reason string) retirementDecision {
+	return retirementDecision{true, reason, nil}
+}
+
+func retirementPending(reason string) retirementDecision {
+	return retirementDecision{false, reason, nil}
+}
+
+func (s *retireCorePods) corePodRetirementReady(
+	r *reconcileRound,
+	instance *crd.EMQX,
+	podName string,
+) retirementDecision {
+	now := time.Now()
+	updatedAt := r.coreRetirement.updatedAt
 
 	fallbackTimeout := corePodForcedRetirementTimeout[condFallback]
-	fallbackDeadline := pod.DeletionTimestamp.Add(fallbackTimeout)
+	fallbackDeadline := updatedAt.Add(fallbackTimeout)
 	if now.After(fallbackDeadline) {
 		deadlineString := fallbackDeadline.UTC().Format(time.RFC3339)
-		return true, fmt.Sprintf("fallback timeout exceeded at %s", deadlineString)
+		return retirementReady(fmt.Sprintf("fallback timeout exceeded at %s", deadlineString))
+	}
+
+	hasPVCs, err := s.corePodHasPVCs(r, podName)
+	if err != nil {
+		return retirementDecision{false, "", err}
+	}
+	if hasPVCs {
+		return retirementPending("pod still has live PVCs")
 	}
 
 	_, apiCondition := instance.Status.GetCondition(crd.EMQXAPIAvailable)
 	if apiCondition != nil && apiCondition.Status == metav1.ConditionFalse {
 		unavailableSince := apiCondition.LastTransitionTime.Time
-		if pod.DeletionTimestamp.After(unavailableSince) {
-			unavailableSince = pod.DeletionTimestamp.Time
+		if updatedAt.After(unavailableSince) {
+			unavailableSince = updatedAt
 		}
 		apiTimeout := corePodForcedRetirementTimeout[condEMQXAPIUnavailable]
 		apiDeadline := unavailableSince.Add(apiTimeout)
 		if now.After(apiDeadline) {
 			deadlineString := apiDeadline.UTC().Format(time.RFC3339)
-			return true, fmt.Sprintf("EMQX API unavailability timeout exceeded at %s", deadlineString)
+			return retirementReady(fmt.Sprintf("EMQX API unavailability timeout exceeded at %s", deadlineString))
 		}
 	}
 
 	if !instance.Status.HasClusterMembership() {
-		return false, "cluster membership state is unknown"
+		return retirementPending("cluster membership state is unknown")
 	}
-
-	node := instance.Status.FindNodeByPodName(pod.Name, crd.RoleCore)
-	if node != nil {
-		return false, fmt.Sprintf("node %s is still present in cluster status", node.Name)
+	if node := instance.Status.FindNodeByPodName(podName, crd.RoleCore); node != nil {
+		return retirementPending(fmt.Sprintf("node %s is still present in cluster status", node.Name))
 	}
-
 	if r.dsCluster == nil {
-		return false, "DS cluster state is not loaded"
+		return retirementPending("DS cluster state is not loaded")
+	}
+	if site := r.dsCluster.FindSite(constructNodeName(podName, instance)); site != nil {
+		return retirementPending(fmt.Sprintf("DS site %s for node %s is still present", site.ID, site.Node))
 	}
 
-	site := r.dsCluster.FindSite(constructNodeName(pod.Name, instance))
-	if site != nil {
-		return false, fmt.Sprintf("DS site %s for node %s is still present", site.ID, site.Node)
-	}
+	return retirementReady("")
+}
 
-	return true, ""
+func (s *retireCorePods) corePodHasPVCs(r *reconcileRound, podName string) (bool, error) {
+	coreSet := r.state.coreSet()
+	for _, claim := range coreSet.Spec.VolumeClaimTemplates {
+		pvc := &corev1.PersistentVolumeClaim{}
+		key := client.ObjectKey{
+			Name:      fmt.Sprintf("%s-%s", claim.Name, podName),
+			Namespace: coreSet.Namespace,
+		}
+		err := s.Client.Get(r.ctx, key, pvc)
+		switch {
+		case err == nil:
+			return true, nil
+		case k8sErrors.IsNotFound(err):
+			continue
+		default:
+			return true, fmt.Errorf("failed to get core pod PVC %s: %w", key.Name, err)
+		}
+	}
+	return false, nil
 }

--- a/internal/controller/retire_core_pods_suite_test.go
+++ b/internal/controller/retire_core_pods_suite_test.go
@@ -1,0 +1,176 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
+	"github.com/emqx/emqx-operator/internal/emqx/api"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = DescribeClientFaultMatrix("Reconciler retireCorePods", Ordered, func() {
+	var ns *corev1.Namespace
+	var instance *crd.EMQX
+
+	var pvcSpec = corev1.PersistentVolumeClaimSpec{
+		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{
+			corev1.ResourceStorage: resource.MustParse("1Mi"),
+		}},
+	}
+
+	mkCoreSet := func(name string, replicas int32) *appsv1.StatefulSet {
+		labels := instance.DefaultLabelsWith(crd.CoreLabels())
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: instance.Namespace,
+				Labels:    labels,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: name,
+				Replicas:    ptr.To(replicas),
+				Selector:    &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "emqx", Image: "emqx"}},
+					},
+				},
+			},
+		}
+	}
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "controller-retire-core-pods-test-",
+			Labels:       map[string]string{"test": "e2e"},
+		}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		instance = emqx.DeepCopy()
+		instance.Namespace = ns.Name
+		instance.Status.CoreNodes = []crd.EMQXNode{{
+			Name: "emqx@surviving-core", PodName: "surviving-core", Role: crd.RoleCore,
+		}}
+	})
+
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
+
+	DescribeTable("advances the watermark only after PVC deletion",
+		func(name string, pvcPresent bool, expectedWatermark int32, expectRequeue bool) {
+			coreSet := mkCoreSet(name, 4)
+			coreSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{{
+				ObjectMeta: metav1.ObjectMeta{Name: "emqx-core-data"},
+				Spec:       pvcSpec,
+			}}
+			util.AttachAnnotations(coreSet, newCoreSetRetirementState(5).annotations())
+			Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+			DeferCleanupObject(coreSet)
+
+			if pvcPresent {
+				podName := fmt.Sprintf("%s-4", coreSet.Name)
+				pvc := &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: "emqx-core-data-" + podName, Namespace: ns.Name},
+					Spec:       pvcSpec,
+				}
+				Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+				DeferCleanupObject(pvc)
+			}
+
+			round := newReconcileRound()
+			round.dsCluster = &api.DSCluster{}
+			reconciler := &retireCorePods{emqxReconciler()}
+			Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+				Should(BeSuccessfulReconcile(Postponed(expectRequeue)))
+
+			actual, err := actualObject(coreSet)
+			Expect(err).NotTo(HaveOccurred())
+			state, err := readCoreSetRetirementState(actual)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state.watermark).To(Equal(expectedWatermark))
+		},
+		Entry("when the PVC is absent", "emqx-core-pvc-absent", false, int32(4), false),
+		Entry("waits while the PVC exists", "emqx-core-pvc-present", true, int32(5), true),
+	)
+
+	It("drains the highest ordinal and preserves the timestamp", func() {
+		coreSet := mkCoreSet("emqx-core-drain-highest", 3)
+		coreSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "emqx-core-data"},
+			Spec:       pvcSpec,
+		}}
+		startedAt := time.Now().Add(-corePodForcedRetirementTimeout[condFallback] - time.Second)
+		retirement := &coreSetRetirement{5, startedAt}
+		util.AttachAnnotations(coreSet, retirement.annotations())
+		Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+		DeferCleanupObject(coreSet)
+
+		round := newReconcileRound()
+		reconciler := &retireCorePods{emqxReconciler()}
+		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+			Should(BeSuccessfulReconcile())
+
+		actual, err := actualObject(coreSet)
+		Expect(err).NotTo(HaveOccurred())
+		state, err := readCoreSetRetirementState(actual)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.watermark).To(Equal(int32(4)))
+		Expect(state.updatedAt).To(Equal(startedAt.UTC()))
+	})
+
+	It("waits for pod absence without deleting the pod", func() {
+		coreSet := mkCoreSet("emqx-core-pod-present", 4)
+		coreSet.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{{
+			ObjectMeta: metav1.ObjectMeta{Name: "emqx-core-data"},
+			Spec:       pvcSpec,
+		}}
+		startedAt := time.Now().Add(-corePodForcedRetirementTimeout[condFallback] - time.Second)
+		retirement := &coreSetRetirement{5, startedAt}
+		util.AttachAnnotations(coreSet, retirement.annotations())
+		Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+		DeferCleanupObject(coreSet)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      coreSet.Name + "-4",
+				Namespace: ns.Name,
+				Labels:    instance.DefaultLabelsWith(crd.CoreLabels()),
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "emqx", Image: "emqx"}}},
+		}
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		DeferCleanupObject(pod)
+
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "emqx-core-data-" + pod.Name, Namespace: ns.Name},
+			Spec:       pvcSpec,
+		}
+		Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+		DeferCleanupObject(pvc)
+
+		round := newReconcileRound()
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
+		reconciler := &retireCorePods{emqxReconciler()}
+		result := reconciler.reconcile(round, instance)
+
+		Expect(result).To(BeSuccessfulReconcile())
+		Expect(result.needRequeue).To(BeTrue())
+		Expect(actualObject(pod)).NotTo(BeNil())
+		actual, err := actualObject(coreSet)
+		Expect(err).NotTo(HaveOccurred())
+		state, err := readCoreSetRetirementState(actual)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.watermark).To(Equal(int32(5)))
+	})
+})

--- a/internal/controller/retire_core_pods_test.go
+++ b/internal/controller/retire_core_pods_test.go
@@ -6,17 +6,16 @@ import (
 
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestCorePodRetirementReadyOverrides(t *testing.T) {
+func TestCoreOrdinalRetirementReadyTimeouts(t *testing.T) {
 	now := time.Now()
 
 	for _, tc := range []struct {
 		name          string
-		labels        map[string]string
-		deletedAt     time.Time
+		startedAt     time.Time
 		apiStatus     metav1.ConditionStatus
 		apiTransition time.Time
 		coreNodes     []crd.EMQXNode
@@ -24,46 +23,39 @@ func TestCorePodRetirementReadyOverrides(t *testing.T) {
 		reason        string
 	}{
 		{
-			name:      "force label",
-			labels:    map[string]string{crd.LabelForceRetirement: "true"},
-			deletedAt: now,
-			ready:     true,
-			reason:    "retirement forced",
-		},
-		{
 			name:      "fallback timeout reached",
-			deletedAt: now.Add(-corePodForcedRetirementTimeout[condFallback] - time.Second),
+			startedAt: now.Add(-corePodForcedRetirementTimeout[condFallback] - time.Second),
 			ready:     true,
 			reason:    "timeout exceeded",
 		},
 		{
 			name:          "API unavailable timeout reached",
-			deletedAt:     now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
+			startedAt:     now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
 			apiStatus:     metav1.ConditionFalse,
 			apiTransition: now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
 			ready:         true,
 			reason:        "API unavailability timeout exceeded",
 		},
 		{
-			name:          "API unavailability predates deletion",
-			deletedAt:     now.Add(-corePodForcedRetirementTimeout[condEMQXAPIUnavailable] / 2),
+			name:          "API unavailability predates retirement",
+			startedAt:     now.Add(-corePodForcedRetirementTimeout[condEMQXAPIUnavailable] / 2),
 			apiStatus:     metav1.ConditionFalse,
 			apiTransition: now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
 			reason:        "cluster membership state is unknown",
 		},
 		{
-			name:          "deletion predates API unavailability",
-			deletedAt:     now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
+			name:          "retirement predates API unavailability",
+			startedAt:     now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
 			apiStatus:     metav1.ConditionFalse,
 			apiTransition: now.Add(-corePodForcedRetirementTimeout[condEMQXAPIUnavailable] / 2),
 			reason:        "cluster membership state is unknown",
 		},
 		{
 			name:          "API available",
-			deletedAt:     now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
+			startedAt:     now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
 			apiStatus:     metav1.ConditionTrue,
 			apiTransition: now.Add(-2 * corePodForcedRetirementTimeout[condEMQXAPIUnavailable]),
-			coreNodes:     []crd.EMQXNode{{Name: "emqx@emqx", PodName: "emqx-1", Status: "running"}},
+			coreNodes:     []crd.EMQXNode{{Name: "emqx@emqx", PodName: "emqx-core-1", Status: "running"}},
 			reason:        "DS cluster state is not loaded",
 		},
 	} {
@@ -77,15 +69,18 @@ func TestCorePodRetirementReadyOverrides(t *testing.T) {
 					LastTransitionTime: metav1.NewTime(tc.apiTransition),
 				}}
 			}
-			r := &retireCorePods{}
-			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-				Name:              "emqx-0",
-				Labels:            tc.labels,
-				DeletionTimestamp: &metav1.Time{Time: tc.deletedAt},
-			}}
-			ready, reason := r.corePodRetirementReady(&reconcileRound{}, instance, pod)
-			assert.Equal(t, tc.ready, ready)
-			assert.Contains(t, reason, tc.reason)
+			reconciler := &retireCorePods{}
+			coreSet := &appsv1.StatefulSet{}
+			decision := reconciler.corePodRetirementReady(
+				&reconcileRound{
+					state:          &reconcileState{coreSets: []*appsv1.StatefulSet{coreSet}},
+					coreRetirement: &coreSetRetirement{watermark: 1, updatedAt: tc.startedAt},
+				},
+				instance,
+				"emqx-core-4",
+			)
+			assert.Equal(t, tc.ready, decision.ready)
+			assert.Contains(t, decision.reason, tc.reason)
 		})
 	}
 }

--- a/internal/controller/suite_faulty_client_test.go
+++ b/internal/controller/suite_faulty_client_test.go
@@ -64,6 +64,18 @@ func newFaultyClient(
 			}
 			return c.Update(ctx, o, opts...)
 		},
+		Patch: func(
+			ctx context.Context,
+			c client.WithWatch,
+			o client.Object,
+			patch client.Patch,
+			opts ...client.PatchOption,
+		) error {
+			if err := fault.err(); err != nil {
+				return err
+			}
+			return c.Patch(ctx, o, patch, opts...)
+		},
 	})
 }
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -275,6 +276,10 @@ func actualObject[Object client.Object](o Object) (Object, error) {
 	return o, err
 }
 
+func actualize[Object client.Object](o Object) error {
+	return k8sClient.Get(ctx, client.ObjectKeyFromObject(o), o)
+}
+
 func ownerReferences(owner client.Object) []metav1.OwnerReference {
 	var apiVersion, kind string
 	switch owner.(type) {
@@ -308,12 +313,36 @@ func newReconcileRound() *reconcileRound {
 
 func newReconcileRoundWithRequester(requester req.RequesterInterface) *reconcileRound {
 	return &reconcileRound{
-		ctx:       ctx,
-		log:       logger,
-		conf:      emqxConf,
-		requester: &apiRequesterOverride{requester},
-		state:     &reconcileState{},
+		ctx:            ctx,
+		log:            logger,
+		conf:           emqxConf,
+		requester:      &apiRequesterOverride{requester},
+		state:          nil,
+		coreRetirement: nil,
 	}
+}
+
+func ensureReconcileState(round *reconcileRound, instance *crd.EMQX) error {
+	err := reloadReconcileState(round, k8sClient, instance)
+	if err != nil {
+		return err
+	}
+	round.coreRetirement, err = loadCoreSetRetirementState(round)
+	return err
+}
+
+// runRoundReconcile performs reconciler.reconcile under a freshly reloaded (through
+// ensureReconcileState) reconcile round.
+func runRoundReconcile(
+	round *reconcileRound,
+	instance *crd.EMQX,
+	reconciler subReconciler,
+) subResult {
+	err := ensureReconcileState(round, instance)
+	if err != nil {
+		return reconcileError(errors.Wrap(err, "ensureReconcileState"))
+	}
+	return reconciler.reconcile(round, instance)
 }
 
 // apiRequesterOverride always provides the given fixed API requester.
@@ -418,13 +447,41 @@ func DescribeClientFaultMatrix(text string, args ...interface{}) bool {
 	})
 }
 
+func DeferCleanupObject(object client.Object) {
+	DeferCleanup(func() {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, object))).To(Succeed())
+	})
+}
+
 // Gomega helpers
 
-func BeSuccessfulReconcile() gomegatypes.GomegaMatcher {
+type ReconcileResultMatcher interface {
+	matcher() gomegatypes.GomegaMatcher
+}
+
+type Postponed bool
+
+func (p Postponed) matcher() gomegatypes.GomegaMatcher {
+	subm := BeFalse()
+	if p {
+		subm = BeTrue()
+	}
 	return WithTransform(
-		func(in subResult) error {
-			return in.err
-		},
-		Succeed(),
+		func(in subResult) bool { return in.needRequeue },
+		subm,
 	)
+}
+
+func BeSuccessfulReconcile(extra ...any) gomegatypes.GomegaMatcher {
+	matchers := []gomegatypes.GomegaMatcher{
+		WithTransform(
+			func(in subResult) error { return in.err },
+			Succeed(),
+		),
+	}
+	for _, arg := range extra {
+		argm := arg.(ReconcileResultMatcher)
+		matchers = append(matchers, argm.matcher())
+	}
+	return And(matchers...)
 }

--- a/internal/controller/sync_cluster_membership.go
+++ b/internal/controller/sync_cluster_membership.go
@@ -22,6 +22,11 @@ func (s *syncClusterMembership) reconcile(r *reconcileRound, instance *crd.EMQX)
 		return reconcilePostpone()
 	}
 
+	coreSet := r.state.coreSet()
+	if coreSet == nil {
+		return reconcilePostpone()
+	}
+
 	desiredReplicas := int(instance.Spec.NumCoreReplicas())
 	staleNodes := []*crd.EMQXNode{}
 	for _, node := range instance.Status.CoreNodes {
@@ -31,11 +36,11 @@ func (s *syncClusterMembership) reconcile(r *reconcileRound, instance *crd.EMQX)
 		}
 		pod := r.state.podWithName(node.PodName)
 		nodeName := parseNodeName(node.Name, instance)
-		retiring := pod != nil && isPodScaleDownRetiring(pod)
 		ordinal := util.PodOrdinal(node.PodName)
 		if ordinal < 0 && nodeName != nil {
 			ordinal = util.PodOrdinal(nodeName.podName)
 		}
+		retiring := r.coreRetirement.isRetiringOrdinal(coreSet, ordinal)
 		// Skip: running non-retiring cores should not be force-left.
 		if !retiring && pod != nil {
 			continue

--- a/internal/controller/sync_cluster_membership_suite_test.go
+++ b/internal/controller/sync_cluster_membership_suite_test.go
@@ -50,9 +50,10 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 		coreLabels := emqx.DefaultLabelsWith(crd.CoreLabels())
 		coreSet = &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      emqx.Name + "-core",
-				Namespace: ns.Name,
-				Labels:    coreLabels,
+				Name:        emqx.Name + "-core",
+				Namespace:   ns.Name,
+				Labels:      coreLabels,
+				Annotations: newCoreSetRetirementState(1).annotations(),
 			},
 			Spec: appsv1.StatefulSetSpec{
 				ServiceName: emqx.Name + "-core",
@@ -182,7 +183,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 			{Name: emqxNodeName(coreSet.Name + "-10"), PodName: "", Status: "stopped"},
 		}
 		s := &syncClusterMembership{emqxReconciler()}
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(ConsistOf(
@@ -197,7 +198,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: coreSet.Name + "-1", Status: "stopped"},
 		}
 		s := &syncClusterMembership{emqxReconciler()}
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
@@ -209,7 +210,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 			{Name: emqxNodeName(coreSet.Name + "-1"), PodName: "", Status: "running"},
 		}
 		s := &syncClusterMembership{emqxReconciler()}
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
@@ -224,7 +225,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 			{Name: "emqx@10.0.0.11", PodName: "", Status: "stopped", Role: "replicant"},
 		}
 		s := &syncClusterMembership{emqxReconciler()}
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
@@ -239,7 +240,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 			{Name: "emqx@10.0.0.1", PodName: replicantPod.Name, Status: "stopped", Role: "replicant"},
 		}
 		s := &syncClusterMembership{emqxReconciler()}
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())
@@ -253,7 +254,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncClusterMembership", Ordered, f
 			{Name: "emqx@10.0.0.99", PodName: "", Status: "running", Role: "replicant"},
 		}
 		s := &syncClusterMembership{emqxReconciler()}
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 		Eventually(s.reconcile).WithArguments(round, instance).
 			Should(BeSuccessfulReconcile())
 		Expect(forceLeftNodes).To(BeEmpty())

--- a/internal/controller/sync_core_set.go
+++ b/internal/controller/sync_core_set.go
@@ -92,16 +92,25 @@ func (s *syncCoreSet) reconcile(r *reconcileRound, instance *crd.EMQX) subResult
 	desiredReplicas := instance.Spec.NumCoreReplicas()
 	currentReplicas := util.NumReplicas(coreSet)
 
-	// Reconcile active and desired scale-downs as one idempotent operation. This
-	// retries pod deletion after a successful StatefulSet update and may extend
-	// the accumulated retirement range by one ordinal.
+	// Handle scale-downs and await retirement convergence.
+	// May extend the retirement range by one ordinal.
+	// Converged retirement enables safe scale-ups / rolling updates. Additionally, retries
+	// removals of any pods that were supposed to be removed by scaleDown.
 	if currentReplicas > desiredReplicas || r.coreRetirement.watermark > currentReplicas {
-		r.log.V(1).Info("scaling down coreSet",
-			"statefulSet", klog.KObj(coreSet),
-			"from", currentReplicas,
-			"to", desiredReplicas,
-			"watermark", r.coreRetirement.watermark,
-		)
+		if currentReplicas > desiredReplicas {
+			r.log.V(1).Info("scaling down coreSet",
+				"statefulSet", klog.KObj(coreSet),
+				"from", currentReplicas,
+				"to", desiredReplicas,
+				"watermark", r.coreRetirement.watermark,
+			)
+		} else {
+			r.log.V(1).Info("awaiting coreSet retirement",
+				"statefulSet", klog.KObj(coreSet),
+				"replicas", currentReplicas,
+				"watermark", r.coreRetirement.watermark,
+			)
+		}
 		return s.scaleDown(r, instance, currentReplicas)
 	}
 

--- a/internal/controller/sync_core_set.go
+++ b/internal/controller/sync_core_set.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"context"
 	"fmt"
 	"slices"
 
@@ -10,9 +9,8 @@ import (
 	util "github.com/emqx/emqx-operator/internal/controller/util"
 	"github.com/emqx/emqx-operator/internal/emqx/api"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // Responsibilities:
@@ -94,24 +92,28 @@ func (s *syncCoreSet) reconcile(r *reconcileRound, instance *crd.EMQX) subResult
 	desiredReplicas := instance.Spec.NumCoreReplicas()
 	currentReplicas := util.NumReplicas(coreSet)
 
-	// Handle scale-up: simply update the StatefulSet replica count.
+	// Reconcile active and desired scale-downs as one idempotent operation. This
+	// retries pod deletion after a successful StatefulSet update and may extend
+	// the accumulated retirement range by one ordinal.
+	if currentReplicas > desiredReplicas || r.coreRetirement.watermark > currentReplicas {
+		r.log.V(1).Info("scaling down coreSet",
+			"statefulSet", klog.KObj(coreSet),
+			"from", currentReplicas,
+			"to", desiredReplicas,
+			"watermark", r.coreRetirement.watermark,
+		)
+		return s.scaleDown(r, instance, currentReplicas)
+	}
+
+	// Handle scale-up after all ordinals being restored have been authorized for reuse.
 	if currentReplicas < desiredReplicas {
 		r.log.V(1).Info("scaling up coreSet",
 			"statefulSet", klog.KObj(coreSet),
 			"from", currentReplicas,
 			"to", desiredReplicas,
+			"watermark", r.coreRetirement.watermark,
 		)
 		return s.scaleUp(r, desiredReplicas)
-	}
-
-	// Handle scale-down: remove highest-ordinal pod with evacuation gating.
-	if currentReplicas > desiredReplicas {
-		r.log.V(1).Info("scaling down coreSet",
-			"statefulSet", klog.KObj(coreSet),
-			"from", currentReplicas,
-			"to", desiredReplicas,
-		)
-		return s.scaleDown(r, instance, currentReplicas)
 	}
 
 	// Stop evacuations of any updated pods.
@@ -163,7 +165,9 @@ func (s *syncCoreSet) rollingUpdate(r *reconcileRound, instance *crd.EMQX) subRe
 
 func (s *syncCoreSet) scaleUp(r *reconcileRound, desiredReplicas int32) subResult {
 	coreSet := r.state.coreSet()
-	coreSet.Spec.Replicas = &desiredReplicas
+	r.coreRetirement = newCoreSetRetirementState(desiredReplicas)
+	util.SetReplicas(coreSet, desiredReplicas)
+	util.AttachAnnotations(coreSet, r.coreRetirement.annotations())
 	err := s.Client.Update(r.ctx, coreSet)
 	if err != nil {
 		return subResult{err: emperror.Wrap(err, "failed to scale up coreSet")}
@@ -171,16 +175,40 @@ func (s *syncCoreSet) scaleUp(r *reconcileRound, desiredReplicas int32) subResul
 	return subResult{}
 }
 
-// scaleDown removes the highest-ordinal pod with evacuation gating, then
-// decrements the StatefulSet replica count.
+// scaleDown reconciles deletion of already-retiring pods, then, if needed,
+// admits one more ordinal and decrements the StatefulSet replica count.
 func (s *syncCoreSet) scaleDown(r *reconcileRound, instance *crd.EMQX, currentReplicas int32) subResult {
+	var candidate *corev1.Pod
+	var admission coreAdmission
+
 	coreSet := r.state.coreSet()
+	desiredReplicas := instance.Spec.NumCoreReplicas()
+	watermark := r.coreRetirement.watermark
+
+	// Remove pods that were supposed to be removed in previous reconciliations.
+	if watermark > currentReplicas {
+		for n := watermark; n > currentReplicas; n-- {
+			pod := r.state.podWithName(fmt.Sprintf("%s-%d", coreSet.Name, n-1))
+			if pod != nil && pod.DeletionTimestamp == nil {
+				admission = coreAdmission{
+					Action: admissionRemove,
+					Reason: "removal already admitted",
+					Cause:  coreScaleDown,
+				}
+				result := s.onCoreAdmission(r, instance, pod, admission)
+				result.needRequeue = true
+				return result
+			}
+		}
+	}
 
 	// Candidate is the highest-ordinal pod, where ordinal = currentReplicas-1.
-	candidateName := fmt.Sprintf("%s-%d", coreSet.Name, currentReplicas-1)
-	candidate := r.state.podWithName(candidateName)
+	if currentReplicas > desiredReplicas {
+		candidate = r.state.podWithName(fmt.Sprintf("%s-%d", coreSet.Name, currentReplicas-1))
+	} else {
+		return reconcilePostpone()
+	}
 
-	var admission coreAdmission
 	if candidate != nil {
 		admission = checkCorePodRemoval(r, instance, candidate, coreScaleDown)
 	} else {
@@ -194,8 +222,11 @@ func (s *syncCoreSet) scaleDown(r *reconcileRound, instance *crd.EMQX, currentRe
 	if admission.Action == admissionRemove {
 		// Decrement StatefulSet replica count first so the StatefulSet controller
 		// won't recreate the pod after we delete it.
-		newReplicas := currentReplicas - 1
-		coreSet.Spec.Replicas = &newReplicas
+		if r.coreRetirement.watermark == currentReplicas {
+			r.coreRetirement = newCoreSetRetirementState(currentReplicas)
+		}
+		util.SetReplicas(coreSet, currentReplicas-1)
+		util.AttachAnnotations(coreSet, r.coreRetirement.annotations())
 		err := s.Client.Update(r.ctx, coreSet)
 		if err != nil {
 			return subResult{err: emperror.Wrap(err, "failed to decrement coreSet replicas")}
@@ -316,12 +347,7 @@ func (s *syncCoreSet) onCoreAdmission(
 			"statefulSet", klog.KObj(r.state.coreSet()),
 			"cause", admission.Cause,
 		)
-		if admission.Cause == coreScaleDown {
-			if err := attachScaleDownRetirementFinalizer(r.ctx, s.Client, candidate); err != nil {
-				return reconcileError(err)
-			}
-		}
-		if err := s.Client.Delete(r.ctx, candidate); err != nil {
+		if err := s.deleteCorePod(r, candidate); err != nil {
 			return reconcileError(emperror.Wrap(err, "failed to delete core pod"))
 		}
 	case admissionWait:
@@ -343,6 +369,16 @@ func (s *syncCoreSet) onCoreAdmission(
 		}
 	}
 	return subResult{}
+}
+
+func (s *syncCoreSet) deleteCorePod(r *reconcileRound, pod *corev1.Pod) error {
+	if pod.DeletionTimestamp == nil {
+		err := s.Client.Delete(r.ctx, pod)
+		if err != nil && !k8sErrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 // actOnCoreAdmission performs the side effects implied by a coreAdmission.
@@ -423,27 +459,4 @@ func migrationTargetNodes(r *reconcileRound, instance *crd.EMQX) []string {
 		}
 	}
 	return targets
-}
-
-func attachScaleDownRetirementFinalizer(ctx context.Context, k8sClient client.Client, pod *corev1.Pod) error {
-	if controllerutil.AddFinalizer(pod, crd.FinalizerScaleDownRetirement) {
-		if err := k8sClient.Update(ctx, pod); err != nil {
-			return emperror.Wrap(err, "failed to attach retirement finalizer")
-		}
-	}
-	return nil
-}
-
-func removeScaleDownRetirementFinalizer(ctx context.Context, k8sClient client.Client, pod *corev1.Pod) error {
-	if controllerutil.RemoveFinalizer(pod, crd.FinalizerScaleDownRetirement) {
-		if err := k8sClient.Update(ctx, pod); err != nil {
-			return emperror.Wrap(err, "failed to remove retirement finalizer")
-		}
-	}
-	return nil
-}
-
-func isPodScaleDownRetiring(pod *corev1.Pod) bool {
-	return pod.DeletionTimestamp != nil &&
-		controllerutil.ContainsFinalizer(pod, crd.FinalizerScaleDownRetirement)
 }

--- a/internal/controller/sync_core_set_suite_test.go
+++ b/internal/controller/sync_core_set_suite_test.go
@@ -338,7 +338,9 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 		round := newReconcileRound()
 		reconciler := &syncCoreSet{emqxReconciler()}
 		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
-			Should(BeSuccessfulReconcile(Postponed(false)))
+			Should(BeSuccessfulReconcile())
+		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+			Should(BeSuccessfulReconcile())
 
 		// Postconditions:
 		// - coreSet scaling down succeeded, 1 replica left

--- a/internal/controller/sync_core_set_suite_test.go
+++ b/internal/controller/sync_core_set_suite_test.go
@@ -1,12 +1,16 @@
 package controller
 
 import (
+	"fmt"
+	"time"
+
 	crd "github.com/emqx/emqx-operator/api/v3beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -18,7 +22,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 
 	var round *reconcileRound
 	var coreSet *appsv1.StatefulSet
-	var pod0, pod1 *corev1.Pod
+	var pods []*corev1.Pod
 
 	const (
 		currentRevision string = "current"
@@ -39,17 +43,18 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 		Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
 	})
 
-	BeforeEach(func() {
+	mkCoreSet := func(replicas int32) *appsv1.StatefulSet {
 		coreLabels := emqx.DefaultLabelsWith(crd.CoreLabels())
-		coreSet = &appsv1.StatefulSet{
+		return &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      emqx.Name + "-core",
-				Namespace: ns.Name,
-				Labels:    coreLabels,
+				Name:        emqx.Name + "-core",
+				Namespace:   ns.Name,
+				Labels:      coreLabels,
+				Annotations: newCoreSetRetirementState(replicas).annotations(),
 			},
 			Spec: appsv1.StatefulSetSpec{
 				ServiceName: emqx.Name + "-core",
-				Replicas:    ptr.To(int32(2)),
+				Replicas:    ptr.To(replicas),
 				UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 					Type: appsv1.OnDeleteStatefulSetStrategyType,
 				},
@@ -68,11 +73,12 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 				},
 			},
 		}
-		Expect(k8sClient.Create(ctx, coreSet)).Should(Succeed())
+	}
 
-		pod0 = &corev1.Pod{
+	mkPod := func(ordinal int) *corev1.Pod {
+		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      coreSet.Name + "-0",
+				Name:      fmt.Sprintf("%s-%d", coreSet.Name, ordinal),
 				Namespace: ns.Name,
 				Labels: map[string]string{
 					crd.LabelInstance:                     "emqx",
@@ -88,50 +94,55 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 				},
 			},
 		}
-		pod1 = pod0.DeepCopy()
-		pod1.Name = coreSet.Name + "-1"
-		Expect(k8sClient.Create(ctx, pod0)).Should(Succeed())
-		Expect(k8sClient.Create(ctx, pod1)).Should(Succeed())
-		pod0.Status.Conditions = []corev1.PodCondition{
-			{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
-		}
-		pod1.Status.Conditions = pod0.Status.Conditions
-		Expect(k8sClient.Status().Update(ctx, pod0)).Should(Succeed())
-		Expect(k8sClient.Status().Update(ctx, pod1)).Should(Succeed())
+	}
 
-		coreSet.Status.Replicas = 2
-		coreSet.Status.ReadyReplicas = 2
-		coreSet.Status.AvailableReplicas = 2
+	BeforeEach(func() {
+		coreSet = mkCoreSet(3)
+		Expect(k8sClient.Create(ctx, coreSet)).Should(Succeed())
+		coreSet.Status.Replicas = 3
+		coreSet.Status.ReadyReplicas = 3
+		coreSet.Status.AvailableReplicas = 3
 		coreSet.Status.CurrentRevision = currentRevision
 		coreSet.Status.UpdateRevision = updateRevision
 		Expect(k8sClient.Status().Update(ctx, coreSet)).Should(Succeed())
 
-		instance = emqx.DeepCopy()
-		instance.Namespace = ns.Name
-		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(2))
-		instance.Status.CoreNodes = []crd.EMQXNode{
-			{Name: "emqx@" + pod0.Name, PodName: pod0.Name, Status: "running"},
-			{Name: "emqx@" + pod1.Name, PodName: pod1.Name, Status: "running"},
+		pods = []*corev1.Pod{}
+		nodes := []crd.EMQXNode{}
+		for i := range 3 {
+			pod := mkPod(i)
+			Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+			pod.Status.Conditions = []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: metav1.Now()},
+			}
+			Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+			pods = append(pods, pod)
+			nodes = append(nodes, crd.EMQXNode{Name: "emqx@" + pod.Name, PodName: pod.Name, Status: "running"})
 		}
 
+		instance = emqx.DeepCopy()
+		instance.Namespace = ns.Name
+		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(3))
+		instance.Status.CoreNodes = nodes
+
 		round = newReconcileRound()
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		_ = k8sClient.Delete(ctx, pod0)
-		_ = k8sClient.Delete(ctx, pod1)
 		Expect(k8sClient.Delete(ctx, coreSet)).Should(Succeed())
+		for _, pod := range pods {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).Should(Succeed())
+		}
 	})
 
 	It("waits when fewer than N-1 other core pods are available (ready)", func() {
 		// Removing pod1 requires at least one *other* available core; pod0 is not Ready.
-		pod0.Status.Conditions = []corev1.PodCondition{}
-		Expect(k8sClient.Status().Update(ctx, pod0)).Should(Succeed())
-		coreSet.Status.AvailableReplicas = 1
+		pods[0].Status.Conditions = []corev1.PodCondition{}
+		Expect(k8sClient.Status().Update(ctx, pods[0])).Should(Succeed())
+		coreSet.Status.AvailableReplicas = 2
 		Expect(k8sClient.Status().Update(ctx, coreSet)).Should(Succeed())
-		Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
-		admission := checkCorePodRemoval(round, instance, pod1, coreRollingUpdate)
+		Expect(ensureReconcileState(round, instance)).To(Succeed())
+		admission := checkCorePodRemoval(round, instance, pods[2], coreRollingUpdate)
 		Expect(admission).Should(And(
 			HaveField("Action", Equal(admissionWait)),
 			HaveField("Reason", Equal("cores are not available yet")),
@@ -140,9 +151,9 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 
 	It("waits while a node evacuation is in progress", func() {
 		instance.Status.NodeEvacuations = []crd.NodeEvacuationStatus{
-			{NodeName: "emqx@" + pod1.Name, State: "evicting_sessions"},
+			{NodeName: "emqx@" + pods[2].Name, State: "evicting_sessions"},
 		}
-		admission := checkCorePodRemoval(round, instance, pod1, coreRollingUpdate)
+		admission := checkCorePodRemoval(round, instance, pods[2], coreRollingUpdate)
 		Expect(admission).Should(And(
 			HaveField("Action", Equal(admissionWait)),
 			HaveField("Reason", Equal("node evacuation in progress")),
@@ -150,8 +161,8 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 	})
 
 	It("node session > 0", func() {
-		instance.Status.CoreNodes[1].Sessions = 99999
-		admission := checkCorePodRemoval(round, instance, pod1, coreRollingUpdate)
+		instance.Status.CoreNodes[2].Sessions = 99999
+		admission := checkCorePodRemoval(round, instance, pods[2], coreRollingUpdate)
 		Expect(admission).Should(And(
 			HaveField("Action", Equal(admissionEvacuate)),
 			HaveField("Reason", ContainSubstring("active sessions")),
@@ -161,9 +172,9 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 	It("single node session > 0", func() {
 		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(1))
 		instance.Status.CoreNodes = []crd.EMQXNode{
-			{Name: "emqx@" + pod0.Name, PodName: pod0.Name, Status: "running", Sessions: 99999},
+			{Name: "emqx@" + pods[0].Name, PodName: pods[0].Name, Status: "running", Sessions: 99999},
 		}
-		admission := checkCorePodRemoval(round, instance, pod0, coreRollingUpdate)
+		admission := checkCorePodRemoval(round, instance, pods[0], coreRollingUpdate)
 		Expect(admission).Should(And(
 			HaveField("Action", Equal(admissionRemove)),
 			HaveField("Reason", ContainSubstring("nowhere")),
@@ -172,16 +183,16 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 
 	It("node session > 0 & node evacuation is disabled", func() {
 		instance.Spec.UpdateStrategy.EvacuationStrategy.Type = crd.DisabledEvacuationStrategy
-		instance.Status.CoreNodes[1].Sessions = 99999
-		admission := checkCorePodRemoval(round, instance, pod1, coreRollingUpdate)
+		instance.Status.CoreNodes[2].Sessions = 99999
+		admission := checkCorePodRemoval(round, instance, pods[2], coreRollingUpdate)
 		Expect(admission).Should(And(
 			HaveField("Action", Equal(admissionRemove)),
 		))
 	})
 
 	It("node session is 0", func() {
-		instance.Status.CoreNodes[1].Sessions = 0
-		admission := checkCorePodRemoval(round, instance, pod1, coreRollingUpdate)
+		instance.Status.CoreNodes[2].Sessions = 0
+		admission := checkCorePodRemoval(round, instance, pods[2], coreRollingUpdate)
 		Expect(admission).To(
 			HaveField("Action", Equal(admissionRemove)),
 		)
@@ -204,19 +215,21 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 			s := &syncCoreSet{emqxReconciler()}
 			Eventually(s.rollingUpdate).WithArguments(round, instance).
 				Should(BeSuccessfulReconcile())
-			_, err := actualObject(pod1)
+			_, err := actualObject(pods[2])
 			Expect(k8sErrors.IsNotFound(err)).To(BeTrue(), "highest-ordinal outdated pod should be deleted first")
 		})
 
 		It("should block rolling update with 1 old core", func() {
 			// Simulate `pod1` already on new revision, while `pod0` is outdated.
-			pod1.Labels[appsv1.ControllerRevisionHashLabelKey] = coreSet.Status.UpdateRevision
-			Expect(k8sClient.Update(ctx, pod1)).Should(Succeed())
-			Expect(reloadReconcileState(round, k8sClient, instance)).To(Succeed())
+			pods[1].Labels[appsv1.ControllerRevisionHashLabelKey] = coreSet.Status.UpdateRevision
+			pods[2].Labels[appsv1.ControllerRevisionHashLabelKey] = coreSet.Status.UpdateRevision
+			Expect(k8sClient.Update(ctx, pods[1])).Should(Succeed())
+			Expect(k8sClient.Update(ctx, pods[2])).Should(Succeed())
+			Expect(ensureReconcileState(round, instance)).To(Succeed())
 			s := &syncCoreSet{emqxReconciler()}
 			Eventually(s.rollingUpdate).WithArguments(round, instance).
 				Should(BeSuccessfulReconcile())
-			Expect(actualObject(pod0)).To(
+			Expect(actualObject(pods[0])).To(
 				Not(BeNil()),
 				"sole remaining outdated core must stay up while replicant ReplicaSet migrates",
 			)
@@ -225,10 +238,10 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 	})
 
 	It("DS replication site blocks scale-down", func() {
-		pod1.Status.Conditions = []corev1.PodCondition{
+		pods[2].Status.Conditions = []corev1.PodCondition{
 			{Type: crd.DSReplicationSite, Status: corev1.ConditionTrue},
 		}
-		admission := checkCorePodRemoval(round, instance, pod1, coreScaleDown)
+		admission := checkCorePodRemoval(round, instance, pods[2], coreScaleDown)
 		Expect(admission).To(And(
 			HaveField("Action", Equal(admissionWait)),
 			HaveField("Reason", ContainSubstring("DS replication site")),
@@ -236,12 +249,109 @@ var _ = DescribeClientFaultMatrix("Reconciler syncCoreSet", Ordered, func() {
 	})
 
 	It("DS replication site does not block rolling update", func() {
-		pod1.Status.Conditions = []corev1.PodCondition{
+		pods[2].Status.Conditions = []corev1.PodCondition{
 			{Type: crd.DSReplicationSite, Status: corev1.ConditionTrue},
 		}
-		admission := checkCorePodRemoval(round, instance, pod1, coreRollingUpdate)
+		admission := checkCorePodRemoval(round, instance, pods[2], coreRollingUpdate)
 		Expect(admission).To(
 			HaveField("Action", Equal(admissionRemove)),
 		)
 	})
+
+	It("blocks reuse until the watermark is forcibly lowered", func() {
+		// Preconditions:
+		// - coreSet was scaled down 5 → 3 replicas
+		// - coreSet has 3 live replicas, with 1 replica `emqx-core-3` still retiring
+		// - watermark is still set to 5, blocking scale-ups
+		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(5))
+		coreSet.Annotations = newCoreSetRetirementState(5).annotations()
+		Expect(k8sClient.Update(ctx, coreSet)).To(Succeed())
+		pod3 := mkPod(3)
+		Expect(k8sClient.Create(ctx, pod3)).To(Succeed())
+
+		round := newReconcileRound()
+		reconciler := &syncCoreSet{emqxReconciler()}
+		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+			Should(BeSuccessfulReconcile())
+
+		// Conditions:
+		// - `emqx-core-3` is deleted: it's below watermark and should be retiring
+		// - scaling up is blocked
+		Expect(actualize(pod3)).To(WithTransform(k8sErrors.IsNotFound, BeTrue()))
+		Expect(actualize(coreSet)).To(Succeed())
+		Expect(coreSet).To(HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(3))))
+
+		coreSet.Annotations = newCoreSetRetirementState(3).annotations()
+		Expect(k8sClient.Update(ctx, coreSet)).To(Succeed())
+		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+			Should(BeSuccessfulReconcile())
+
+		// Postconditions:
+		// - coreSet scaled up
+		// - watermark is updated to reflect current number of replicas
+		Expect(actualize(coreSet)).To(Succeed())
+		Expect(coreSet).To(HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(5))))
+		state, err := readCoreSetRetirementState(coreSet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.watermark).To(BeEquivalentTo(5))
+	})
+
+	It("starts one ordinal retirement", func() {
+		// Preconditions:
+		// - coreSet is scaling down 3 → 1 replicas
+		// - watermark is at 3
+		// - coreSet retirement state was last updated an hour ago
+		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(1))
+		retirement := &coreSetRetirement{3, time.Now().Add(-time.Hour)}
+		coreSet.Annotations = retirement.annotations()
+		Expect(k8sClient.Update(ctx, coreSet)).To(Succeed())
+
+		round := newReconcileRound()
+		reconciler := &syncCoreSet{emqxReconciler()}
+		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+			Should(BeSuccessfulReconcile())
+
+		// Postconditions:
+		// - only one replica is removed per call
+		// - watermark remains at 3, preventing ordinal 2 from being reused
+		// - the timestamp is refreshed because a new retirement epoch began
+		Expect(actualize(coreSet)).To(Succeed())
+		Expect(coreSet).To(HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(2))))
+		state, err := readCoreSetRetirementState(coreSet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.watermark).To(BeEquivalentTo(3))
+		Expect(state.updatedAt).To(BeTemporally("~", time.Now(), time.Second*5))
+	})
+
+	It("continues scale-down while earlier ordinals retire", func() {
+		// Preconditions:
+		// - coreSet is scaling down 3 → 1 replicas, currently has 2 replicas
+		// - watermark is still at 3
+		// - coreSet retirement state was last updated a minute ago
+		instance.Spec.CoreTemplate.Spec.Replicas = ptr.To(int32(1))
+		startedAt := time.Now().Add(-time.Minute)
+		retirement := &coreSetRetirement{3, startedAt}
+		coreSet.Spec.Replicas = ptr.To(int32(2))
+		coreSet.Annotations = retirement.annotations()
+		Expect(k8sClient.Update(ctx, coreSet)).To(Succeed())
+
+		round := newReconcileRound()
+		reconciler := &syncCoreSet{emqxReconciler()}
+		Eventually(runRoundReconcile).WithArguments(round, instance, reconciler).
+			Should(BeSuccessfulReconcile(Postponed(false)))
+
+		// Postconditions:
+		// - coreSet scaling down succeeded, 1 replica left
+		// - watermark is still at 3
+		// - coreSet retirement update timestamp unchanged
+		Expect(actualize(coreSet)).To(Succeed())
+		Expect(coreSet).To(HaveField("Spec.Replicas", HaveValue(BeEquivalentTo(1))))
+		Expect(actualize(pods[2])).To(WithTransform(k8sErrors.IsNotFound, BeTrue()))
+		Expect(actualize(pods[1])).To(WithTransform(k8sErrors.IsNotFound, BeTrue()))
+		state, err := readCoreSetRetirementState(coreSet)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state.watermark).To(BeEquivalentTo(3))
+		Expect(state.updatedAt).To(BeTemporally("~", startedAt.UTC(), time.Nanosecond))
+	})
+
 })

--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -293,14 +293,14 @@ func (s *syncReplicantSets) onReplicantAdmission(
 	pod *corev1.Pod,
 	admission replicantAdmission,
 ) error {
-	annotationsDirty := util.AttachPodAnnotation(pod, crd.AnnotationScalingDown, "true")
+	annotationsDirty := util.AttachAnnotation(pod, crd.AnnotationScalingDown, "true")
 	switch admission.Action {
 	case admissionRemove:
 		r.log.V(1).Info("scheduling replicant pod removal",
 			"reason", admission.Reason,
 			"pod", klog.KObj(pod),
 		)
-		annotationsDirty = util.AttachPodAnnotation(pod, corev1.PodDeletionCost, "-99999") || annotationsDirty
+		annotationsDirty = util.AttachAnnotation(pod, corev1.PodDeletionCost, "-99999") || annotationsDirty
 	case admissionWait:
 		r.log.V(1).Info("removal of replicant pod postponed",
 			"reason", admission.Reason,

--- a/internal/controller/sync_replicant_sets_suite_test.go
+++ b/internal/controller/sync_replicant_sets_suite_test.go
@@ -612,8 +612,8 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 			//    cancelled by scaling back up.
 			// 2. No scaling is requested.
 			instance.Spec.ReplicantTemplate.Spec.Replicas = ptr.To(int32(3))
-			_ = util.AttachPodAnnotation(replicants[0], crd.AnnotationScalingDown, "true")
-			_ = util.AttachPodAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
+			_ = util.AttachAnnotation(replicants[0], crd.AnnotationScalingDown, "true")
+			_ = util.AttachAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
 			Expect(k8sClient.Update(ctx, replicants[0])).Should(Succeed())
 
 			s := &syncReplicantSets{emqxReconciler()}
@@ -647,8 +647,8 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 			instance.Status.NodeEvacuations = []crd.NodeEvacuationStatus{
 				{NodeName: "emqx@10.0.0.1", State: "evicting_conns"},
 			}
-			_ = util.AttachPodAnnotation(replicants[0], crd.AnnotationScalingDown, "true")
-			_ = util.AttachPodAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
+			_ = util.AttachAnnotation(replicants[0], crd.AnnotationScalingDown, "true")
+			_ = util.AttachAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
 			Expect(k8sClient.Update(ctx, replicants[0])).Should(Succeed())
 
 			// Use a requester that accepts the stop-evacuation POST.
@@ -684,8 +684,8 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets", Ordered, func(
 			instance.Status.NodeEvacuations = []crd.NodeEvacuationStatus{
 				{NodeName: "emqx@10.0.0.1", State: "evicting_conns"},
 			}
-			_ = util.AttachPodAnnotation(replicants[0], crd.AnnotationScalingDown, "true")
-			_ = util.AttachPodAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
+			_ = util.AttachAnnotation(replicants[0], crd.AnnotationScalingDown, "true")
+			_ = util.AttachAnnotation(replicants[0], corev1.PodDeletionCost, "-99999")
 			Expect(k8sClient.Update(ctx, replicants[0])).Should(Succeed())
 
 			// Use a requester that accepts the stop-evacuation POST.
@@ -911,7 +911,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 			MaxUnavailable: ptr.To(intstr.FromInt(0)),
 			MaxSurge:       ptr.To(intstr.FromInt(1)),
 		}
-		_ = util.AttachPodAnnotation(currentPod, crd.AnnotationScalingDown, "true")
+		_ = util.AttachAnnotation(currentPod, crd.AnnotationScalingDown, "true")
 		Expect(k8sClient.Update(ctx, currentPod)).Should(Succeed())
 		currentPod.Status.Conditions = []corev1.PodCondition{
 			{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.Now()},
@@ -947,7 +947,7 @@ var _ = DescribeClientFaultMatrix("Reconciler syncReplicantSets admission", func
 			MaxUnavailable: ptr.To(intstr.FromInt(0)),
 			MaxSurge:       ptr.To(intstr.FromInt(1)),
 		}
-		_ = util.AttachPodAnnotation(currentPod, crd.AnnotationScalingDown, "true")
+		_ = util.AttachAnnotation(currentPod, crd.AnnotationScalingDown, "true")
 		Expect(k8sClient.Update(ctx, currentPod)).Should(Succeed())
 		// Make the update pod unavailable so budget = 0.
 		updatePod.Status.Conditions = []corev1.PodCondition{

--- a/internal/controller/update_emqx_status_suite_test.go
+++ b/internal/controller/update_emqx_status_suite_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Reconciler updateStatus", Ordered, func() {
+var _ = DescribeClientFaultMatrix("Reconciler updateStatus", Ordered, func() {
 	var ns *corev1.Namespace
 	var instance *crd.EMQX
 
@@ -48,10 +48,9 @@ var _ = Describe("Reconciler updateStatus", Ordered, func() {
 	It("marks EMQX API unavailable when no core pod can serve API requests", func() {
 		round := newReconcileRound()
 		round.requester = &apiRequesterUnavailable{}
-		round.state = &reconcileState{}
 		s := &updateStatus{emqxReconciler()}
 
-		Expect(s.reconcile(round, instance)).To(BeSuccessfulReconcile())
+		Expect(runRoundReconcile(round, instance, s)).To(BeSuccessfulReconcile())
 
 		Expect(actualObject(instance)).To(HaveCondition(crd.EMQXAPIAvailable, And(
 			HaveField("Status", Equal(metav1.ConditionFalse)),
@@ -83,9 +82,8 @@ var _ = Describe("Reconciler updateStatus", Ordered, func() {
 		)
 		Expect(k8sClient.Status().Update(ctx, instance)).Should(Succeed())
 
-		actual, err := actualObject(instance)
-		Expect(err).NotTo(HaveOccurred())
-		_, conditionBefore := actual.Status.GetCondition(crd.EMQXAPIAvailable)
+		Expect(actualize(instance)).NotTo(HaveOccurred())
+		_, conditionBefore := instance.Status.GetCondition(crd.EMQXAPIAvailable)
 		Expect(conditionBefore).NotTo(BeNil())
 
 		round := newReconcileRoundWithRequester(req.NewMockRequester(
@@ -96,20 +94,18 @@ var _ = Describe("Reconciler updateStatus", Ordered, func() {
 		))
 
 		s := &updateStatus{emqxReconciler()}
-		result := s.reconcile(round, instance)
-		Expect(result).To(BeSuccessfulReconcile())
+		Expect(runRoundReconcile(round, instance, s)).To(BeSuccessfulReconcile())
 
-		actual, err = actualObject(instance)
-		Expect(err).NotTo(HaveOccurred())
-		_, condition := actual.Status.GetCondition(crd.EMQXAPIAvailable)
+		Expect(actualize(instance)).NotTo(HaveOccurred())
+		_, condition := instance.Status.GetCondition(crd.EMQXAPIAvailable)
 		Expect(condition).NotTo(BeNil())
 		Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 		Expect(condition.Reason).To(Equal("RequestFailed"))
 		Expect(condition.Message).To(ContainSubstring("connection refused"))
 		Expect(condition.LastTransitionTime).To(Equal(conditionBefore.LastTransitionTime))
-		Expect(actual.Status.CoreNodes).To(BeEmpty())
-		Expect(actual.Status.ReplicantNodes).To(BeEmpty())
-		Expect(actual.Status.NodeEvacuations).To(BeEmpty())
-		Expect(actual.Status.DSReplication.DBs).To(BeEmpty())
+		Expect(instance.Status.CoreNodes).To(BeEmpty())
+		Expect(instance.Status.ReplicantNodes).To(BeEmpty())
+		Expect(instance.Status.NodeEvacuations).To(BeEmpty())
+		Expect(instance.Status.DSReplication.DBs).To(BeEmpty())
 	})
 })

--- a/internal/controller/util/meta.go
+++ b/internal/controller/util/meta.go
@@ -44,3 +44,52 @@ func CloneAnnotations(annotations map[string]string) map[string]string {
 	}
 	return clone
 }
+
+func AttachAnnotation(object metav1.Object, name, value string) bool {
+	return AttachAnnotations(object, map[string]string{name: value})
+}
+
+func AttachAnnotations(object metav1.Object, annotations map[string]string) bool {
+	dirty := false
+	attached := object.GetAnnotations()
+	if len(annotations) > 0 && attached == nil {
+		attached = make(map[string]string, len(annotations))
+	}
+	for name, value := range annotations {
+		valueWas, present := attached[name]
+		if !present || valueWas != value {
+			attached[name] = value
+			dirty = true
+		}
+	}
+	if dirty {
+		object.SetAnnotations(attached)
+	}
+	return dirty
+}
+
+func PeekAnnotations(object metav1.Object, names ...string) map[string]string {
+	peeked := make(map[string]string, len(names))
+	annotations := object.GetAnnotations()
+	for _, name := range names {
+		if value, present := annotations[name]; present {
+			peeked[name] = value
+		}
+	}
+	return peeked
+}
+
+func UnsetAnnotations(object metav1.Object, names ...string) bool {
+	dirty := false
+	annotations := object.GetAnnotations()
+	for _, name := range names {
+		if _, present := annotations[name]; present {
+			dirty = true
+			delete(annotations, name)
+		}
+	}
+	if dirty {
+		object.SetAnnotations(annotations)
+	}
+	return dirty
+}

--- a/internal/controller/util/meta_test.go
+++ b/internal/controller/util/meta_test.go
@@ -1,0 +1,50 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAttachAnnotation(t *testing.T) {
+	object := &metav1.PartialObjectMetadata{}
+
+	assert.True(t, AttachAnnotation(object, "key", "value"))
+	assert.Equal(t, map[string]string{"key": "value"}, object.GetAnnotations())
+	assert.False(t, AttachAnnotation(object, "key", "value"))
+	assert.True(t, AttachAnnotation(object, "key", "updated"))
+	assert.Equal(t, "updated", object.GetAnnotations()["key"])
+}
+
+func TestAttachAnnotations(t *testing.T) {
+	object := &metav1.PartialObjectMetadata{}
+
+	assert.False(t, AttachAnnotations(object, nil))
+	assert.Nil(t, object.GetAnnotations())
+	assert.True(t, AttachAnnotations(object, map[string]string{"one": "1", "two": "2"}))
+	assert.False(t, AttachAnnotations(object, map[string]string{"one": "1", "two": "2"}))
+	assert.Equal(t, map[string]string{"one": "1", "two": "2"}, object.GetAnnotations())
+}
+
+func TestPeekAnnotations(t *testing.T) {
+	object := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"one": "1", "two": "2", "three": "3"},
+	}}
+
+	peeked := PeekAnnotations(object, "one", "three", "missing")
+
+	assert.Equal(t, map[string]string{"one": "1", "three": "3"}, peeked)
+	peeked["one"] = "updated"
+	assert.Equal(t, "1", object.GetAnnotations()["one"])
+}
+
+func TestUnsetAnnotations(t *testing.T) {
+	object := &metav1.PartialObjectMetadata{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{"one": "1", "two": "2"},
+	}}
+
+	assert.True(t, UnsetAnnotations(object, "one", "missing"))
+	assert.Equal(t, map[string]string{"two": "2"}, object.GetAnnotations())
+	assert.False(t, UnsetAnnotations(object, "one", "missing"))
+}

--- a/internal/controller/util/pod.go
+++ b/internal/controller/util/pod.go
@@ -49,19 +49,6 @@ func UpdatePodCondition(
 	return k8sClient.Status().Patch(ctx, pod, patch)
 }
 
-func AttachPodAnnotation(pod *corev1.Pod, name string, value string) bool {
-	dirty := false
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
-	}
-	valueWas, present := pod.Annotations[name]
-	if !present || valueWas != value {
-		pod.Annotations[name] = value
-		dirty = true
-	}
-	return dirty
-}
-
 func PodReadyDuration(pod *corev1.Pod) time.Duration {
 	cond := FindPodCondition(pod, corev1.PodReady)
 	if cond == nil || cond.Status != corev1.ConditionTrue {

--- a/internal/controller/util/statefulset.go
+++ b/internal/controller/util/statefulset.go
@@ -10,3 +10,7 @@ func NumReplicas(sts *appsv1.StatefulSet) int32 {
 	}
 	return 1
 }
+
+func SetReplicas(sts *appsv1.StatefulSet, numReplicas int32) {
+	sts.Spec.Replicas = &numReplicas
+}


### PR DESCRIPTION
## Summary

This PR redefines how core pod retirement is tracked: a pair of annotations on core set is used instead of individual per-pod finalizers. Annotations consist of the core pod ordinal watermark and the time last retirement epoch started.

This makes retirement ordered, as retirement progresses from watermark down to current `coreSet.Spec.Replicas`. However, this in turn:
1. Enables tracking of more elaborate conditions, primarily PVC absence, as finalizers no longer block pod deletions.
2. Avoids extra operational burden of having to deal with K8s object finalizers.

Additionally, this PR:
* Ensures core set scale-down is idempotent, and interrupted operations are retried safely.
* Improves test coverage.
* Adds K8s client fault injection for `PATCH` API requests.

Addresses https://github.com/emqx/emqx-operator/actions/runs/31387886111/job/93452411712.