### PR TITLE
feat: implement best-effort annotation-driven controller pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ This will install both the CRDs, the controller manager and relevant resources i
 
 ## Operation
 
+### Pause reconciliation
+
+Use the `apps.emqx.io/paused` annotation to temporarily prevent the Operator from changing one EMQX cluster while it continues to report status.
+
+Operator reports corresponding `Paused` status condition. While `Paused=True`, the Operator continues to observe Kubernetes and EMQX state and update the EMQX resource status. It creates the bootstrap API-key and node-cookie Secrets when they are missing, but does not create, update, or delete managed resources, or manage EMQX cluster in any way.
+
+Remove the annotation or set to `"false"` to resume reconciliation. Specification changes made while paused are then applied.
+
 ### PVC Lifecycle
 
 Core nodes are managed by a single StatefulSet with deterministic names (`{name}-core-0`, `{name}-core-1`, ...). Each core pod has a PersistentVolumeClaim named `{name}-core-data-{name}-core-{ordinal}`. PVC names are stable across image updates and rolling upgrades because the StatefulSet name never changes.

--- a/api/v3beta1/const.go
+++ b/api/v3beta1/const.go
@@ -35,6 +35,9 @@ const (
 
 // annotations
 const (
+	// AnnotationPaused prevents the controller from mutating the managed cluster
+	// resources while it continues to observe and report cluster status.
+	AnnotationPaused string = "apps.emqx.io/paused"
 	// AnnotationStartupConfigRevision marks Pod templates and Pods with the
 	// revision of configuration that takes effect when EMQX starts. Changing or
 	// removing this annotation from a Pod template drives a rollout.

--- a/api/v3beta1/emqx_types_status.go
+++ b/api/v3beta1/emqx_types_status.go
@@ -241,6 +241,7 @@ const (
 	Available                 string = "Available"
 	Ready                     string = "Ready"
 	ConfigApplied             string = "ConfigApplied"
+	Paused                    string = "Paused"
 )
 
 func (s *EMQXStatus) SetCondition(

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -43,8 +43,9 @@ import (
 
 // Currently executing round of reconciliation
 type reconcileRound struct {
-	ctx context.Context
-	log logr.Logger
+	ctx  context.Context
+	log  logr.Logger
+	step string
 	// Populated by `setupAPIRequester` reconciler:
 	requester apiRequester
 	// Populated by loadState reconciler:
@@ -140,8 +141,35 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	logger := log.FromContext(ctx)
 	round := reconcileRound{ctx: ctx, log: logger}
-	needRequeue := false
+	result := r.runReconcilers(&round, instance)
+	if result.err != nil && errors.IsCommonError(result.err) {
+		round.log.Info("reconciler requeue", "reason", result.err)
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+	if result.err != nil {
+		r.EventRecorder.Eventf(instance, corev1.EventTypeWarning,
+			"ReconcilerFailed",
+			"reconcile failed at step %s, reason: %s", round.step, result.err.Error(),
+		)
+		return ctrl.Result{}, result.err
+	}
+	if result.immediateResult != nil {
+		return *result.immediateResult, nil
+	}
 
+	if !instance.Status.IsConditionTrue(crd.Ready) || result.needRequeue {
+		return ctrl.Result{RequeueAfter: time.Second}, nil
+	}
+
+	return ctrl.Result{RequeueAfter: observationInterval}, nil
+}
+
+func (r *EMQXReconciler) runReconcilers(
+	round *reconcileRound,
+	instance *crd.EMQX,
+) subResult {
+	logger := round.log
+	needRequeue := false
 	for _, subReconciler := range []subReconciler{
 		// Load the current state of the resources managed by the controller:
 		&loadState{r},
@@ -168,30 +196,15 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		&retireCorePods{r},
 		&cleanupOutdatedSets{r},
 	} {
-		round.log = logger.WithValues("reconciler", subReconcilerName(subReconciler))
-		subResult := subReconciler.reconcile(&round, instance)
+		round.step = subReconcilerName(subReconciler)
+		round.log = logger.WithValues("reconciler", round.step)
+		subResult := subReconciler.reconcile(round, instance)
 		needRequeue = needRequeue || subResult.needRequeue
-		if subResult.err != nil {
-			if errors.IsCommonError(subResult.err) {
-				round.log.Info("reconciler requeue", "reason", subResult.err)
-				return ctrl.Result{RequeueAfter: time.Second}, nil
-			}
-			r.EventRecorder.Eventf(instance, corev1.EventTypeWarning,
-				"ReconcilerFailed",
-				"reconcile failed at step %s, reason: %s", subReconcilerName(subReconciler), subResult.err.Error(),
-			)
-			return ctrl.Result{}, subResult.err
-		}
-		if subResult.immediateResult != nil {
-			return *subResult.immediateResult, nil
+		if subResult.err != nil || subResult.immediateResult != nil {
+			return subResult
 		}
 	}
-
-	if !instance.Status.IsConditionTrue(crd.Ready) || needRequeue {
-		return ctrl.Result{RequeueAfter: time.Second}, nil
-	}
-
-	return ctrl.Result{RequeueAfter: observationInterval}, nil
+	return subResult{needRequeue: needRequeue}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/emqx_controller.go
+++ b/internal/controller/emqx_controller.go
@@ -63,6 +63,8 @@ func (r *reconcileRound) preferredCoreRequester() req.RequesterInterface {
 	return r.requester.forCore(r.state)
 }
 
+const observationInterval = 30 * time.Second
+
 // subResult provides a wrapper around different results from a subreconciler.
 type subResult struct {
 	err error
@@ -145,10 +147,11 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		&loadState{r},
 		// Setup secrets with bootstrap API keys / node cookie:
 		&addBootstrap{r},
-		// Set up API requester builder for the current round:
+		// Observe status before deciding whether to pause later mutations:
 		&setupAPIRequester{r},
-		// Perform reconciliation steps:
 		&updateStatus{r},
+		&pauseReconciliation{r},
+		// Perform mutating reconciliation steps:
 		&syncConfig{r},
 		&addHeadlessService{r},
 		&addCoreSet{r},
@@ -188,14 +191,18 @@ func (r *EMQXReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
-	return ctrl.Result{RequeueAfter: time.Duration(30) * time.Second}, nil
+	return ctrl.Result{RequeueAfter: observationInterval}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *EMQXReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crd.EMQX{}).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			// Reconcile metadata-only pause and resume annotation changes.
+			predicate.AnnotationChangedPredicate{},
+		)).
 		Named("emqx").
 		Complete(r)
 }

--- a/internal/controller/emqx_controller_suite_test.go
+++ b/internal/controller/emqx_controller_suite_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	util "github.com/emqx/emqx-operator/internal/controller/util"
+	. "github.com/emqx/emqx-operator/test/util"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = DescribeClientFaultMatrix("paused reconciliation", Ordered, func() {
+	var (
+		ns       *corev1.Namespace
+		instance *crd.EMQX
+	)
+
+	BeforeAll(func() {
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "controller-paused-reconciliation-test-",
+		}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+	})
+
+	BeforeEach(func() {
+		instance = emqx.DeepCopy()
+		instance.Name = ""
+		instance.GenerateName = "paused-reconciliation-"
+		instance.Namespace = ns.Name
+		instance.Labels = nil
+	})
+
+	AfterEach(func() {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, instance))).To(Succeed())
+	})
+
+	reconcile := func(reconciler *EMQXReconciler, instance *crd.EMQX) (ctrl.Result, error) {
+		return reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
+			Namespace: instance.Namespace,
+			Name:      instance.Name,
+		}})
+	}
+
+	It("observes a new paused resource after creating only bootstrap Secrets", func() {
+		util.AttachAnnotation(instance, crd.AnnotationPaused, "true")
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+		reconciler := emqxReconciler()
+		Eventually(reconcile).WithArguments(reconciler, instance).
+			Should(Equal(ctrl.Result{RequeueAfter: observationInterval}))
+
+		Expect(actualize(instance)).To(Succeed())
+		Expect(instance).To(HaveCondition(crd.Paused, And(
+			HaveField("Status", Equal(metav1.ConditionTrue)),
+			HaveField("Reason", Equal("AnnotationSet")),
+		)))
+		Expect(instance).To(HaveCondition(crd.EMQXAPIAvailable, And(
+			HaveField("Status", Equal(metav1.ConditionFalse)),
+			HaveField("Reason", Equal("NoRequester")),
+		)))
+
+		Expect(k8sClient.Get(ctx, instance.BootstrapAPIKeyNamespacedName(), &corev1.Secret{})).
+			To(Succeed())
+		Expect(k8sClient.Get(ctx, instance.NodeCookieNamespacedName(), &corev1.Secret{})).
+			To(Succeed())
+
+		for _, list := range []client.ObjectList{
+			&corev1.ConfigMapList{},
+			&corev1.ServiceList{},
+			&appsv1.StatefulSetList{},
+			&appsv1.ReplicaSetList{},
+		} {
+			Expect(k8sClient.List(ctx, list,
+				client.InNamespace(instance.Namespace),
+				client.MatchingLabels(instance.DefaultLabels()),
+			)).To(Succeed())
+			objects, err := meta.ExtractList(list)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objects).To(BeEmpty())
+		}
+	})
+
+	It("refreshes status but leaves an existing workload unchanged", func() {
+		util.AttachAnnotation(instance, crd.AnnotationPaused, "true")
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+
+		coreSet := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.CoreName(),
+				Namespace: instance.Namespace,
+				Labels:    instance.DefaultLabelsWith(crd.CoreLabels()),
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: instance.Spec.CoreTemplate.Spec.Replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: instance.DefaultLabelsWith(crd.CoreLabels())},
+				Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
+					Labels: instance.DefaultLabelsWith(crd.CoreLabels()),
+				}},
+				ServiceName: instance.HeadlessServiceNamespacedName().Name,
+			},
+		}
+		Expect(k8sClient.Create(ctx, coreSet)).To(Succeed())
+		coreSet.Status.Replicas = 3
+		Expect(k8sClient.Status().Update(ctx, coreSet)).To(Succeed())
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(coreSet), coreSet)).To(Succeed())
+		before := coreSet.DeepCopy()
+
+		reconciler := emqxReconciler()
+		Eventually(reconcile).WithArguments(reconciler, instance).
+			Should(Equal(ctrl.Result{RequeueAfter: observationInterval}))
+
+		after := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(coreSet), after)).To(Succeed())
+		Expect(reflect.DeepEqual(before, after)).To(BeTrue(), "paused reconciliation changed the StatefulSet")
+
+		Expect(actualize(instance)).To(Succeed())
+		Expect(instance.Status.CoreReplicas).To(Equal(int32(3)))
+		Expect(instance).To(HaveCondition(crd.Paused, HaveField("Status", Equal(metav1.ConditionTrue))))
+	})
+
+	It("resumes normal convergence after removing the annotation", func() {
+		util.AttachAnnotation(instance, crd.AnnotationPaused, "true")
+		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
+		reconciler := emqxReconciler()
+		Eventually(reconcile).WithArguments(reconciler, instance).
+			Should(Equal(ctrl.Result{RequeueAfter: observationInterval}))
+
+		Expect(actualize(instance)).To(Succeed())
+		delete(instance.Annotations, crd.AnnotationPaused)
+		Expect(k8sClient.Update(ctx, instance)).To(Succeed())
+
+		reconciler = emqxReconciler()
+		Eventually(func(g Gomega) {
+			_, err := reconcile(reconciler, instance)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(actualize(instance)).To(Succeed())
+			g.Expect(instance).To(HaveCondition(crd.Paused, And(
+				HaveField("Status", Equal(metav1.ConditionFalse)),
+				HaveField("Reason", Equal("AnnotationNotSet")),
+			)))
+			g.Expect(k8sClient.Get(ctx, instance.HeadlessServiceNamespacedName(), &corev1.Service{})).
+				To(Succeed())
+		}).Should(Succeed())
+	})
+})

