### PR TITLE
chore: tolerate lagging replicant node info

### DIFF
--- a/internal/controller/sync_replicant_sets.go
+++ b/internal/controller/sync_replicant_sets.go
@@ -71,10 +71,7 @@ func (s *syncReplicantSets) reconcile(r *reconcileRound, instance *crd.EMQX) sub
 
 	// Steady state: clean up stale artifacts.
 	if currentReplicas == specReplicas {
-		err := s.ensureConsistency(r, instance, updateRs)
-		if err != nil {
-			return reconcileError(emperror.Wrap(err, "failed to restore replicant consistency"))
-		}
+		return s.ensureConsistency(r, instance, updateRs)
 	}
 
 	return subResult{}
@@ -147,28 +144,35 @@ func (s *syncReplicantSets) ensureConsistency(
 	r *reconcileRound,
 	instance *crd.EMQX,
 	updateRs *appsv1.ReplicaSet,
-) error {
+) subResult {
+	postpone := false
 	for _, pod := range r.state.listPods(podsManagedBy{updateRs}, podsAlive{}) {
 		// 1. Check if pod has stale scale-down annotations.
 		dirty := s.removeStaleReplicantAnnotations(pod)
 		if !dirty {
 			continue
 		}
-
 		// 2. Stop any ongoing node evacuation.
 		// This is attempted irrespective of whether Node Evacuation is enabled or not,
 		// to avoid ending up in transient state if it was disabled mid-update.
 		stopped, err := s.stopStaleReplicantEvacuation(r, instance, pod)
-		if err != nil {
-			return err
-		}
-		if stopped {
+		switch {
+		case stopped && err != nil:
+			return reconcileError(emperror.Wrap(err, "failed to restore replicant consistency"))
+		case err != nil:
+			r.log.V(1).Info("stopping stale replicant node evacuation postponed",
+				"replicaSet", klog.KObj(updateRs),
+				"pod", klog.KObj(pod),
+				"reason", err.Error(),
+			)
+			postpone = true
+			continue
+		case stopped:
 			r.log.V(1).Info("stopped stale replicant node evacuation",
 				"replicaSet", klog.KObj(updateRs),
 				"pod", klog.KObj(pod),
 			)
 		}
-
 		// 3. Remove stale annotations.
 		err = s.Client.Update(r.ctx, pod)
 		if err == nil {
@@ -177,10 +181,13 @@ func (s *syncReplicantSets) ensureConsistency(
 				"pod", klog.KObj(pod),
 			)
 		} else {
-			return emperror.Wrap(err, "failed to remove stale replicant pod annotations")
+			return reconcileError(emperror.Wrap(err, "failed to remove stale replicant pod annotations"))
 		}
 	}
-	return nil
+	if postpone {
+		return reconcilePostpone()
+	}
+	return subResult{}
 }
 
 // removeStaleReplicantAnnotations strips AnnotationScalingDown and PodDeletionCost from


### PR DESCRIPTION
## Summary

This PR lowers the impact of having lagging EMQX cluster nodes information in EMQX CR status on `syncReplicantSets` activities. Now, missing node information is not a reconciliation error, as the cluster node information is expected to eventually be consistent with the set of live replicant nodes.

This manifested in error logs similar to the following.

```
2026-08-12T18:55:11Z	DEBUG	events	reconcile failed at step syncReplicantSets, reason: failed to restore replicant consistency: missing replicant emqx-replicant-7464754c6-hvz42 node information	{"type": "Warning", "object": {"kind":"EMQX","namespace":"default","name":"emqx","uid":"48450d1d-46e0-4989-b0e7-d088303f4cf5","apiVersion":"apps.emqx.io/v3beta1","resourceVersion":"519197"}, "reason": "ReconcilerFailed"}
2026-08-12T18:55:11Z	ERROR	Reconciler error	{"controller": "emqx", "controllerGroup": "apps.emqx.io", "controllerKind": "EMQX", "EMQX": {"name":"emqx","namespace":"default"}, "namespace": "default", "name": "emqx", "reconcileID": "a2c182fe-d827-4ba9-a3f2-83f54f5714f4", "error": "failed to restore replicant consistency: missing replicant emqx-replicant-7464754c6-hvz42 node information", "errorVerbose": "missing replicant emqx-replicant-7464754c6-hvz42 node information\ngithub.com/emqx/emqx-operator/internal/controller.(*syncReplicantSets).stopStaleReplicantEvacuation\n\t/workspace/internal/controller/sync_replicant_sets.go:210\ngithub.com/emqx/emqx-operator/internal/controller.(*syncReplicantSets).ensureConsistency\n\t/workspace/internal/controller/sync_replicant_sets.go:161\ngithub.com/emqx/emqx-operator/internal/controller.(*syncReplicantSets).reconcile\n\t/workspace/internal/controller/sync_replicant_sets.go:74\ngithub.com/emqx/emqx-operator/internal/controller.(*EMQXReconciler).Reconcile\n\t/workspace/internal/controller/emqx_controller.go:174\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1693\nfailed to restore replicant consistency\ngithub.com/emqx/emqx-operator/internal/controller.(*syncReplicantSets).reconcile\n\t/workspace/internal/controller/sync_replicant_sets.go:76\ngithub.com/emqx/emqx-operator/internal/controller.(*EMQXReconciler).Reconcile\n\t/workspace/internal/controller/emqx_controller.go:174\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:334\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1693"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:347
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:294
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.20.4/pkg/internal/controller/controller.go:255
```