--- a/internal/controller/emqx_controller_suite_test.go
+++ b/internal/controller/emqx_controller_suite_test.go
@@ -28,8 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -62,11 +60,8 @@ var _ = DescribeClientFaultMatrix("paused reconciliation", Ordered, func() {
 		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, instance))).To(Succeed())
 	})
 
-	reconcile := func(reconciler *EMQXReconciler, instance *crd.EMQX) (ctrl.Result, error) {
-		return reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{
-			Namespace: instance.Namespace,
-			Name:      instance.Name,
-		}})
+	reconcile := func(reconciler *EMQXReconciler, instance *crd.EMQX) subResult {
+		return reconciler.runReconcilers(newReconcileRound(), instance)
 	}
 
 	It("observes a new paused resource after creating only bootstrap Secrets", func() {
@@ -75,7 +70,7 @@ var _ = DescribeClientFaultMatrix("paused reconciliation", Ordered, func() {
 
 		reconciler := emqxReconciler()
 		Eventually(reconcile).WithArguments(reconciler, instance).
-			Should(Equal(ctrl.Result{RequeueAfter: observationInterval}))
+			Should(BeSuccessfulReconcile(WithImmediateResult{RequeueAfter: observationInterval}))
 
 		Expect(actualize(instance)).To(Succeed())
 		Expect(instance).To(HaveCondition(crd.Paused, And(
@@ -135,7 +130,7 @@ var _ = DescribeClientFaultMatrix("paused reconciliation", Ordered, func() {
 
 		reconciler := emqxReconciler()
 		Eventually(reconcile).WithArguments(reconciler, instance).
-			Should(Equal(ctrl.Result{RequeueAfter: observationInterval}))
+			Should(BeSuccessfulReconcile(WithImmediateResult{RequeueAfter: observationInterval}))
 
 		after := &appsv1.StatefulSet{}
 		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(coreSet), after)).To(Succeed())
@@ -151,23 +146,22 @@ var _ = DescribeClientFaultMatrix("paused reconciliation", Ordered, func() {
 		Expect(k8sClient.Create(ctx, instance)).To(Succeed())
 		reconciler := emqxReconciler()
 		Eventually(reconcile).WithArguments(reconciler, instance).
-			Should(Equal(ctrl.Result{RequeueAfter: observationInterval}))
+			Should(BeSuccessfulReconcile(WithImmediateResult{RequeueAfter: observationInterval}))
 
 		Expect(actualize(instance)).To(Succeed())
 		delete(instance.Annotations, crd.AnnotationPaused)
 		Expect(k8sClient.Update(ctx, instance)).To(Succeed())
 
 		reconciler = emqxReconciler()
-		Eventually(func(g Gomega) {
-			_, err := reconcile(reconciler, instance)
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(actualize(instance)).To(Succeed())
-			g.Expect(instance).To(HaveCondition(crd.Paused, And(
-				HaveField("Status", Equal(metav1.ConditionFalse)),
-				HaveField("Reason", Equal("AnnotationNotSet")),
-			)))
-			g.Expect(k8sClient.Get(ctx, instance.HeadlessServiceNamespacedName(), &corev1.Service{})).
-				To(Succeed())
-		}).Should(Succeed())
+		Eventually(reconcile).WithArguments(reconciler, instance).
+			Should(BeSuccessfulReconcile())
+
+		Expect(actualize(instance)).To(Succeed())
+		Expect(instance).To(HaveCondition(crd.Paused, And(
+			HaveField("Status", Equal(metav1.ConditionFalse)),
+			HaveField("Reason", Equal("AnnotationNotSet")),
+		)))
+		Expect(k8sClient.Get(ctx, instance.HeadlessServiceNamespacedName(), &corev1.Service{})).
+			To(Succeed())
 	})
 })

--- a/internal/controller/pause_reconciliation.go
+++ b/internal/controller/pause_reconciliation.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	emperror "emperror.dev/errors"
+	crd "github.com/emqx/emqx-operator/api/v3beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type pauseReconciliation struct {
+	*EMQXReconciler
+}
+
+// reconcile updates the Paused condition and stops the flat reconciliation
+// pipeline before any post-bootstrap Kubernetes or EMQX state can be mutated.
+func (p *pauseReconciliation) reconcile(r *reconcileRound, instance *crd.EMQX) subResult {
+	paused := reconciliationPaused(instance)
+	changed := false
+	if paused {
+		changed = instance.Status.SetCondition(
+			crd.Paused,
+			metav1.ConditionTrue,
+			"AnnotationSet",
+			fmt.Sprintf("Reconciliation is paused by the %s annotation", crd.AnnotationPaused),
+			instance.Generation,
+		)
+	} else {
+		reason := "AnnotationNotSet"
+		message := "Reconciliation is active"
+		if _, present := instance.Annotations[crd.AnnotationPaused]; present {
+			reason = "AnnotationFalse"
+			message = fmt.Sprintf("Reconciliation is active because the %s annotation is false", crd.AnnotationPaused)
+		}
+		changed = instance.Status.SetCondition(
+			crd.Paused,
+			metav1.ConditionFalse,
+			reason,
+			message,
+			instance.Generation,
+		)
+	}
+
+	if changed {
+		if err := p.Client.Status().Update(r.ctx, instance); err != nil {
+			return reconcileError(emperror.Wrap(err, "failed to update pause status"))
+		}
+	}
+	if paused {
+		return reconcileRequeueAfter(observationInterval)
+	}
+
+	return subResult{}
+}
+
+func reconciliationPaused(instance *crd.EMQX) bool {
+	value, present := instance.Annotations[crd.AnnotationPaused]
+	if !present {
+		return false
+	}
+	return value != "false"
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -40,6 +40,7 @@ import (
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -565,6 +566,15 @@ func (p Postponed) matcher() gomegatypes.GomegaMatcher {
 	return WithTransform(
 		func(in subResult) bool { return in.needRequeue },
 		subm,
+	)
+}
+
+type WithImmediateResult ctrl.Result
+
+func (imm WithImmediateResult) matcher() gomegatypes.GomegaMatcher {
+	return WithTransform(
+		func(in subResult) *ctrl.Result { return in.immediateResult },
+		And(Not(BeNil()), HaveValue(Equal(ctrl.Result(imm)))),
 	)
 }
 


### PR DESCRIPTION
## Summary

This PR specifies API and implements reconciliation pausing driven by special "paused" annotation, and exposes corresponding condition in CR status.

Pausing is "best-effort" in the sense that minimal resource management is still permitted to happen, namely secret bootstrapping. This is done primarily to simplify implementation, to avoid introducing custom logic to the existing reconcilers.